### PR TITLE
Fixing cache pointer

### DIFF
--- a/src/senselab/audio/tasks/ssl_embeddings/api.py
+++ b/src/senselab/audio/tasks/ssl_embeddings/api.py
@@ -1,6 +1,7 @@
 """This module implements some utilities to extract embeddings from self-supervised models."""
 
-from typing import List, Optional
+import os
+from typing import List, Optional, Union
 
 import torch
 
@@ -12,7 +13,7 @@ from senselab.utils.data_structures import DeviceType, HFModel, SenselabModel
 def extract_ssl_embeddings_from_audios(
     audios: List[Audio],
     model: SenselabModel,
-    cache_dir: str = "~/",
+    cache_dir: Optional[Union[str, os.PathLike]] = None,
     device: Optional[DeviceType] = None,
 ) -> List[torch.Tensor]:
     """Extract embedding of audio signals from pre-trained SSL models.
@@ -20,7 +21,7 @@ def extract_ssl_embeddings_from_audios(
     Args:
         audios (List[Audio]): A list of Audio objects containing the audio signals and their properties.
         model (SenselabModel): The model used to extract their embeddings.
-        cache_dir (str): The path to where the model's weights will be saved.
+        cache_dir (Optional[str, os.PathLike]): The path to where the model's weights will be saved.
         device (Optional[DeviceType]): The device to run the model on (default is None).
 
     Returns:

--- a/src/senselab/audio/tasks/ssl_embeddings/self_supervised_features.py
+++ b/src/senselab/audio/tasks/ssl_embeddings/self_supervised_features.py
@@ -1,6 +1,7 @@
 """This module contains functions for extracting features from pre-trained self-supervised models."""
 
-from typing import Dict, List, Optional
+import os
+from typing import Dict, List, Optional, Union
 
 import torch
 from transformers import AutoFeatureExtractor, AutoModel
@@ -19,13 +20,13 @@ class SSLEmbeddingsFactory:
     def _get_feature_extractor(
         cls,
         model: HFModel,
-        cache_dir: str = "~/",
+        cache_dir: Optional[Union[str, os.PathLike]] = None,
     ) -> AutoFeatureExtractor:
         """Get or create a feature extractor for SSL model.
 
         Args:
             model (HFModel): The HuggingFace model.
-            cache_dir (str): The path to where the model's weights will be saved.
+            cache_dir (Optional[str, os.PathLike]): The path to where the model's weights will be saved.
 
         Returns:
             AutoFeatureExtractor: The feature extractor for the model.
@@ -42,13 +43,13 @@ class SSLEmbeddingsFactory:
         cls,
         model: HFModel,
         device: DeviceType,
-        cache_dir: str = "~/",
+        cache_dir: Optional[Union[str, os.PathLike]] = None,
     ) -> AutoModel:
         """Load weights of SSL model.
 
         Args:
             model (HFModel): The Hugging Face model.
-            cache_dir (str): The path to where the model's weights will be saved.
+            cache_dir (Optional[os.PathLike, str]): The path to where the model's weights will be saved.
             device (DeviceType): The device to run the model on.
 
         Returns:
@@ -66,7 +67,7 @@ class SSLEmbeddingsFactory:
         cls,
         audios: List[Audio],
         model: HFModel,
-        cache_dir: str = "~/",
+        cache_dir: Optional[Union[str, os.PathLike]] = None,
         device: Optional[DeviceType] = None,
     ) -> List[torch.Tensor]:
         """Compute the ssl embeddings of audio signals.
@@ -75,7 +76,7 @@ class SSLEmbeddingsFactory:
             audios (List[Audio]): A list of Audio objects containing the audio signals and their properties.
             model (HFModel): The model used to compute the embeddings
                 (default is "facebook/wav2vec2-base").
-            cache_dir (str): The path to where the model's weights will be saved.
+            cache_dir (Optional[str, os.PathLike]): The path to where the model's weights will be saved.
             device (Optional[DeviceType]): The device to run the model on (default is None).
                 Only CPU and CUDA are supported.
 


### PR DESCRIPTION
## Description
Removes default cache pointing to home directory. Now matches all other references to cache directories in senselab.

## Related Issue(s)
No issue created but existing implementation causes errors.

## Motivation and Context
Implementation errors and does not make sense to default the cache to the user's home directory when existing logic within HF and other packages do a better job of finding it.

## How Has This Been Tested?
Passes existing tests (hopefully)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
