### PR TITLE
fixing import in the speaker emebeddings tutorial

### DIFF
--- a/tutorials/audio/extract_speaker_embeddings.ipynb
+++ b/tutorials/audio/extract_speaker_embeddings.ipynb
@@ -112,7 +112,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "from senselab.utils.tasks.cosine_similarity import cosine_similarity\n",
+                "from senselab.utils.tasks.cosine_similarity import compute_cosine_similarity\n",
                 "\n",
                 "\n",
                 "# DIRECTLY PLOT THE EMBEDDINGS FOR THE TWO FILES\n",
@@ -142,7 +142,7 @@
                 "    \n",
                 "    for i in range(n):\n",
                 "        for j in range(n):\n",
-                "            similarity_matrix[i, j] = cosine_similarity(embeddings[i], embeddings[j])\n",
+                "            similarity_matrix[i, j] = compute_cosine_similarity(embeddings[i], embeddings[j])\n",
                 "    \n",
                 "    fig, ax = plt.subplots(figsize=(8, 6))\n",
                 "    im = ax.imshow(similarity_matrix, cmap='coolwarm', vmin=-1, vmax=1)\n",
@@ -187,7 +187,7 @@
     ],
     "metadata": {
         "kernelspec": {
-            "display_name": "senselab",
+            "display_name": "senselab-KP8v1V64-py3.10",
             "language": "python",
             "name": "python3"
         },
@@ -201,7 +201,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.12.0"
+            "version": "3.10.10"
         }
     },
     "nbformat": 4,


### PR DESCRIPTION
## Description
This pull request fixes an import error in the `extract_speaker_embeddings.ipynb` tutorial. The issue was caused by an incorrect import statement in the "Visualizing Embeddings" cell. The line:
```python
from senselab.utils.tasks.cosine_similarity import cosine_similarity
```
has been replaced with:
```python
from senselab.utils.tasks.cosine_similarity import compute_cosine_similarity
```
and `compute_cosine_similarity` has replaced `cosine_similarity` in the rest of the code. 
This change resolves the `ImportError` caused by the absence of a `cosine_similarity.py` file in the specified module.

## Related Issue(s)
https://github.com/sensein/senselab/issues/237

## Motivation and Context
This fix is necessary to ensure that the tutorial can run without errors when executed sequentially. The previous import error prevented the completion of the tutorial, which could hinder the learning experience for users.

## How Has This Been Tested?
The corrected import statement has been tested by running the tutorial from start to finish, confirming that the "Visualizing Embeddings" cell now runs without errors.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.