### PR TITLE
fixing extract_praat_parselmouth_features_from_audios

### DIFF
--- a/src/senselab/audio/tasks/features_extraction/__init__.py
+++ b/src/senselab/audio/tasks/features_extraction/__init__.py
@@ -1,1 +1,3 @@
 """.. include:: ./doc.md"""  # noqa: D415
+
+from .api import extract_features_from_audios  # noqa: F401

--- a/src/senselab/audio/tasks/features_extraction/opensmile.py
+++ b/src/senselab/audio/tasks/features_extraction/opensmile.py
@@ -15,6 +15,22 @@ try:
 except ModuleNotFoundError:
     OPENSMILE_AVAILABLE = False
 
+    class DummyOpenSmile:
+        """Dummy class to represent openSMILE when it's not available."""
+
+        def __init__(self) -> None:
+            """Dummy constructor for when openSMILE is not available."""
+            self.__dict__ = {}
+
+        class Smile:
+            """Dummy class to represent openSMILE when it's not available."""
+
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                """Dummy class for when openSMILE is not available."""
+                pass
+
+    opensmile = DummyOpenSmile()
+
 import os
 from typing import Any, Dict, List, Optional
 
@@ -32,10 +48,10 @@ class OpenSmileFeatureExtractorFactory:
     exists per unique combination of `feature_set` and `feature_level`.
     """
 
-    _extractors: Dict[str, "opensmile.Smile"] = {}  # Cache for feature extractors
+    _extractors: Dict[str, opensmile.Smile] = {}  # Cache for feature extractors
 
     @classmethod
-    def get_opensmile_extractor(cls, feature_set: str, feature_level: str) -> "opensmile.Smile":
+    def get_opensmile_extractor(cls, feature_set: str, feature_level: str) -> opensmile.Smile:
         """Get or create an openSMILE feature extractor.
 
         Args:

--- a/src/senselab/audio/tasks/features_extraction/praat_parselmouth.py
+++ b/src/senselab/audio/tasks/features_extraction/praat_parselmouth.py
@@ -23,8 +23,30 @@ try:
 except ModuleNotFoundError:
     PARSELMOUTH_AVAILABLE = False
 
+    class DummyParselmouth:
+        """Dummy class for when parselmouth is not available.
 
-def get_sound(audio: Union[Path, Audio], sampling_rate: int = 16000) -> "parselmouth.Sound":
+        This is helpful for type checking when parselmouth is not installed.
+        """
+
+        def __init__(self) -> None:
+            """Dummy constructor for when parselmouth is not available."""
+            pass
+
+        def call(self, *args: object, **kwargs: object) -> None:  # type: ignore
+            """Dummy method for when parselmouth is not available."""
+
+        class Sound:
+            """Dummy class for when parselmouth is not available."""
+
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                """Dummy class for when parselmouth is not available."""
+                pass
+
+    parselmouth = DummyParselmouth()
+
+
+def get_sound(audio: Union[Path, Audio], sampling_rate: int = 16000) -> parselmouth.Sound:
     """Get a sound object from a given audio file or Audio object.
 
     Args:
@@ -66,7 +88,7 @@ def get_sound(audio: Union[Path, Audio], sampling_rate: int = 16000) -> "parselm
     return snd_full
 
 
-def extract_speech_rate(snd: Union["parselmouth.Sound", Path, Audio]) -> Dict[str, float]:
+def extract_speech_rate(snd: Union[parselmouth.Sound, Path, Audio]) -> Dict[str, float]:
     """Extract speech timing and pausing features from a given sound object.
 
     Args:
@@ -333,7 +355,7 @@ def extract_speech_rate(snd: Union["parselmouth.Sound", Path, Audio]) -> Dict[st
         }
 
 
-def extract_pitch_values(snd: Union["parselmouth.Sound", Path, Audio]) -> Dict[str, float]:
+def extract_pitch_values(snd: Union[parselmouth.Sound, Path, Audio]) -> Dict[str, float]:
     """Estimate Pitch Range.
 
     Calculates the mean pitch using a wide range and uses this to shorten the range for future pitch extraction
@@ -413,7 +435,7 @@ def extract_pitch_values(snd: Union["parselmouth.Sound", Path, Audio]) -> Dict[s
 
 
 def extract_pitch_descriptors(
-    snd: Union["parselmouth.Sound", Path, Audio],
+    snd: Union[parselmouth.Sound, Path, Audio],
     floor: float,
     ceiling: float,
     frame_shift: float = 0.005,
@@ -480,7 +502,7 @@ def extract_pitch_descriptors(
 
 
 def extract_intensity_descriptors(
-    snd: Union["parselmouth.Sound", Path, Audio], floor: float, frame_shift: float
+    snd: Union[parselmouth.Sound, Path, Audio], floor: float, frame_shift: float
 ) -> Dict[str, float]:
     """Extract Intensity Features.
 
