### PR TITLE
Fixing  timestamped-ASR with long audio recordings

### DIFF
--- a/src/senselab/audio/tasks/speech_to_text/huggingface.py
+++ b/src/senselab/audio/tasks/speech_to_text/huggingface.py
@@ -73,7 +73,7 @@ class HuggingFaceASR:
         return_timestamps: Optional[str] = "word",
         max_new_tokens: int = 128,
         chunk_length_s: int = 30,
-        batch_size: int = 16,
+        batch_size: int = 1,
         device: Optional[DeviceType] = None,
     ) -> List[ScriptLine]:
         """Transcribes all audio samples in the dataset.
@@ -86,7 +86,10 @@ class HuggingFaceASR:
             return_timestamps (Optional[str]): The level of timestamp details (default is "word").
             max_new_tokens (int): The maximum number of new tokens (default is 128).
             chunk_length_s (int): The length of audio chunks in seconds (default is 30).
-            batch_size (int): The batch size for processing (default is 16).
+            batch_size (int): The batch size for processing (default is 1).
+                Note: Issues have been observed with long audio recordings and timestamped transcript
+                if the batch_size is high - not exactly clear what high means
+                (https://github.com/huggingface/transformers/issues/2615#issuecomment-656923205).
             device (Optional[DeviceType]): The device to run the model on (default is None).
 
         Returns:


### PR DESCRIPTION
## Description
Patch for fixing issues with timestamped-ASR with long audio recordings (same as here: https://github.com/huggingface/transformers/issues/21262). In a related issue (https://github.com/huggingface/transformers/issues/2615#issuecomment-656923205), they recommended reducing the batch size and it seems to work from my tests. 

## How Has This Been Tested?
unit tests (locally and on github)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
