### PR TITLE
334 Task Store Filepath if Provided with Waveform

### DIFF
--- a/src/senselab/audio/data_structures/audio.py
+++ b/src/senselab/audio/data_structures/audio.py
@@ -80,6 +80,8 @@ class Audio(BaseModel):
                 raise ValueError("When a waveform is provided, a sampling_rate must also be supplied.")
             self._waveform = self.convert_to_tensor(waveform)
             self._sampling_rate = provided_sr
+            if filepath:
+                self._file_path = filepath
         else:
             # otherwise, a valid filepath is required for lazy loading.
             if not filepath:
@@ -311,7 +313,7 @@ class Audio(BaseModel):
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
             torchaudio.save(
-                uri=file_path,
+                uri=str(file_path),
                 src=self.waveform,
                 sample_rate=self.sampling_rate,
                 channels_first=True,

--- a/src/tests/audio/data_structures/audio_test.py
+++ b/src/tests/audio/data_structures/audio_test.py
@@ -228,7 +228,7 @@ def test_audio_save_to_file(audio_fixture: str, request: pytest.FixtureRequest) 
         assert temp_file_path.exists(), "The audio file was not saved."
 
         # Load the saved file and verify its content
-        loaded_waveform, loaded_sampling_rate = torchaudio.load(temp_file_path)
+        loaded_waveform, loaded_sampling_rate = torchaudio.load(str(temp_file_path))
         assert torch.allclose(audio_sample.waveform, loaded_waveform, atol=1e-5), "Waveform data does not match."
         assert audio_sample.sampling_rate == loaded_sampling_rate, "Sampling rate does not match."
 

--- a/src/tests/audio/data_structures/audio_test.py
+++ b/src/tests/audio/data_structures/audio_test.py
@@ -401,3 +401,15 @@ def test_window_generator_step_greater_than_audio(audio_fixture: str, request: p
     expected_windows = (audio_length - window_size) // step_size + 1  # This is always 1
     assert len(windowed_audios) == expected_windows, f"Should yield {expected_windows} \
         windows when step size is greater than audio length. Yielded {len(windowed_audios)}."
+
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_audio_filepath_is_stored_with_waveform() -> None:
+    """Tests that the filepath is stored even when a waveform is provided."""
+    dummy_path = "/tmp/dummy_audio.wav"
+    dummy_waveform = torch.randn(1, 16000)
+    dummy_sr = 16000
+
+    audio = Audio(waveform=dummy_waveform, sampling_rate=dummy_sr, filepath=dummy_path)
+
+    assert audio.filepath() == dummy_path, "Filepath should be preserved even when waveform is provided."


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes you've made. -->
Ensures that a filepath is stored in an `Audio` object if both `filepath` and `waveform` arguments are passed when an `Audio` is initialized.

## Related Issue(s)
<!-- Link any related issues here. -->

## Motivation and Context
<!-- Explain why these changes are necessary and what problem they solve. -->

## How Has This Been Tested?
<!-- Describe how you have tested these changes. -->

## Screenshots (if appropriate):
<!-- Include any relevant screenshots. -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