@@ -545,7 +567,7 @@ def extract_intensity_descriptors(
 
 
 def extract_harmonicity_descriptors(
-    snd: Union["parselmouth.Sound", Path, Audio], floor: float, frame_shift: float
+    snd: Union[parselmouth.Sound, Path, Audio], floor: float, frame_shift: float
 ) -> Dict[str, float]:
     """Voice Quality - HNR.
 
@@ -603,7 +625,7 @@ def extract_harmonicity_descriptors(
         return {"hnr_db_mean": np.nan, "hnr_db_std_dev": np.nan}
 
 
-def extract_slope_tilt(snd: Union["parselmouth.Sound", Path, Audio], floor: float, ceiling: float) -> Dict[str, float]:
+def extract_slope_tilt(snd: Union[parselmouth.Sound, Path, Audio], floor: float, ceiling: float) -> Dict[str, float]:
     """Voice Quality - Spectral Slope/Tilt.
 
     Function to extract spectral slope and tilt from a given sound object. This function is based on default
@@ -672,7 +694,7 @@ def extract_slope_tilt(snd: Union["parselmouth.Sound", Path, Audio], floor: floa
 
 
 def extract_cpp_descriptors(
-    snd: Union["parselmouth.Sound", Path, Audio], floor: float, ceiling: float, frame_shift: float
+    snd: Union[parselmouth.Sound, Path, Audio], floor: float, ceiling: float, frame_shift: float
 ) -> Dict[str, float]:
     """Extract Cepstral Peak Prominence (CPP).
 
@@ -789,7 +811,7 @@ def extract_cpp_descriptors(
 
 
 def measure_f1f2_formants_bandwidths(
-    snd: Union["parselmouth.Sound", Path, Audio], floor: float, ceiling: float, frame_shift: float
+    snd: Union[parselmouth.Sound, Path, Audio], floor: float, ceiling: float, frame_shift: float
 ) -> Dict[str, float]:
     """Extract Formant Frequency Features.
 
@@ -905,7 +927,7 @@ def measure_f1f2_formants_bandwidths(
 
 
 def extract_spectral_moments(
-    snd: Union["parselmouth.Sound", Path, Audio], floor: float, ceiling: float, window_size: float, frame_shift: float
+    snd: Union[parselmouth.Sound, Path, Audio], floor: float, ceiling: float, window_size: float, frame_shift: float
 ) -> Dict[str, float]:
     """Extract Spectral Moments.
 
@@ -1018,7 +1040,7 @@ def extract_spectral_moments(
 ### More functions ###
 
 
-def extract_audio_duration(snd: Union["parselmouth.Sound", Path, Audio]) -> Dict[str, float]:
+def extract_audio_duration(snd: Union[parselmouth.Sound, Path, Audio]) -> Dict[str, float]:
     """Get the duration of a given audio file or Audio object.
 
     This function calculates the total duration of an audio file or audio object
@@ -1068,7 +1090,7 @@ def extract_audio_duration(snd: Union["parselmouth.Sound", Path, Audio]) -> Dict
         return {"duration": np.nan}
 
 
-def extract_jitter(snd: Union["parselmouth.Sound", Path, Audio], floor: float, ceiling: float) -> Dict[str, float]:
+def extract_jitter(snd: Union[parselmouth.Sound, Path, Audio], floor: float, ceiling: float) -> Dict[str, float]:
     """Returns the jitter descriptors for the given sound or audio file.
 
     Args:
@@ -1124,7 +1146,7 @@ def extract_jitter(snd: Union["parselmouth.Sound", Path, Audio], floor: float, c
         }
 
 
-def extract_shimmer(snd: Union["parselmouth.Sound", Path, Audio], floor: float, ceiling: float) -> Dict[str, float]:
+def extract_shimmer(snd: Union[parselmouth.Sound, Path, Audio], floor: float, ceiling: float) -> Dict[str, float]:
     """Returns the shimmer descriptors for the given sound or audio file.
 
     Args:

--- a/src/tests/audio/tasks/features_extraction_test.py
+++ b/src/tests/audio/tasks/features_extraction_test.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from senselab.audio.data_structures import Audio
+from senselab.audio.tasks.features_extraction import extract_features_from_audios
 from senselab.audio.tasks.features_extraction.opensmile import extract_opensmile_features_from_audios
 from senselab.audio.tasks.features_extraction.praat_parselmouth import (
     extract_audio_duration,
@@ -347,3 +348,29 @@ def test_extract_subjective_quality_features_invalid_audio(mono_audio_sample: Au
         extract_subjective_quality_features_from_audios(
             audios=[mono_audio_sample], non_matching_references=[mono_audio_sample]
         )
+
+
+@pytest.mark.skipif(
+    not (OPENSMILE_AVAILABLE and PARSELMOUTH_AVAILABLE and TORCHAUDIO_AVAILABLE),
+    reason="One or more required dependencies (openSMILE, Praat-Parselmouth, or torchaudio) are not installed.",
+)
+def test_extract_features_from_audios(resampled_mono_audio_sample: Audio) -> None:
+    """Simple test for extract_features_from_audios.
+
+    This test verifies that given a valid list of audio samples,
+    the extract_features_from_audios function returns a list of dictionaries (one per audio)
+    containing non-empty feature data.
+    """
+    audios = [resampled_mono_audio_sample]
+    features = extract_features_from_audios(
+        audios=audios, opensmile=True, parselmouth=True, torchaudio=True, torchaudio_squim=True
+    )
+
+    # Check that the output is a list and that it has one feature dict per audio.
+    assert isinstance(features, list)
+    assert len(features) == len(audios)
+
+    # Check that each feature extraction result is a non-empty dictionary.
+    for feat in features:
+        assert isinstance(feat, dict)
+        assert feat, "The feature dictionary should not be empty."


### PR DESCRIPTION
## Description
fixed `extract_praat_parselmouth_features_from_audios`. I took inspiration from @Evan8456 's solution (https://github.com/sensein/senselab/pull/293) PLUS tricked the type checker by creating a placeholder class for opensmile and parselmouth if they are not installed

## Related Issue(s)
[Bug: Issues running feature extractions on latest version of senselab](https://github.com/sensein/senselab/issues/292)

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
