### PR TITLE
Initialize HF models using their preferred data type

### DIFF
--- a/src/senselab/audio/tasks/data_augmentation/torch_audiomentations.py
+++ b/src/senselab/audio/tasks/data_augmentation/torch_audiomentations.py
@@ -50,7 +50,7 @@ def augment_audios_with_torch_audiomentations(
         )
 
     augmentation.output_type = "dict"
-    device_type, dtype = _select_device_and_dtype(
+    device_type, _ = _select_device_and_dtype(
         user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]
     )
     if device_type == DeviceType.CPU:
@@ -108,7 +108,7 @@ def augment_audios_with_torch_audiomentations(
     else:
         batched_audios, sampling_rates, metadatas = batch_audios(audios)
 
-        batched_audios = batched_audios.to(device=torch.device(device_type.value), dtype=dtype)
+        batched_audios = batched_audios.to(device=torch.device(device_type.value))
         sampling_rate = sampling_rates[0] if isinstance(sampling_rates, List) else sampling_rates
         augmented_audio = augmentation(batched_audios, sample_rate=sampling_rate).samples
 

--- a/src/senselab/audio/tasks/speech_to_text/huggingface.py
+++ b/src/senselab/audio/tasks/speech_to_text/huggingface.py
@@ -43,7 +43,7 @@ class HuggingFaceASR:
         Returns:
             pipeline: The ASR pipeline.
         """
-        device, torch_dtype = _select_device_and_dtype(
+        device, _ = _select_device_and_dtype(
             user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]
         )
         key = (
@@ -60,7 +60,6 @@ class HuggingFaceASR:
                 chunk_length_s=chunk_length_s,
                 batch_size=batch_size,
                 device=device.value,
-                torch_dtype=torch_dtype,
             )
         return cls._pipelines[key]
 

--- a/src/senselab/audio/tasks/text_to_speech/huggingface.py
+++ b/src/senselab/audio/tasks/text_to_speech/huggingface.py
@@ -28,7 +28,7 @@ class HuggingFaceTTS:
         Returns:
             pipeline: The TTS pipeline.
         """
-        device, torch_dtype = _select_device_and_dtype(
+        device, _ = _select_device_and_dtype(
             user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]
         )
         key = f"{model.path_or_uri}-{model.revision}-{device.value}"
@@ -38,7 +38,6 @@ class HuggingFaceTTS:
                 model=model.path_or_uri,
                 revision=model.revision,
                 device=device.value,
-                torch_dtype=torch_dtype,
             )
         return cls._pipelines[key]
 


### PR DESCRIPTION
## Description
This PR updates the model initialization logic to rely on the Hugging Face model configuration (`config.torch_dtype`) for selecting the best `dtype`, rather than manually forcing it. This change was suggested by @ wilke0818 long time ago.

## Motivation and Context
This ensures compatibility with various model architectures and optimizes performance based on the model's intended precision. 

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.