### PR TITLE
Fixed but where n_fft defaults to 1024

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
   rev: v1.10.0
   hooks:
   - id: mypy
-    args: [--ignore-missing-imports]
+    args: [--ignore-missing-imports, --extra-checks]
     additional_dependencies:
     - pydantic>=1.10.4
     - types-requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ ignore_missing_imports = true
 plugins = [
   "pydantic.mypy"
 ]
+extra_checks = true
 
 [tool.ruff]
 exclude = [

--- a/src/senselab/audio/tasks/features_extraction/torchaudio.py
+++ b/src/senselab/audio/tasks/features_extraction/torchaudio.py
@@ -332,7 +332,7 @@ def extract_torchaudio_features_from_audios(
         extract_spectrogram_from_audios_pt(
             name="extract_spectrogram_from_audios_pt",
             audios=wf.lzin.x,
-            n_nfft=n_fft,
+            n_fft=n_fft,
             win_length=win_length,
             hop_length=hop_length,
         )
@@ -342,7 +342,7 @@ def extract_torchaudio_features_from_audios(
             name="extract_mel_spectrogram_from_audios_pt",
             audios=wf.lzin.x,
             n_mels=n_mels,
-            n_nfft=n_fft,
+            n_fft=n_fft,
             win_length=win_length,
             hop_length=hop_length,
         )
@@ -353,7 +353,7 @@ def extract_torchaudio_features_from_audios(
             spectrograms=wf.extract_spectrogram_from_audios_pt.lzout.out,
             sampling_rate=wf._extract_sampling_rate_pt.lzout.out,
             n_mels=n_mels,
-            n_nfft=n_fft,
+            n_fft=n_fft,
         )
     )
     wf.add(

--- a/src/tests/audio/tasks/features_extraction_test.py
+++ b/src/tests/audio/tasks/features_extraction_test.py
@@ -221,6 +221,7 @@ def test_extract_spectrogram_from_audios(resampled_mono_audio_sample: Audio) -> 
     assert all(spec["spectrogram"].dim() == 2 for spec in result)
     assert all(spec["spectrogram"].shape[0] == 513 for spec in result)
 
+
 @pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
 def test_extract_spectrogram_from_audios_specify_n_fft(resampled_mono_audio_sample: Audio) -> None:
     """Test extraction of spectrogram from audio."""

--- a/src/tests/audio/tasks/features_extraction_test.py
+++ b/src/tests/audio/tasks/features_extraction_test.py
@@ -221,6 +221,19 @@ def test_extract_spectrogram_from_audios(resampled_mono_audio_sample: Audio) -> 
     assert all(spec["spectrogram"].dim() == 2 for spec in result)
     assert all(spec["spectrogram"].shape[0] == 513 for spec in result)
 
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_spectrogram_from_audios_specify_n_fft(resampled_mono_audio_sample: Audio) -> None:
+    """Test extraction of spectrogram from audio."""
+    n_fft = 400
+    result = extract_spectrogram_from_audios([resampled_mono_audio_sample], n_fft)
+    assert isinstance(result, list)
+    assert all(isinstance(spec, dict) for spec in result)
+    assert all("spectrogram" in spec for spec in result)
+    assert all(isinstance(spec["spectrogram"], torch.Tensor) for spec in result)
+    # Spectrogram shape is (freq, time)
+    assert all(spec["spectrogram"].dim() == 2 for spec in result)
+    assert all(spec["spectrogram"].shape[0] == 201 for spec in result)
+
 
 @pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
 def test_extract_mel_spectrogram_from_audios(resampled_mono_audio_sample: Audio) -> None:


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes you've made. -->
Fixed a bug with spectrogram dimensions being generated with n_fft = 1024 instead of specified value.
## Related Issue(s)
<!-- Link any related issues here. -->
https://github.com/sensein/b2aiprep/issues/135
## Motivation and Context
<!-- Explain why these changes are necessary and what problem they solve. -->

## How Has This Been Tested?
<!-- Describe how you have tested these changes. -->
Added test case where we input n_fft to a 400 and confirm the dimensions match.
## Screenshots (if appropriate):
<!-- Include any relevant screenshots. -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
