### PR TITLE
Fixing enhancement with segment duration < kernel size

### DIFF
--- a/src/senselab/audio/tasks/preprocessing/preprocessing.py
+++ b/src/senselab/audio/tasks/preprocessing/preprocessing.py
@@ -246,7 +246,7 @@ def concatenate_audios(audios: List[Audio]) -> Audio:
         if audio.waveform.shape[0] != num_channels:
             raise ValueError("All audios must have the same number of channels (mono or stereo) to concatenate.")
 
-    concatenated_waveform = torch.cat([audio.waveform for audio in audios], dim=1)
+    concatenated_waveform = torch.cat([audio.waveform.cpu() for audio in audios], dim=1)
 
     # TODO: do we want to concatenate metadata? TBD
 

--- a/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
+++ b/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
@@ -17,7 +17,7 @@ class SpeechBrainEnhancer:
     """A factory for managing SpeechBrain enhancement pipelines."""
 
     MAX_DURATION_SECONDS = 60  # Maximum duration per segment in seconds
-    MIN_LENGTH = 16 # kernel size for speechbrain/sepformer-wham16k-enhancement
+    MIN_LENGTH = 16  # kernel size for speechbrain/sepformer-wham16k-enhancement
     _models: Dict[str, Union[separator, enhance_model]] = {}
 
     @classmethod
@@ -115,11 +115,11 @@ class SpeechBrainEnhancer:
                         enhanced_waveform = enhancer.enhance_batch(segment.waveform, lengths=torch.tensor([1.0]))
                     else:
                         enhanced_waveform = enhancer.separate_batch(segment.waveform)
-    
+
                     enhanced_segments.append(
                         Audio(waveform=enhanced_waveform.reshape(1, -1), sampling_rate=segment.sampling_rate)
                     )
-                    
+
             # TODO: decide what to do with metadata
             enhanced_audio = concatenate_audios(enhanced_segments)
             enhanced_audio.metadata = audio.metadata


### PR DESCRIPTION
## Description
Fixing enhancement with segment duration < kernel size

## Related Issue(s)
`
INFO:senselab:Time taken to initialize the speechbrain model: 1.77 seconds
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/orcd/data/satra/001/users/fabiocat/conda/minic/envs/normative_values/lib/python3.11/site-packages/senselab/audio/tasks/speech_enhancement/api.py", line 30, in enhance_audios
    return SpeechBrainEnhancer.enhance_audios_with_speechbrain(audios=audios, model=model, device=device)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/data/satra/001/users/fabiocat/conda/minic/envs/normative_values/lib/python3.11/site-packages/senselab/audio/tasks/speech_enhancement/speechbrain.py", line 111, in enhance_audios_with_speechbrain
    enhanced_waveform = enhancer.separate_batch(segment.waveform)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/data/satra/001/users/fabiocat/conda/minic/envs/normative_values/lib/python3.11/site-packages/speechbrain/inference/separation.py", line 61, in separate_batch
    mix_w = self.mods.encoder(mix)
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/data/satra/001/users/fabiocat/conda/minic/envs/normative_values/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/data/satra/001/users/fabiocat/conda/minic/envs/normative_values/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/data/satra/001/users/fabiocat/conda/minic/envs/normative_values/lib/python3.11/site-packages/speechbrain/lobes/models/dual_path.py", line 230, in forward
    x = self.conv1d(x)
        ^^^^^^^^^^^^^^
  File "/orcd/data/satra/001/users/fabiocat/conda/minic/envs/normative_values/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/data/satra/001/users/fabiocat/conda/minic/envs/normative_values/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/data/satra/001/users/fabiocat/conda/minic/envs/normative_values/lib/python3.11/site-packages/torch/nn/modules/conv.py", line 375, in forward
    return self._conv_forward(input, self.weight, self.bias)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/orcd/data/satra/001/users/fabiocat/conda/minic/envs/normative_values/lib/python3.11/site-packages/torch/nn/modules/conv.py", line 370, in _conv_forward
    return F.conv1d(
           ^^^^^^^^^
RuntimeError: Calculated padded input size per channel: (6). Kernel size: (16). Kernel size can't be greater than actual input size
`

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
