### PR TITLE
fixing broken colab link

### DIFF
--- a/tutorials/audio/speaker_verification.ipynb
+++ b/tutorials/audio/speaker_verification.ipynb
@@ -6,7 +6,7 @@
             "source": [
                 "# Speaker Verification\n",
                 "\n",
-                "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/sensein/senselab/blob/main/tutorials/audio/speaker_diarization.ipynb)\n",
+                "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/sensein/senselab/blob/main/tutorials/audio/speaker_verification.ipynb)\n",
                 "\n",
                 "Speaker Verification is a process in which an audio system determines whether a given set of speech samples are from the same speaker. This technology is widely used in various applications such as security systems, authentication processes, and personalized user experiences. The core concept revolves around comparing voice characteristics extracted from speech samples to verify the identity of the speaker.\n",
                 "\n",


### PR DESCRIPTION
## Description
Fixed the broken link in `tutorials/audio/speaker_verification.ipynb` that previously directed to the speaker diarization Collab instead of the correct speaker verification Collab.

## Related Issue(s)
https://github.com/sensein/senselab/issues/238

## Motivation and Context
The incorrect link caused confusion as it opened the speaker diarization Collab instead of the expected speaker verification Collab. This fix ensures the link now correctly points to the intended tutorial.

## How Has This Been Tested?
Manually tested by clicking the corrected link to verify it now directs to the speaker verification Collab.

Types of changes
- Simply fixed the broken link