### PR TITLE
Fix nest_asyncio crash on uvloop: apply only when safe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ codespell = "~=2.3"
 jupyter = "~=1.0"
 ipywidgets = "~=8.1"
 ipykernel = "*"
+uvloop = "~=0.21"
 
 [tool.poetry.group.docs]
 optional = true

--- a/src/senselab/__init__.py
+++ b/src/senselab/__init__.py
@@ -1,23 +1,32 @@
 """.. include:: ../../README.md"""  # noqa: D415
 
 import platform
+import asyncio
+import nest_asyncio
 from multiprocessing import set_start_method
 
+# Raise error on incompatible macOS architecture
 if platform.system() == "Darwin" and platform.machine() != "arm64":
     raise RuntimeError(
         "Error: This package requires an ARM64 architecture on macOS "
         "since PyTorch 2.2.2+ does not support x86-64 on macOS."
     )
 
+# Conditionally apply nest_asyncio to avoid uvloop conflict
+def safe_apply_nest_asyncio():
+    try:
+        loop = asyncio.get_event_loop()
+        if "uvloop" not in str(type(loop)):
+            nest_asyncio.apply()
+    except Exception as e:
+        print(f"nest_asyncio not applied: {e}")
 
-import nest_asyncio
-
-nest_asyncio.apply()
+safe_apply_nest_asyncio()
 
 from senselab.utils.data_structures.pydra_helpers import *  # NOQA
 
+# Ensure multiprocessing start method is 'spawn'
 try:
     set_start_method("spawn", force=True)
 except RuntimeError:
-    # Already set
-    pass
+    pass  # Method already set

--- a/src/senselab/__init__.py
+++ b/src/senselab/__init__.py
@@ -1,9 +1,10 @@
 """.. include:: ../../README.md"""  # noqa: D415
 
-import platform
 import asyncio
-import nest_asyncio
+import platform
 from multiprocessing import set_start_method
+
+import nest_asyncio
 
 # Raise error on incompatible macOS architecture
 if platform.system() == "Darwin" and platform.machine() != "arm64":
@@ -12,14 +13,17 @@ if platform.system() == "Darwin" and platform.machine() != "arm64":
         "since PyTorch 2.2.2+ does not support x86-64 on macOS."
     )
 
+
 # Conditionally apply nest_asyncio to avoid uvloop conflict
-def safe_apply_nest_asyncio():
+def safe_apply_nest_asyncio() -> None:
+    """Apply nest_asyncio to avoid uvloop conflict."""
     try:
         loop = asyncio.get_event_loop()
         if "uvloop" not in str(type(loop)):
             nest_asyncio.apply()
     except Exception as e:
         print(f"nest_asyncio not applied: {e}")
+
 
 safe_apply_nest_asyncio()
 

--- a/src/tests/utils/data_structures/uvloop_test.py
+++ b/src/tests/utils/data_structures/uvloop_test.py
@@ -1,0 +1,37 @@
+"""Test senselab init with uvloop."""
+
+import asyncio
+import sys
+
+import pytest
+
+try:
+    import uvloop
+
+    UVLOOP_AVAILABLE = True
+except ImportError:
+    UVLOOP_AVAILABLE = False
+
+
+@pytest.mark.skipif(not UVLOOP_AVAILABLE, reason="uvloop not available")
+def test_senselab_init_with_uvloop() -> None:
+    """Test senselab init with uvloop."""
+    # Force the use of uvloop in the test
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+    try:
+        # Force fresh import of senselab to trigger __init__.py
+        sys.modules.pop("senselab", None)
+        import senselab  # noqa: F401
+
+        # If we reach here, the init did not crash due to uvloop conflict
+        async def dummy() -> int:
+            """Dummy async function."""
+            return 42
+
+        loop = asyncio.get_event_loop()
+        result = loop.run_until_complete(dummy())
+        assert result == 42
+
+    except Exception as e:
+        pytest.fail(f"senselab __init__ raised an unexpected error with uvloop: {e}")


### PR DESCRIPTION
## Description
This PR updates the initialization logic to apply nest_asyncio only if the current event loop is not managed by uvloop, which avoids a known runtime ValueError when both are used together. 

## Related Issue(s)
https://github.com/sensein/senselab/issues/341

## Motivation and Context
This makes the library more robust across different environments, including Jupyter notebooks, scripts, and production servers using uvloop.

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
