### PR TITLE
Fix/workaround to Pydra serialization issue while keeping torch up to date

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [{include = "senselab", from = "src"}]
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
 datasets = "~=3"
-torch = ">=2.5,<2.6"
+torch = "~=2.6"
 torchvision = "~=0.20"
 torchaudio = "~=2.5"
 transformers = "~=4.47"

--- a/src/tests/utils/data_structures/pydra_helpers_test.py
+++ b/src/tests/utils/data_structures/pydra_helpers_test.py
@@ -5,6 +5,7 @@ import torch
 
 
 @pydra.mark.task
+@pydra.mark.annotate({"return": {"out": torch.Tensor}})
 def pydra_task(test_input: torch.Tensor) -> torch.Tensor:
     """Task function for Pydra workflow to run."""
     return test_input + 2
@@ -22,6 +23,9 @@ def test_pydra() -> None:
         sub(wf)
 
     results = wf.result()
-    print("results", results)
-    assert results[0].output.wf_out.equal(torch.tensor([[5, 6], [7, 8]]))
-    assert results[1].output.wf_out.equal(torch.tensor([[2, 3], [3, 4]]))
+    assert results[0].output.wf_out.equal(
+        torch.tensor([[5, 6], [7, 8]])
+    ), f"Expected Tensor of [[5,6],[7,8]] but got {results[0].output.wf_out}"
+    assert results[1].output.wf_out.equal(
+        torch.tensor([[2, 3], [3, 4]])
+    ), f"Expected Tensor of [[2,3],[3,4]] but got {results[1].output.wf_out}"


### PR DESCRIPTION
## Description
Added solution for serialization from @satra that allows torch.Tensors to remain serializable outputs of Pydra functions.

## Related Issue(s)
#245 

## Motivation and Context
Previous workaround was to keep torch at previous working version but this is a cleaner solution.

## How Has This Been Tested?
Existing test now passes with most up-to-date torch version

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
