### PR TITLE
Update model.py

### DIFF
--- a/src/senselab/utils/data_structures/model.py
+++ b/src/senselab/utils/data_structures/model.py
@@ -153,7 +153,10 @@ def check_hf_repo_exists(repo_id: str, revision: str = "main", repo_type: str = 
     """Private function to check if a Hugging Face repository exists."""
     api = HfApi()
     try:
-        api.list_repo_commits(repo_id=repo_id, revision=revision, repo_type=repo_type)
+        if repo_type == "model":
+            api.model_info(repo_id=repo_id, revision=revision)
+        else:
+            api.list_repo_commits(repo_id=repo_id, revision=revision, repo_type=repo_type)
         return True
     except Exception:
         # raise RuntimeError(f"An error occurred: {e}")

--- a/src/tests/utils/data_structures/model_test.py
+++ b/src/tests/utils/data_structures/model_test.py
@@ -9,7 +9,7 @@ from senselab.utils.data_structures import HFModel, check_hf_repo_exists
 
 def test_check_hf_repo_exists_true() -> None:
     """Test HF repo exists."""
-    with patch("huggingface_hub.HfApi.list_repo_commits") as mock_list_repo_commits:
+    with patch("huggingface_hub.HfApi.model_info") as mock_list_repo_commits:
         mock_list_repo_commits.return_value = True
         assert check_hf_repo_exists("valid_repo") is True
 


### PR DESCRIPTION
## Description
I have noticed that for some huggingface models, `hf_api.list_repo_commits` doesn't work as expected (it cannot find all repos). And this is bad for us, since we use this utility to verify that a model exists. I replaced it with `hf_api.model_info`, which seems to work as expected.

## How Has This Been Tested?
I run pytests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Tests where already there and have been adapted.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
