### PR TITLE
Migrate from Pydra v0 to v1

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
         include:
         - os: ubuntu-latest
-          python-version: '3.10'
+          python-version: '3.11'
           deploy: true   # Only deploy from this configuration
     outputs:
       deploy: ${{ steps.set-deploy-output.outputs.deploy }}
@@ -69,10 +69,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest] # For demonstration, other OSes are commented out
-        python-version: ['3.10']
+        python-version: ['3.11']
         include:
         - os: ubuntu-latest
-          python-version: '3.10'
+          python-version: '3.11'
           deploy: true   # Only deploy from this configuration
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Download auto
       run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,10 +13,9 @@ jobs:
       fail-fast: true
       matrix:
         include:
-        - {os: macos-latest, architecture: arm64, python-version: '3.10'}
-        # - {os: macos-latest, architecture: arm64, python-version: '3.11'}
+        - {os: macos-latest, architecture: arm64, python-version: '3.11'}
         # - {os: macos-latest, architecture: arm64, python-version: '3.12'}
-        # the reason why we commented out 3.11 and 3.12 is that it hits github rate limit for some modules (e.g., knn-vc, Camb-ai/mars5-tts)
+        # the reason why we commented out 3.12 is that it hits github rate limit for some modules (e.g., knn-vc, Camb-ai/mars5-tts)
     steps:
     - uses: actions/checkout@v4
       with:
@@ -80,7 +79,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
     steps:
     - uses: actions/checkout@v4
       with:  # no need for the history
@@ -107,12 +106,12 @@ jobs:
       shell: bash
 
 
-  start-runner-310-core:
+  start-runner-311-core:
     if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'to-test-gpu') && success()
     needs:
     - pre-commit
     - macos-tests
-    name: start-runner-310-core
+    name: start-runner-311-core
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
@@ -138,17 +137,17 @@ jobs:
         subnet-id: ${{ vars.AWS_SUBNET }}
         security-group-id: ${{ vars.AWS_SECURITY_GROUP }}
 
-  ubuntu-tests-310-core:
-    name: ubuntu-tests-310-core
-    needs: start-runner-310-core
-    runs-on: ${{ needs.start-runner-310-core.outputs.label }}
+  ubuntu-tests-311-core:
+    name: ubuntu-tests-311-core
+    needs: start-runner-311-core
+    runs-on: ${{ needs.start-runner-311-core.outputs.label }}
     defaults:
       run:
         shell: bash
         working-directory: ${{ vars.WORKING_DIR }}
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
     env:
       WORKING_DIR: ${{ vars.WORKING_DIR }}
       TORCH_HOME: ${{ vars.WORKING_DIR }}/torch
@@ -241,13 +240,13 @@ jobs:
           --verbose
       shell: bash
 
-  stop-runner-310-core:
-    name: stop-runner-310-core
+  stop-runner-311-core:
+    name: stop-runner-311-core
     needs:
-    - start-runner-310-core   # waits for the EC2 instance to be created
-    - ubuntu-tests-310-core   # waits for the actual job to finish
+    - start-runner-311-core   # waits for the EC2 instance to be created
+    - ubuntu-tests-311-core   # waits for the actual job to finish
     runs-on: ubuntu-latest
-    if: ${{ needs.start-runner-310-core.outputs.job-ran == 'true' && needs.ubuntu-tests-310-core.outputs.job-ran == 'true' || failure() }} # required to stop the runner even if an error occurred in previous jobs
+    if: ${{ needs.start-runner-311-core.outputs.job-ran == 'true' && needs.ubuntu-tests-311-core.outputs.job-ran == 'true' || failure() }} # required to stop the runner even if an error occurred in previous jobs
     steps:
     - name: Check available space
       run: |
@@ -264,173 +263,9 @@ jobs:
       with:
         mode: stop
         github-token: ${{ secrets.GH_TOKEN }}
-        label: ${{ needs.start-runner-310-core.outputs.label }}
-        ec2-instance-id: ${{ needs.start-runner-310-core.outputs.ec2-instance-id }}
+        label: ${{ needs.start-runner-311-core.outputs.label }}
+        ec2-instance-id: ${{ needs.start-runner-311-core.outputs.ec2-instance-id }}
 
-
-  start-runner-310:
-    if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'to-test-gpu') && success()
-    needs:
-    - pre-commit
-    - macos-tests
-    name: start-runner-310
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-ec2-runner.outputs.label }}
-      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
-      job-ran: ${{ steps.set-ran.outputs.ran }}
-    steps:
-    - id: set-ran
-      run: echo "::set-output name=ran::true"
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-access-key-id: ${{ secrets.AWS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_KEY_SECRET }}
-        aws-region: ${{ vars.AWS_REGION }}
-    - name: Start EC2 runner
-      id: start-ec2-runner
-      uses: machulav/ec2-github-runner@v2
-      with:
-        mode: start
-        github-token: ${{ secrets.GH_TOKEN }}
-        ec2-image-id: ${{ vars.AWS_IMAGE_ID }}
-        ec2-instance-type: ${{ vars.AWS_INSTANCE_TYPE }}
-        subnet-id: ${{ vars.AWS_SUBNET }}
-        security-group-id: ${{ vars.AWS_SECURITY_GROUP }}
-
-
-  ubuntu-tests-310:
-    name: ubuntu-tests-310
-    needs: start-runner-310
-    runs-on: ${{ needs.start-runner-310.outputs.label }}
-    defaults:
-      run:
-        shell: bash
-        working-directory: ${{ vars.WORKING_DIR }}
-    strategy:
-      matrix:
-        python-version: ['3.10']
-    env:
-      WORKING_DIR: ${{ vars.WORKING_DIR }}
-      TORCH_HOME: ${{ vars.WORKING_DIR }}/torch
-      PIP_CACHE_DIR: ${{ vars.WORKING_DIR }}/pip
-      POETRY_CACHE_DIR: ${{ vars.WORKING_DIR }}/poetry
-      HF_HOME: ${{ vars.WORKING_DIR }}/huggingface
-      TRANSFORMERS_CACHE: ${{ vars.WORKING_DIR }}/huggingface/transformers
-      HF_DATASETS_CACHE: ${{ vars.WORKING_DIR }}/huggingface/datasets
-    outputs:
-      job-ran: ${{ steps.set-ran.outputs.ran }}
-    steps:
-    - id: set-ran
-      run: echo "::set-output name=ran::true"
-    - name: Check available space before execution
-      run: df -h
-      shell: bash
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 1   # no need for the history
-    - name: Cleanup disk space
-      run: |
-        echo "Cleaning up disk space..."
-        rm -rf ~/.cache
-        rm -rf ~/.npm
-        rm -rf ~/.poetry
-        df -h
-      shell: bash
-    - name: Create cache directories
-      run: |
-        mkdir -p "$POETRY_CACHE_DIR" "$PIP_CACHE_DIR" "$TORCH_HOME" "$HF_HOME" "$TRANSFORMERS_CACHE" "$HF_DATASETS_CACHE"
-        ls -lah ${{ vars.WORKING_DIR }}
-      shell: bash
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install ffmpeg
-      run: |
-        sudo apt-get update && sudo apt-get install -y ffmpeg
-        ffmpeg -version
-      shell: bash
-    - name: Install Poetry
-      run: |
-        which python
-        python --version
-        pip install poetry==2.1.3
-        which poetry
-        poetry --version
-      shell: bash
-    - name: Check available space
-      run: |
-        df -h
-      shell: bash
-    - name: Echo python info
-      run: |
-        python --version
-        which python
-        which poetry
-      shell: bash
-    - name: Copy senselab directory to current directory
-      run: |
-        cp -r /actions-runner/_work/senselab/senselab .
-    - name: Install dependencies with Poetry
-      run: |
-        cd senselab
-        poetry env use ${{ matrix.python-version }}
-        poetry install --extras "audio text video" --with dev
-      shell: bash
-    - name: Check NVIDIA SMI details
-      run: |
-        cd senselab
-        poetry run nvidia-smi
-        poetry run nvidia-smi -L
-        poetry run nvidia-smi -q -d Memory
-      shell: bash
-    - name: Prepare cache folder for pytest
-      run: mkdir -p $WORKING_DIR/pytest/temp
-      shell: bash
-    - name: Run unit tests
-      id: run-tests
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      run: >
-        cd senselab && poetry run pytest \
-          --rootdir=$WORKING_DIR/pytest \
-          --basetemp=$WORKING_DIR/pytest/temp \
-          --junitxml=pytest.xml \
-          --cov-report=term-missing:skip-covered \
-          --cov-report=xml:coverage.xml \
-          --cov=src src/tests \
-          --log-level=DEBUG \
-          --verbose
-      shell: bash
-
-  stop-runner-310:
-    name: stop-runner-310
-    needs:
-    - start-runner-310   # waits for the EC2 instance to be created
-    - ubuntu-tests-310   # waits for the actual job to finish
-    runs-on: ubuntu-latest
-    if: ${{ needs.start-runner-310.outputs.job-ran == 'true' && needs.ubuntu-tests-310.outputs.job-ran == 'true' || failure() }} # required to stop the runner even if an error occurred in previous jobs
-    steps:
-    - name: Check available space
-      run: |
-        df -h
-      shell: bash
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-access-key-id: ${{ secrets.AWS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_KEY_SECRET }}
-        aws-region: ${{ vars.AWS_REGION }}
-    - name: Stop EC2 runner
-      uses: machulav/ec2-github-runner@v2
-      with:
-        mode: stop
-        github-token: ${{ secrets.GH_TOKEN }}
-        label: ${{ needs.start-runner-310.outputs.label }}
-        ec2-instance-id: ${{ needs.start-runner-310.outputs.ec2-instance-id }}
 
   start-runner-311:
     if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'to-test-gpu') && success()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,13 @@ maintainers = [
 ]
 license = {file = "LICENSE.txt"}
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.11,<3.13"
 homepage = "https://github.com/sensein/senselab"
 repository = "https://github.com/sensein/senselab"
 documentation = "https://sensein.github.io/senselab"
 keywords = ["audio", "voice", "speech", "video", "pose", "face", "text", "nlp"]
 classifiers = [
   "Development Status :: 3 - Alpha",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "License :: OSI Approved :: Apache Software License",
@@ -36,7 +35,7 @@ datasets = "~=3"
 torch = {version = "~=2.6", markers = "sys_platform != 'darwin' or platform_machine == 'arm64'"}
 torchvision = "~=0.20"
 transformers = "~=4.48"
-pydra = "~=0.25"
+pydra = ">=1.0a0"
 pydantic = "~=2.7"
 accelerate = "*"
 huggingface-hub = "~=0.23"

--- a/src/senselab/audio/tasks/classification/huggingface.py
+++ b/src/senselab/audio/tasks/classification/huggingface.py
@@ -49,15 +49,16 @@ class HuggingFaceAudioClassifier:
             cls._pipelines[key] = cast(
                 Pipeline,
                 pipeline(  # type: ignore[call-overload]
-                task="audio-classification",
-                model=model.path_or_uri,
-                revision=model.revision,
-                # top_k=top_k, #TODO: this causes a bug in the pipeline that has been reported to transformers
-                # https://github.com/huggingface/transformers/issues/35736
-                function_to_apply=function_to_apply,  # TODO: parameter ignored in transformer code, bug reported
-                # https://github.com/huggingface/transformers/issues/35739
-                device=device.value,
-            ))
+                    task="audio-classification",
+                    model=model.path_or_uri,
+                    revision=model.revision,
+                    # top_k=top_k, #TODO: this causes a bug in the pipeline that has been reported to transformers
+                    # https://github.com/huggingface/transformers/issues/35736
+                    function_to_apply=function_to_apply,  # TODO: parameter ignored in transformer code, bug reported
+                    # https://github.com/huggingface/transformers/issues/35739
+                    device=device.value,
+                ),
+            )
         return cls._pipelines[key]
 
     @classmethod
@@ -124,7 +125,7 @@ class HuggingFaceAudioClassifier:
         feature_extractor = getattr(pipe, "feature_extractor", None)
         if feature_extractor is None:
             raise ValueError("Internal error: The Hugging Face pipeline does not have a feature extractor.")
-        
+
         # Retrieve the expected sampling rate from the Hugging Face model
         expected_sampling_rate = cast(int, getattr(feature_extractor, "sampling_rate", None))  # type: ignore[attr-defined]
         if expected_sampling_rate is None:

--- a/src/senselab/audio/tasks/classification/huggingface.py
+++ b/src/senselab/audio/tasks/classification/huggingface.py
@@ -6,9 +6,9 @@ function at once, rather than calling the function with one audio at a time.
 """
 
 import time
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, cast
 
-from transformers import pipeline
+from transformers import Pipeline, pipeline
 
 from senselab.audio.data_structures import Audio, AudioClassificationResult
 from senselab.utils.data_structures import DeviceType, HFModel, _select_device_and_dtype
@@ -18,7 +18,7 @@ from senselab.utils.data_structures.logging import logger
 class HuggingFaceAudioClassifier:
     """A factory for managing Hugging Face audio classification pipelines."""
 
-    _pipelines: Dict[str, pipeline] = {}
+    _pipelines: Dict[str, Pipeline] = {}
 
     @classmethod
     def _get_hf_audio_classification_pipeline(
@@ -28,7 +28,7 @@ class HuggingFaceAudioClassifier:
         function_to_apply: Literal["softmax", "sigmoid", "none"],
         batch_size: int,
         device: Optional[DeviceType] = None,
-    ) -> pipeline:
+    ) -> Pipeline:
         """Get or create a Hugging Face audio classification pipeline.
 
         Args:
@@ -39,15 +39,17 @@ class HuggingFaceAudioClassifier:
             device (Optional[DeviceType]): The device to run the model on.
 
         Returns:
-            pipeline: The Audio Classification pipeline.
+            Pipeline: The Audio Classification pipeline.
         """
         device, _ = _select_device_and_dtype(
             user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]
         )
         key = f"{model.path_or_uri}-{model.revision}-{top_k}-" f"{function_to_apply}-{batch_size}-{device.value}"
         if key not in cls._pipelines:
-            cls._pipelines[key] = pipeline(
-                "audio-classification",
+            cls._pipelines[key] = cast(
+                Pipeline,
+                pipeline(  # type: ignore[call-overload]
+                task="audio-classification",
                 model=model.path_or_uri,
                 revision=model.revision,
                 # top_k=top_k, #TODO: this causes a bug in the pipeline that has been reported to transformers
@@ -55,7 +57,7 @@ class HuggingFaceAudioClassifier:
                 function_to_apply=function_to_apply,  # TODO: parameter ignored in transformer code, bug reported
                 # https://github.com/huggingface/transformers/issues/35739
                 device=device.value,
-            )
+            ))
         return cls._pipelines[key]
 
     @classmethod
@@ -119,8 +121,14 @@ class HuggingFaceAudioClassifier:
             pipeline: {elapsed_time_pipeline:.2f} seconds"
         )
 
+        feature_extractor = getattr(pipe, "feature_extractor", None)
+        if feature_extractor is None:
+            raise ValueError("Internal error: The Hugging Face pipeline does not have a feature extractor.")
+        
         # Retrieve the expected sampling rate from the Hugging Face model
-        expected_sampling_rate = pipe.feature_extractor.sampling_rate
+        expected_sampling_rate = cast(int, getattr(feature_extractor, "sampling_rate", None))  # type: ignore[attr-defined]
+        if expected_sampling_rate is None:
+            raise ValueError("Internal error: The Hugging Face model does not specify an expected sampling rate.")
 
         # Check that all audio objects are mono
         for audio in audios:
@@ -137,7 +145,7 @@ class HuggingFaceAudioClassifier:
         # Take the start time of the transcription
         start_time_transcription = time.time()
         # Run the pipeline
-        classifications = pipe(formatted_audios, top_k=top_k, function_to_apply=function_to_apply)
+        classifications = pipe(formatted_audios, top_k=top_k, function_to_apply=function_to_apply)  # type: ignore[call-arg]
 
         # Take the end time of the classification
         end_time_transcription = time.time()

--- a/src/senselab/audio/tasks/data_augmentation/audiomentations.py
+++ b/src/senselab/audio/tasks/data_augmentation/audiomentations.py
@@ -41,7 +41,7 @@ def augment_audios_with_audiomentations(
         )
 
     # Serialize augmentation deterministically
-    aug_payload = __import__("cloudpickle").dumps(augmentation)
+    aug_payload = cloudpickle.dumps(augmentation)
 
     @python.define
     def _augment_single_audio(audio: Audio, aug_payload: Any) -> Audio:  # noqa: ANN401

--- a/src/senselab/audio/tasks/data_augmentation/audiomentations.py
+++ b/src/senselab/audio/tasks/data_augmentation/audiomentations.py
@@ -1,4 +1,5 @@
 """This module contains functions for applying data augmentation using audiomentations."""
+
 from __future__ import annotations
 
 from typing import Any, List, Optional, Sequence
@@ -10,6 +11,7 @@ from senselab.audio.data_structures import Audio
 
 try:
     from audiomentations import Compose
+
     AUDIOMENTATIONS_AVAILABLE = True
 except ModuleNotFoundError:
     AUDIOMENTATIONS_AVAILABLE = False
@@ -58,7 +60,5 @@ def augment_audios_with_audiomentations(
         return node.out
 
     worker = "debug" if plugin in ("serial", "debug") else plugin
-    res = _wf(xs=audios, aug_payload=aug_payload)(
-        worker=worker, cache_root=cache_dir, **(plugin_args or {})
-    )
+    res = _wf(xs=audios, aug_payload=aug_payload)(worker=worker, cache_root=cache_dir, **(plugin_args or {}))
     return list(res.out)

--- a/src/senselab/audio/tasks/data_augmentation/audiomentations.py
+++ b/src/senselab/audio/tasks/data_augmentation/audiomentations.py
@@ -1,76 +1,64 @@
-"""This module implements some utilities for audio data augmentation with audiomentations."""
+"""This module contains functions for applying data augmentation using audiomentations."""
+from __future__ import annotations
 
-from typing import List
+from typing import Any, List, Optional, Sequence
+
+import cloudpickle
+from pydra.compose import python, workflow
 
 from senselab.audio.data_structures import Audio
 
 try:
     from audiomentations import Compose
-
     AUDIOMENTATIONS_AVAILABLE = True
 except ModuleNotFoundError:
     AUDIOMENTATIONS_AVAILABLE = False
 
 
-def augment_audios_with_audiomentations(audios: List[Audio], augmentation: "Compose") -> List[Audio]:
-    """Augments all provided audios with audiomentations library.
+def augment_audios_with_audiomentations(
+    audios: List[Audio],
+    augmentation: "Compose",
+    plugin: str = "debug",
+    plugin_args: Optional[dict[str, Any]] = None,
+    cache_dir: Optional[str] = None,
+) -> List[Audio]:
+    """Apply data augmentation using audiomentations.
 
     Args:
         audios: List of Audios whose data will be augmented with the given augmentations.
-        augmentation: A Composition of augmentations to run on each audio (uses audiomentations).
+        augmentation: A composition of augmentations (audiomentations).
+        plugin: The plugin to use for running the workflow. Default is "debug".
+        plugin_args: Additional arguments to pass to the plugin. Default is None.
+        cache_dir: The directory to use for caching the workflow. Default is None.
 
     Returns:
-        List of audios that have passed through the provided augmentation.
+        List of augmented audios.
     """
-
-    def _augment_single_audio(audio: Audio, augmentation: "Compose"):  # noqa: ANN202
-        """Augments a single audio with audiomentations.
-
-        Args:
-            audio: The audio to be augmented.
-            augmentation: The audiomentations augmentation to be applied.
-
-        Returns:
-            The augmented audio. The returned data type is not explicitly specified
-                in the function signature because it would brake pydra.
-        """
-        augmented_waveform = augmentation(samples=audio.waveform.numpy(), sample_rate=audio.sampling_rate)
-        return Audio(
-            waveform=augmented_waveform,
-            sampling_rate=audio.sampling_rate,
-            metadata=audio.metadata.copy(),
-        )
-
     if not AUDIOMENTATIONS_AVAILABLE:
         raise ModuleNotFoundError(
             "`audiomentations` is not installed. "
             "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
         )
 
-    """
-    # The commented code is for parallelizing the augmentation using pydra
-    # Due to some issues with pydra, this is disabled for now
+    # Serialize augmentation deterministically
+    aug_payload = __import__("cloudpickle").dumps(augmentation)
 
-    import pydra
+    @python.define
+    def _augment_single_audio(audio: Audio, aug_payload: Any) -> Audio:  # noqa: ANN401
+        aug = cloudpickle.loads(aug_payload)
+        augmented = aug(samples=audio.waveform, sample_rate=audio.sampling_rate)
+        return Audio(waveform=augmented, sampling_rate=audio.sampling_rate, metadata=audio.metadata.copy())
 
-    _augment_single_audio_pt = pydra.mark.task(_augment_single_audio)
+    @workflow.define
+    def _wf(xs: Sequence[Audio], aug_payload: Any) -> List[Audio]:  # noqa: ANN401
+        node = workflow.add(
+            _augment_single_audio(aug_payload=aug_payload).split(audio=xs),
+            name="map_audiomentations",
+        )
+        return node.out
 
-    # Create the workflow
-    wf = pydra.Workflow(name="audio_augmentation_wf", input_spec=["y"])
-    wf.split("y", y=audios)
-    wf.add(_augment_single_audio_pt(name="augment_audio", audio=wf.lzin.y, augmentation=augmentation))
-    wf.set_output([("augmented_audio", wf.augment_audio.lzout.out)])
-
-    # Execute the workflow
-    with pydra.Submitter(plugin="cf") as submitter:
-        submitter(wf)
-
-    outputs = wf.result()
-    return [out.output.augmented_audio for out in outputs]
-    """
-
-    augmented_audios = []
-    for audio in audios:
-        augmented_audios.append(_augment_single_audio(audio, augmentation))
-
-    return augmented_audios
+    worker = "debug" if plugin in ("serial", "debug") else plugin
+    res = _wf(xs=audios, aug_payload=aug_payload)(
+        worker=worker, cache_root=cache_dir, **(plugin_args or {})
+    )
+    return list(res.out)

--- a/src/senselab/audio/tasks/data_augmentation/torch_audiomentations.py
+++ b/src/senselab/audio/tasks/data_augmentation/torch_audiomentations.py
@@ -1,114 +1,98 @@
-"""This module implements some utilities for audio data augmentation with torch_audiomentations."""
+"""This module contains functions for applying data augmentation using torch-audiomentations."""
+from typing import Any, List, Optional, Sequence
 
-from typing import List, Optional
-
+import cloudpickle
 import torch
+from pydra.compose import python, workflow
 
-from senselab.audio.data_structures import (
-    Audio,
-    batch_audios,
-    unbatch_audios,
-)
+from senselab.audio.data_structures import Audio, batch_audios, unbatch_audios
 from senselab.utils.data_structures import DeviceType, _select_device_and_dtype
 
 try:
-    from torch_audiomentations import Compose
-
+    from torch_audiomentations import Compose as _TACompose  # runtime check
     TORCH_AUDIOMENTATIONS_AVAILABLE = True
 except ModuleNotFoundError:
     TORCH_AUDIOMENTATIONS_AVAILABLE = False
+    _TACompose = object  # sentinel to satisfy type-checkers
 
 
 def augment_audios_with_torch_audiomentations(
-    audios: List[Audio], augmentation: "Compose", device: Optional[DeviceType] = None
+    audios: List[Audio],
+    augmentation: "_TACompose",
+    device: Optional[DeviceType] = None,
+    *,
+    plugin: str = "debug",
+    plugin_args: Optional[dict[str, Any]] = None,
+    cache_dir: Optional[str] = None,
 ) -> List[Audio]:
-    """Augments all provided audios with a given augmentation, either individually or all batched together.
+    """Augment a list of Audio with torch-audiomentations.
 
-    Augment all audios with a user defined augmentation that can be a composition of multiple augmentations.
-    This augmentation is either performed on each audio individually (using pydra for optimization)
-    or all of the audios provided are batched together and run at once.
-    It uses torch_audiomentations. If batching, all audios must have the same sampling rate.
-
-    Args:
-        audios: List of Audios whose data will be augmented with the given augmentations
-        augmentation: A Composition of augmentations to run on each audio (uses torch-audiomentations), should have its
-            output_type set to "dict"
-        device: The device to use for augmenting. If the chosen device
-            is CUDA then the audios are all batched together, so for optimal performance, batching should
-            be done by passing a batch_size worth of audios ar a time.
-            Default is None, which will select the device automatically.
-
-    Returns:
-        List of audios that has passed the all of input audios through the provided augmentation. This does
-            not necessarily mean that the augmentation has been run on every audio. For more information,
-            see the torch-audiomentations documentation.
+    CPU: parallel map over audios with Pydra compose.
+    CUDA: batch once on device for throughput.
     """
     if not TORCH_AUDIOMENTATIONS_AVAILABLE:
         raise ModuleNotFoundError(
             "`torch-audiomentations` is not installed. "
             "Please install senselab audio dependencies using `pip install 'senselab[audio]'`"
         )
+    if not isinstance(augmentation, _TACompose):
+        raise TypeError("`augmentation` must be an instance of torch_audiomentations.Compose")
 
+    # torch-audiomentations Compose needs dict output
     augmentation.output_type = "dict"
+
     device_type, _ = _select_device_and_dtype(
-        user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]
+        user_preference=device,
+        compatible_devices=[DeviceType.CUDA, DeviceType.CPU],
     )
-    if device_type == DeviceType.CPU:
-        '''
-        # The commented code is for parallelizing the augmentation using pydra
-        # Due to some issues with pydra, this is disabled for now
-        import pydra
 
-        def _augment_single_audio(audio: Audio, augmentation: Compose):  # noqa: ANN202
-            """Augments a single audio with torch-audiomentations.
+    # --------------------------
+    # GPU path: batch once
+    # --------------------------
+    if device_type == DeviceType.CUDA:
+        batched, sampling_rates, metadatas = batch_audios(audios)
+        batched = batched.to(device=torch.device(device_type.value))
+        sampling_rate = sampling_rates[0] if isinstance(sampling_rates, list) else sampling_rates
 
-            Args:
-                audio: The audio to be augmented.
-                augmentation: The torch-audiomentations augmentation to be applied.
+        with torch.inference_mode():
+            out = augmentation(batched, sample_rate=sampling_rate).samples  # (B, C, T)
 
-            Returns:
-                The augmented audio. The returned data type is not explicitly specified
-                    in the function signature because it would brake pydra.
-            """
-            augmented_waveform = augmentation(audio.waveform.unsqueeze(0), sample_rate=audio.sampling_rate).samples
-            return Audio(
-                waveform=torch.squeeze(augmented_waveform),
-                sampling_rate=audio.sampling_rate,
-                metadata=audio.metadata.copy(),
-            )
+        out = out.detach().cpu()
+        return unbatch_audios(out, sampling_rates, metadatas)
 
-        _augment_single_audio_pt = pydra.mark.task(_augment_single_audio)
+    # --------------------------
+    # CPU path: map with Pydra
+    # --------------------------
+    aug_payload = cloudpickle.dumps(augmentation)
 
-        # Create the workflow
-        wf = pydra.Workflow(name="audio_augmentation_wf", input_spec=["y"])
-        wf.split("y", y=audios)
-        wf.add(_augment_single_audio_pt(name="augment_audio", audio=wf.lzin.y, augmentation=augmentation))
-        wf.set_output([("augmented_audio", wf.augment_audio.lzout.out)])
+    @python.define
+    def _augment_single_audio(audio: Audio, aug_payload: bytes) -> Audio:
+        aug = cloudpickle.loads(aug_payload)
 
-        # Execute the workflow
-        with pydra.Submitter(plugin="cf") as submitter:
-            submitter(wf)
-        outputs = wf.result()
-        return [out.output.augmented_audio for out in outputs]
-        '''
-        new_audios = []
-        for audio in audios:
-            audio_to_augment = audio.waveform.unsqueeze(0)
-            augmented_audio = augmentation(audio_to_augment, sample_rate=audio.sampling_rate).samples
-            new_audios.append(
-                Audio(
-                    waveform=torch.squeeze(augmented_audio),
-                    sampling_rate=audio.sampling_rate,
-                    metadata=audio.metadata.copy(),
-                )
-            )
-        return new_audios
-    else:
-        batched_audios, sampling_rates, metadatas = batch_audios(audios)
+        # torch-audiomentations expects (B, C, T) Tensor
+        x = audio.waveform.unsqueeze(0)  # (1, C, T)
+        with torch.inference_mode():
+            y = aug(x, sample_rate=audio.sampling_rate).samples  # (1, C, T)
+        y = torch.squeeze(y, 0)  # (C, T)
 
-        batched_audios = batched_audios.to(device=torch.device(device_type.value))
-        sampling_rate = sampling_rates[0] if isinstance(sampling_rates, List) else sampling_rates
-        augmented_audio = augmentation(batched_audios, sample_rate=sampling_rate).samples
+        return Audio(
+            waveform=y,
+            sampling_rate=audio.sampling_rate,
+            metadata=audio.metadata.copy(),
+        )
 
-        augmented_audio = augmented_audio.detach().cpu()
-        return unbatch_audios(augmented_audio, sampling_rates, metadatas)
+    @workflow.define
+    def _wf(xs: Sequence[Audio], aug_payload: bytes) -> List[Audio]:
+        node = workflow.add(
+            _augment_single_audio(aug_payload=aug_payload).split(audio=xs),
+            name="map_torch_audiomentations",
+        )
+        return node.out
+
+    worker = "debug" if plugin in ("serial", "debug") else plugin
+    res = _wf(xs=audios, aug_payload=aug_payload)(
+        worker=worker,
+        cache_root=cache_dir,
+        **(plugin_args or {}),
+    )
+    return list(res.out)

--- a/src/senselab/audio/tasks/data_augmentation/torch_audiomentations.py
+++ b/src/senselab/audio/tasks/data_augmentation/torch_audiomentations.py
@@ -1,4 +1,5 @@
 """This module contains functions for applying data augmentation using torch-audiomentations."""
+
 from typing import Any, List, Optional, Sequence
 
 import cloudpickle
@@ -10,6 +11,7 @@ from senselab.utils.data_structures import DeviceType, _select_device_and_dtype
 
 try:
     from torch_audiomentations import Compose as _TACompose  # runtime check
+
     TORCH_AUDIOMENTATIONS_AVAILABLE = True
 except ModuleNotFoundError:
     TORCH_AUDIOMENTATIONS_AVAILABLE = False

--- a/src/senselab/audio/tasks/features_extraction/api.py
+++ b/src/senselab/audio/tasks/features_extraction/api.py
@@ -307,10 +307,10 @@ def extract_features_from_audios(
         'si_sdr': 11.71167278289795}}]
     """
     if opensmile:
-        default_opensmile = {
+        default_opensmile: Dict[str, Any] = {
             "feature_set": "eGeMAPSv02",
             "feature_level": "Functionals",
-            "plugin": "serial",
+            "plugin": "debug",
             "plugin_args": {},
             "cache_dir": None,
         }
@@ -320,7 +320,7 @@ def extract_features_from_audios(
             my_opensmile = default_opensmile
         opensmile_features = extract_opensmile_features_from_audios(audios, **my_opensmile)  # type: ignore
     if parselmouth:
-        default_parselmouth = {
+        default_parselmouth: Dict[str, Any] = {
             "time_step": 0.005,
             "window_length": 0.025,
             "pitch_unit": "Hertz",
@@ -336,7 +336,7 @@ def extract_features_from_audios(
             "duration": True,
             "jitter": True,
             "shimmer": True,
-            "plugin": "serial",
+            "plugin": "debug",
             "plugin_args": {},
         }
         # Update default_parselmouth with provided parselmouth dictionary
@@ -356,7 +356,7 @@ def extract_features_from_audios(
             "n_mfcc": 40,
             "win_length": None,
             "hop_length": None,
-            "plugin": "serial",
+            "plugin": "debug",
             "plugin_args": {},
             "cache_dir": None,
         }

--- a/src/senselab/audio/tasks/features_extraction/opensmile.py
+++ b/src/senselab/audio/tasks/features_extraction/opensmile.py
@@ -33,6 +33,7 @@ except ModuleNotFoundError:
 
         class Smile:
             """Dummy class for when openSMILE is not available."""
+
             def __init__(self, *args: object, **kwargs: object) -> None:
                 """Dummy constructor for when openSMILE is not available."""
                 pass
@@ -83,13 +84,13 @@ def extract_opensmile_features_from_audios(
     cache_dir: Optional[str | os.PathLike] = None,
 ) -> List[Dict[str, Any]]:
     """Extract openSMILE features from a list of audio files using a Pydra compose workflow.
-    
+
     Args:
         audios (List[Audio]): A list of Audio objects.
         feature_set (str, optional): The feature set to use. Defaults to "eGeMAPSv02".
         feature_level (str, optional): The feature level to use. Defaults to "Functionals".
         plugin (str, optional): The Pydra plugin to use for workflow submission. Defaults to "debug".
-        plugin_args (Optional[Dict[str, Any]], optional): Additional arguments for the Pydra plugin. 
+        plugin_args (Optional[Dict[str, Any]], optional): Additional arguments for the Pydra plugin.
             Defaults to None.
         cache_dir (Optional[str | os.PathLike], optional): The directory for caching intermediate results.
             Defaults to None.
@@ -113,10 +114,7 @@ def extract_opensmile_features_from_audios(
         sampling_rate = sample.sampling_rate
         try:
             df = smile.process_signal(audio_array, sampling_rate)
-            return {
-                k: (v[0] if isinstance(v, list) and len(v) == 1 else v)
-                for k, v in df.to_dict("list").items()
-            }
+            return {k: (v[0] if isinstance(v, list) and len(v) == 1 else v) for k, v in df.to_dict("list").items()}
         except Exception as e:
             filepath = sample.filepath() if hasattr(sample, "filepath") and sample.filepath() else ""
             desc = f"{sample.generate_id()}{f' ({filepath})' if filepath else ''}"

--- a/src/senselab/audio/tasks/features_extraction/opensmile.py
+++ b/src/senselab/audio/tasks/features_extraction/opensmile.py
@@ -8,6 +8,15 @@ for parallel processing. This approach supports efficient and scalable feature
 extraction across multiple audio files.
 """
 
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional, Sequence
+
+from pydra.compose import python, workflow
+
+from senselab.audio.data_structures import Audio
+
 try:
     import opensmile
 
@@ -23,43 +32,32 @@ except ModuleNotFoundError:
             self.__dict__ = {}
 
         class Smile:
-            """Dummy class to represent openSMILE when it's not available."""
-
+            """Dummy class for when openSMILE is not available."""
             def __init__(self, *args: object, **kwargs: object) -> None:
-                """Dummy class for when openSMILE is not available."""
+                """Dummy constructor for when openSMILE is not available."""
                 pass
 
-    opensmile = DummyOpenSmile()
-
-import os
-from typing import Any, Dict, List, Optional
-
-import numpy as np
-import pydra
-
-from senselab.audio.data_structures import Audio
+    opensmile = DummyOpenSmile()  # type: ignore[assignment]
 
 
 class OpenSmileFeatureExtractorFactory:
-    """A factory for managing openSMILE feature extractors.
+    """A factory for managing openSMILE feature extractors."""
 
-    This class creates and caches openSMILE feature extractors, allowing for
-    efficient reuse. It ensures only one instance of each feature extractor
-    exists per unique combination of `feature_set` and `feature_level`.
-    """
-
-    _extractors: Dict[str, opensmile.Smile] = {}  # Cache for feature extractors
+    _extractors: Dict[str, opensmile.Smile] = {}
 
     @classmethod
     def get_opensmile_extractor(cls, feature_set: str, feature_level: str) -> opensmile.Smile:
-        """Get or create an openSMILE feature extractor.
+        """Get an openSMILE feature extractor for a given feature set and feature level.
 
         Args:
-            feature_set (str): The openSMILE feature set.
-            feature_level (str): The openSMILE feature level.
+            feature_set (str): The feature set to use.
+            feature_level (str): The feature level to use.
 
         Returns:
             opensmile.Smile: The openSMILE feature extractor.
+
+        Raises:
+            ModuleNotFoundError: If `opensmile` is not installed.
         """
         if not OPENSMILE_AVAILABLE:
             raise ModuleNotFoundError(
@@ -67,40 +65,40 @@ class OpenSmileFeatureExtractorFactory:
                 "Please install senselab audio dependencies using `pip install 'senselab[audio]'`"
             )
 
-        key = f"{feature_set}-{feature_level}"  # Unique key for each feature extractor
-        if key not in cls._extractors:  # Check if extractor exists in cache
-            # Create and store a new extractor if not found in cache
+        key = f"{feature_set}-{feature_level}"
+        if key not in cls._extractors:
             cls._extractors[key] = opensmile.Smile(
                 feature_set=opensmile.FeatureSet[feature_set],
                 feature_level=opensmile.FeatureLevel[feature_level],
             )
-        return cls._extractors[key]  # Return cached or newly created extractor
+        return cls._extractors[key]
 
 
 def extract_opensmile_features_from_audios(
     audios: List[Audio],
     feature_set: str = "eGeMAPSv02",
     feature_level: str = "Functionals",
-    plugin: str = "serial",
-    plugin_args: Optional[Dict[str, Any]] = {},
+    plugin: str = "debug",
+    plugin_args: Optional[Dict[str, Any]] = None,
     cache_dir: Optional[str | os.PathLike] = None,
 ) -> List[Dict[str, Any]]:
-    """Extract openSMILE features from a list of audio files using Pydra workflow.
-
-    This function sets up a Pydra workflow for parallel processing of openSMILE
-    feature extraction on a list of audio samples. Each sample's features are
-    extracted and formatted as dictionaries.
-
+    """Extract openSMILE features from a list of audio files using a Pydra compose workflow.
+    
     Args:
-        audios (List[Audio]): The list of audio objects to extract features from.
-        feature_set (str): The openSMILE feature set (default is "eGeMAPSv02").
-        feature_level (str): The openSMILE feature level (default is "Functionals").
-        plugin (str): The Pydra plugin to use (default is "serial").
-        plugin_args (Optional[Dict[str, Any]]): Additional arguments for the Pydra plugin.
-        cache_dir (Optional[str | os.PathLike]): The path to the Pydra cache directory.
+        audios (List[Audio]): A list of Audio objects.
+        feature_set (str, optional): The feature set to use. Defaults to "eGeMAPSv02".
+        feature_level (str, optional): The feature level to use. Defaults to "Functionals".
+        plugin (str, optional): The Pydra plugin to use for workflow submission. Defaults to "debug".
+        plugin_args (Optional[Dict[str, Any]], optional): Additional arguments for the Pydra plugin. 
+            Defaults to None.
+        cache_dir (Optional[str | os.PathLike], optional): The directory for caching intermediate results.
+            Defaults to None.
 
     Returns:
-        List[Dict[str, Any]]: A list of dictionaries, each containing extracted features.
+        List[Dict[str, Any]]: A list of dictionaries containing the extracted features.
+
+    Raises:
+        ModuleNotFoundError: If `opensmile` is not installed.
     """
     if not OPENSMILE_AVAILABLE:
         raise ModuleNotFoundError(
@@ -108,62 +106,37 @@ def extract_opensmile_features_from_audios(
             "`pip install 'senselab[audio]'`"
         )
 
-    def _extract_feats_from_audio(sample: Audio, smile: opensmile.Smile) -> Dict[str, Any]:
-        """Extract features from a single audio sample using openSMILE.
-
-        Args:
-            sample (Audio): The audio object.
-            smile (opensmile.Smile): The openSMILE feature extractor.
-
-        Returns:
-            Dict[str, Any]: The extracted features as a dictionary.
-        """
-        # Convert audio tensor to a NumPy array for processing
+    @python.define
+    def _extract_feats_from_audio(sample: Audio, feature_set: str, feature_level: str) -> Dict[str, Any]:
+        smile = OpenSmileFeatureExtractorFactory.get_opensmile_extractor(feature_set, feature_level)
         audio_array = sample.waveform.squeeze().numpy()
-        sampling_rate = sample.sampling_rate  # Get sampling rate from Audio object
+        sampling_rate = sample.sampling_rate
         try:
-            # Process the audio and extract features
-            sample_features = smile.process_signal(audio_array, sampling_rate)
-            # Convert features to a dictionary and handle single-item lists
+            df = smile.process_signal(audio_array, sampling_rate)
             return {
-                k: v[0] if isinstance(v, list) and len(v) == 1 else v
-                for k, v in sample_features.to_dict("list").items()
+                k: (v[0] if isinstance(v, list) and len(v) == 1 else v)
+                for k, v in df.to_dict("list").items()
             }
         except Exception as e:
-            # Log error and return NaNs if feature extraction fails
             filepath = sample.filepath() if hasattr(sample, "filepath") and sample.filepath() else ""
             desc = f"{sample.generate_id()}{f' ({filepath})' if filepath else ''}"
             print(f"Error processing sample {desc}: {e}")
-            return {feature: np.nan for feature in smile.feature_names}
+            names = getattr(smile, "feature_names", [])
+            return {name: float("nan") for name in names} if names else {}
 
-    # Decorate the feature extraction function for Pydra
-    _extract_feats_from_audio_pt = pydra.mark.task(_extract_feats_from_audio)
+    @workflow.define
+    def _wf(xs: Sequence[Audio], feature_set: str, feature_level: str) -> List[Dict[str, Any]]:
+        t = _extract_feats_from_audio(
+            feature_set=feature_set,
+            feature_level=feature_level,
+        ).split(sample=xs)
 
-    # Obtain the feature extractor using the factory
-    smile = OpenSmileFeatureExtractorFactory.get_opensmile_extractor(feature_set, feature_level)
+        node = workflow.add(t, name="map_extract_feats")
+        return node.out
 
-    # Create a Pydra workflow, split it over the list of audio samples
-    wf = pydra.Workflow(name="wf", input_spec=["x"], cache_dir=cache_dir)
-    wf.split("x", x=audios)  # Each audio is treated as a separate task
-    # Add feature extraction task to the workflow
-    wf.add(_extract_feats_from_audio_pt(name="_extract_feats_from_audio_pt", sample=wf.lzin.x, smile=smile))
+    worker = "debug" if plugin in ("serial", "debug") else plugin
+    worker_kwargs = plugin_args or {}
 
-    # Set workflow output to the results of each audio feature extraction
-    wf.set_output([("opensmile", wf._extract_feats_from_audio_pt.lzout.out)])
-
-    # Run the workflow using the specified Pydra plugin and arguments
-    with pydra.Submitter(plugin=plugin, **plugin_args) as sub:
-        sub(wf)
-
-    # Retrieve results from the completed workflow
-    outputs = wf.result()
-
-    # Format the outputs into a list of dictionaries
-    formatted_output: List[Dict[str, Any]] = []
-    for output in outputs:
-        # Extract features and organize into a dictionary
-        formatted_output_item = {
-            f"{feature}": output.output.opensmile[f"{feature}"] for feature in output.output.opensmile
-        }
-        formatted_output.append(formatted_output_item)  # Append to final output list
-    return formatted_output  # Return the list of formatted feature dictionaries
+    wf = _wf(xs=audios, feature_set=feature_set, feature_level=feature_level)
+    res: Any = wf(worker=worker, cache_root=cache_dir, **worker_kwargs)
+    return list(res.out)

--- a/src/senselab/audio/tasks/features_extraction/praat_parselmouth.py
+++ b/src/senselab/audio/tasks/features_extraction/praat_parselmouth.py
@@ -8,10 +8,10 @@ by the senselab community.
 import inspect
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
-import pydra  # type: ignore
+from pydra.compose import python, workflow
 
 from senselab.audio.data_structures import Audio
 from senselab.utils.data_structures import logger
@@ -1222,267 +1222,220 @@ def extract_praat_parselmouth_features_from_audios(
     duration: bool = True,
     jitter: bool = True,
     shimmer: bool = True,
-    plugin: str = "serial",
-    plugin_args: Dict[str, Any] = {},
+    plugin: str = "debug",
+    plugin_args: Dict[str, Any] | None = None,
 ) -> List[Dict[str, Any]]:
-    """Extract features from a list of Audio objects and return a JSON-like dictionary.
+    """Extract Parselmouth features for each Audio using Pydra v1 compose, in parallel over inputs."""
 
-    Args:
-        audios (list): List of Audio objects to extract features from.
-        pitch_unit (str): Unit for pitch measurements. Defaults to "Hertz".
-        time_step (float): Time rate at which to extract features. Defaults to 0.005.
-        window_length (float): Window length in seconds for spectral features. Defaults to 0.025.
-        cache_dir (Optional[str]): Directory to use for caching by pydra. Defaults to None.
-        speech_rate (bool): Whether to extract speech rate. Defaults to True.
-        intensity_descriptors (bool): Whether to extract intensity descriptors. Defaults to True.
-        harmonicity_descriptors (bool): Whether to extract harmonic descriptors. Defaults to True.
-        formants (bool): Whether to extract formants. Defaults to True.
-        spectral_moments (bool): Whether to extract spectral moments. Defaults to True.
-        pitch (bool): Whether to extract pitch. Defaults to True.
-        slope_tilt (bool): Whether to extract slope and tilt. Defaults to True.
-        cpp_descriptors (bool): Whether to extract CPP descriptors. Defaults to True.
-        duration (bool): Whether to extract duration. Defaults to True.
-        jitter (bool): Whether to extract jitter. Defaults to True.
-        shimmer (bool): Whether to extract shimmer. Defaults to True.
-        plugin (str): Plugin to use for feature extraction. Defaults to "serial".
-        plugin_args (Optional[Dict[str, Any]]): Arguments for the pydra plugin. Defaults to {}.
+    @python.define
+    def _extract_all_for_sample(
+        sample: Audio,
+        time_step: float,
+        window_length: float,
+        pitch_unit: str,
+        speech_rate: bool,
+        intensity_descriptors: bool,
+        harmonicity_descriptors: bool,
+        formants: bool,
+        spectral_moments: bool,
+        pitch: bool,
+        slope_tilt: bool,
+        cpp_descriptors: bool,
+        duration: bool,
+        jitter: bool,
+        shimmer: bool,
+    ) -> Dict[str, Any]:
+        """Compute all requested features for a single Audio and return one flat dict."""
+        # 1) Always compute pitch floor/ceiling once (many features depend on them)
+        pv = extract_pitch_values(snd=sample)
+        pitch_floor = pv["pitch_floor"]
+        pitch_ceiling = pv["pitch_ceiling"]
 
-    Returns:
-        dict: A JSON-like dictionary with extracted features structured under "praat_parselmouth".
-    """
-    # Mark tasks with Pydra
-    extract_pitch_values_pt = pydra.mark.task(extract_pitch_values)
+        out: Dict[str, Any] = {}
 
-    def _extract_pitch_floor(pitch_values_out: dict) -> float:
-        return pitch_values_out["pitch_floor"]
+        # 2) Duration
+        if duration:
+            dur = extract_audio_duration(snd=sample)
+            out["duration"] = dur["duration"]
 
-    _extract_pitch_floor_pt = pydra.mark.task(_extract_pitch_floor)
+        # 3) Speech rate / pausing
+        if speech_rate:
+            sr = extract_speech_rate(snd=sample)
+            out["speaking_rate"] = sr["speaking_rate"]
+            out["articulation_rate"] = sr["articulation_rate"]
+            out["phonation_ratio"] = sr["phonation_ratio"]
+            out["pause_rate"] = sr["pause_rate"]
+            out["mean_pause_duration"] = sr["mean_pause_dur"]
 
-    def _extract_pitch_ceiling(pitch_values_out: dict) -> float:
-        return pitch_values_out["pitch_ceiling"]
-
-    _extract_pitch_ceiling_pt = pydra.mark.task(_extract_pitch_ceiling)
-    if speech_rate:
-        extract_speech_rate_pt = pydra.mark.task(extract_speech_rate)
-    if intensity_descriptors:
-        extract_intensity_descriptors_pt = pydra.mark.task(extract_intensity_descriptors)
-    if harmonicity_descriptors:
-        extract_harmonicity_descriptors_pt = pydra.mark.task(extract_harmonicity_descriptors)
-    if formants:
-        measure_f1f2_formants_bandwidths_pt = pydra.mark.task(measure_f1f2_formants_bandwidths)
-    if spectral_moments:
-        extract_spectral_moments_pt = pydra.mark.task(extract_spectral_moments)
-    if pitch:
-        extract_pitch_descriptors_pt = pydra.mark.task(extract_pitch_descriptors)
-    if slope_tilt:
-        extract_slope_tilt_pt = pydra.mark.task(extract_slope_tilt)
-    if cpp_descriptors:
-        extract_cpp_descriptors_pt = pydra.mark.task(extract_cpp_descriptors)
-    if duration:
-        extract_audio_duration_pt = pydra.mark.task(extract_audio_duration)
-    if jitter:
-        extract_jitter_pt = pydra.mark.task(extract_jitter)
-    if shimmer:
-        extract_shimmer_pt = pydra.mark.task(extract_shimmer)
-
-    # Create the workflow
-    wf = pydra.Workflow(name="wf", input_spec=["x"], cache_dir=cache_dir)
-    wf.split("x", x=audios)
-    wf.add(extract_pitch_values_pt(name="extract_pitch_values_pt", snd=wf.lzin.x))
-    wf.add(
-        _extract_pitch_floor_pt(name="_extract_pitch_floor_pt", pitch_values_out=wf.extract_pitch_values_pt.lzout.out)
-    )
-    wf.add(
-        _extract_pitch_ceiling_pt(
-            name="_extract_pitch_ceiling_pt", pitch_values_out=wf.extract_pitch_values_pt.lzout.out
-        )
-    )
-    if speech_rate:
-        wf.add(extract_speech_rate_pt(name="extract_speech_rate_pt", snd=wf.lzin.x))
-    if pitch:
-        wf.add(
-            extract_pitch_descriptors_pt(
-                name="extract_pitch_descriptors_pt",
-                snd=wf.lzin.x,
-                floor=wf._extract_pitch_floor_pt.lzout.out,
-                ceiling=wf._extract_pitch_ceiling_pt.lzout.out,
+        # 4) Pitch + Intensity
+        if pitch:
+            pd = extract_pitch_descriptors(
+                snd=sample,
+                floor=pitch_floor,
+                ceiling=pitch_ceiling,
                 frame_shift=time_step,
                 unit=pitch_unit,
             )
-        )
-    if intensity_descriptors:
-        wf.add(
-            extract_intensity_descriptors_pt(
-                name="extract_intensity_descriptors_pt",
-                snd=wf.lzin.x,
-                floor=wf._extract_pitch_floor_pt.lzout.out,
+            out[f"mean_f0_{pitch_unit.lower()}"] = pd[f"mean_f0_{pitch_unit.lower()}"]
+            out[f"std_f0_{pitch_unit.lower()}"] = pd[f"stdev_f0_{pitch_unit.lower()}"]
+
+        if intensity_descriptors:
+            idesc = extract_intensity_descriptors(
+                snd=sample,
+                floor=pitch_floor,
                 frame_shift=time_step,
             )
-        )
-    if harmonicity_descriptors:
-        wf.add(
-            extract_harmonicity_descriptors_pt(
-                name="extract_harmonicity_descriptors_pt",
-                snd=wf.lzin.x,
-                floor=wf._extract_pitch_floor_pt.lzout.out,
+            out["mean_intensity_db"] = idesc["mean_db"]
+            out["std_intensity_db"] = idesc["std_db"]
+            out["range_ratio_intensity_db"] = idesc["range_db_ratio"]
+
+        # 5) Harmonicity, spectral slope/tilt, CPP
+        if harmonicity_descriptors:
+            hdesc = extract_harmonicity_descriptors(
+                snd=sample,
+                floor=pitch_floor,
                 frame_shift=time_step,
             )
-        )
-    if formants:
-        wf.add(
-            measure_f1f2_formants_bandwidths_pt(
-                name="measure_f1f2_formants_bandwidths_pt",
-                snd=wf.lzin.x,
-                floor=wf._extract_pitch_floor_pt.lzout.out,
-                ceiling=wf._extract_pitch_ceiling_pt.lzout.out,
+            out["mean_hnr_db"] = hdesc["hnr_db_mean"]
+            out["std_hnr_db"] = hdesc["hnr_db_std_dev"]
+
+        if slope_tilt:
+            st = extract_slope_tilt(
+                snd=sample,
+                floor=pitch_floor,
+                ceiling=pitch_ceiling,
+            )
+            out["spectral_slope"] = st["spectral_slope"]
+            out["spectral_tilt"] = st["spectral_tilt"]
+
+        if cpp_descriptors:
+            cpp = extract_cpp_descriptors(
+                snd=sample,
+                floor=pitch_floor,
+                ceiling=pitch_ceiling,
                 frame_shift=time_step,
             )
-        )
-    if spectral_moments:
-        wf.add(
-            extract_spectral_moments_pt(
-                name="extract_spectral_moments_pt",
-                snd=wf.lzin.x,
-                floor=wf._extract_pitch_floor_pt.lzout.out,
-                ceiling=wf._extract_pitch_ceiling_pt.lzout.out,
+            out["cepstral_peak_prominence_mean"] = cpp["mean_cpp"]
+            out["cepstral_peak_prominence_std"] = cpp["std_dev_cpp"]
+
+        # 6) Formants
+        if formants:
+            fm = measure_f1f2_formants_bandwidths(
+                snd=sample,
+                floor=pitch_floor,
+                ceiling=pitch_ceiling,
+                frame_shift=time_step,
+            )
+            out["mean_f1_loc"] = fm["f1_mean"]
+            out["std_f1_loc"] = fm["f1_std"]
+            out["mean_b1_loc"] = fm["b1_mean"]
+            out["std_b1_loc"] = fm["b1_std"]
+            out["mean_f2_loc"] = fm["f2_mean"]
+            out["std_f2_loc"] = fm["f2_std"]
+            out["mean_b2_loc"] = fm["b2_mean"]
+            out["std_b2_loc"] = fm["b2_std"]
+
+        # 7) Spectral moments
+        if spectral_moments:
+            sm = extract_spectral_moments(
+                snd=sample,
+                floor=pitch_floor,
+                ceiling=pitch_ceiling,
                 window_size=window_length,
                 frame_shift=time_step,
             )
-        )
-    if slope_tilt:
-        wf.add(
-            extract_slope_tilt_pt(
-                name="extract_slope_tilt_pt",
-                snd=wf.lzin.x,
-                floor=wf._extract_pitch_floor_pt.lzout.out,
-                ceiling=wf._extract_pitch_ceiling_pt.lzout.out,
-            )
-        )
-    if cpp_descriptors:
-        wf.add(
-            extract_cpp_descriptors_pt(
-                name="extract_cpp_descriptors_pt",
-                snd=wf.lzin.x,
-                floor=wf._extract_pitch_floor_pt.lzout.out,
-                ceiling=wf._extract_pitch_ceiling_pt.lzout.out,
-                frame_shift=time_step,
-            )
-        )
-    if duration:
-        wf.add(extract_audio_duration_pt(name="extract_audio_duration_pt", snd=wf.lzin.x))
-    if jitter:
-        wf.add(
-            extract_jitter_pt(
-                name="extract_jitter_pt",
-                snd=wf.lzin.x,
-                floor=wf._extract_pitch_floor_pt.lzout.out,
-                ceiling=wf._extract_pitch_ceiling_pt.lzout.out,
-            )
-        )
-    if shimmer:
-        wf.add(
-            extract_shimmer_pt(
-                name="extract_shimmer_pt",
-                snd=wf.lzin.x,
-                floor=wf._extract_pitch_floor_pt.lzout.out,
-                ceiling=wf._extract_pitch_ceiling_pt.lzout.out,
-            )
-        )
+            out["spectral_gravity"] = sm["spectral_gravity"]
+            out["spectral_std_dev"] = sm["spectral_std_dev"]
+            out["spectral_skewness"] = sm["spectral_skewness"]
+            out["spectral_kurtosis"] = sm["spectral_kurtosis"]
 
-    # setting multiple workflow outputs
-    output_connections = [("pitch_values_out", wf.extract_pitch_values_pt.lzout.out)]
-    if speech_rate:
-        output_connections.append(("speech_rate_out", wf.extract_speech_rate_pt.lzout.out))
-    if pitch:
-        output_connections.append(("pitch_out", wf.extract_pitch_descriptors_pt.lzout.out))
-    if intensity_descriptors:
-        output_connections.append(("intensity_out", wf.extract_intensity_descriptors_pt.lzout.out))
-    if harmonicity_descriptors:
-        output_connections.append(("harmonicity_out", wf.extract_harmonicity_descriptors_pt.lzout.out))
-    if formants:
-        output_connections.append(("formants_out", wf.measure_f1f2_formants_bandwidths_pt.lzout.out))
-    if spectral_moments:
-        output_connections.append(("spectral_moments_out", wf.extract_spectral_moments_pt.lzout.out))
-    if slope_tilt:
-        output_connections.append(("slope_tilt_out", wf.extract_slope_tilt_pt.lzout.out))
-    if cpp_descriptors:
-        output_connections.append(("cpp_out", wf.extract_cpp_descriptors_pt.lzout.out))
-    if duration:
-        output_connections.append(("audio_duration", wf.extract_audio_duration_pt.lzout.out))
-    if jitter:
-        output_connections.append(("jitter_out", wf.extract_jitter_pt.lzout.out))
-    if shimmer:
-        output_connections.append(("shimmer_out", wf.extract_shimmer_pt.lzout.out))
-    wf.set_output(output_connections)
-
-    with pydra.Submitter(plugin=plugin, **plugin_args) as sub:
-        sub(wf)
-
-    outputs = wf.result()
-
-    extracted_data = []
-
-    for output in outputs:
-        feature_data = {}
-        # Audio duration
-        if duration:
-            feature_data["duration"] = output.output.audio_duration["duration"]
-        # Timing and Pausing
-        if speech_rate:
-            feature_data["speaking_rate"] = output.output.speech_rate_out["speaking_rate"]
-            feature_data["articulation_rate"] = output.output.speech_rate_out["articulation_rate"]
-            feature_data["phonation_ratio"] = output.output.speech_rate_out["phonation_ratio"]
-            feature_data["pause_rate"] = output.output.speech_rate_out["pause_rate"]
-            feature_data["mean_pause_duration"] = output.output.speech_rate_out["mean_pause_dur"]
-        # Pitch and Intensity:
-        if pitch:
-            feature_data[f"mean_f0_{pitch_unit.lower()}"] = output.output.pitch_out[f"mean_f0_{pitch_unit.lower()}"]
-            feature_data[f"std_f0_{pitch_unit.lower()}"] = output.output.pitch_out[f"stdev_f0_{pitch_unit.lower()}"]
-            feature_data["mean_intensity_db"] = output.output.intensity_out["mean_db"]
-            feature_data["std_intensity_db"] = output.output.intensity_out["std_db"]
-            feature_data["range_ratio_intensity_db"] = output.output.intensity_out["range_db_ratio"]
-            # feature_data["pitch_floor"] = output.output.pitch_values_out["pitch_floor"]
-            # feature_data["pitch_ceiling"] = output.output.pitch_values_out["pitch_ceiling"]
-        # Quality Features:
-        if harmonicity_descriptors:
-            feature_data["mean_hnr_db"] = output.output.harmonicity_out["hnr_db_mean"]
-            feature_data["std_hnr_db"] = output.output.harmonicity_out["hnr_db_std_dev"]
-            feature_data["spectral_slope"] = output.output.slope_tilt_out["spectral_slope"]
-            feature_data["spectral_tilt"] = output.output.slope_tilt_out["spectral_tilt"]
-            feature_data["cepstral_peak_prominence_mean"] = output.output.cpp_out["mean_cpp"]
-            feature_data["cepstral_peak_prominence_std"] = output.output.cpp_out["std_dev_cpp"]
-        # Formant (F1, F2):
-        if formants:
-            feature_data["mean_f1_loc"] = output.output.formants_out["f1_mean"]
-            feature_data["std_f1_loc"] = output.output.formants_out["f1_std"]
-            feature_data["mean_b1_loc"] = output.output.formants_out["b1_mean"]
-            feature_data["std_b1_loc"] = output.output.formants_out["b1_std"]
-            feature_data["mean_f2_loc"] = output.output.formants_out["f2_mean"]
-            feature_data["std_f2_loc"] = output.output.formants_out["f2_std"]
-            feature_data["mean_b2_loc"] = output.output.formants_out["b2_mean"]
-            feature_data["std_b2_loc"] = output.output.formants_out["b2_std"]
-        # Spectral Moments:
-        if spectral_moments:
-            feature_data["spectral_gravity"] = output.output.spectral_moments_out["spectral_gravity"]
-            feature_data["spectral_std_dev"] = output.output.spectral_moments_out["spectral_std_dev"]
-            feature_data["spectral_skewness"] = output.output.spectral_moments_out["spectral_skewness"]
-            feature_data["spectral_kurtosis"] = output.output.spectral_moments_out["spectral_kurtosis"]
-        # Jitter Descriptors:
+        # 8) Jitter / shimmer
         if jitter:
-            feature_data["local_jitter"] = output.output.jitter_out["local_jitter"]
-            feature_data["localabsolute_jitter"] = output.output.jitter_out["localabsolute_jitter"]
-            feature_data["rap_jitter"] = output.output.jitter_out["rap_jitter"]
-            feature_data["ppq5_jitter"] = output.output.jitter_out["ppq5_jitter"]
-            feature_data["ddp_jitter"] = output.output.jitter_out["ddp_jitter"]
-        # Shimmer Descriptors:
+            jit = extract_jitter(
+                snd=sample,
+                floor=pitch_floor,
+                ceiling=pitch_ceiling,
+            )
+            out["local_jitter"] = jit["local_jitter"]
+            out["localabsolute_jitter"] = jit["localabsolute_jitter"]
+            out["rap_jitter"] = jit["rap_jitter"]
+            out["ppq5_jitter"] = jit["ppq5_jitter"]
+            out["ddp_jitter"] = jit["ddp_jitter"]
+
         if shimmer:
-            feature_data["local_shimmer"] = output.output.shimmer_out["local_shimmer"]
-            feature_data["localDB_shimmer"] = output.output.shimmer_out["localDB_shimmer"]
-            feature_data["apq3_shimmer"] = output.output.shimmer_out["apq3_shimmer"]
-            feature_data["apq5_shimmer"] = output.output.shimmer_out["apq5_shimmer"]
-            feature_data["apq11_shimmer"] = output.output.shimmer_out["apq11_shimmer"]
-            feature_data["dda_shimmer"] = output.output.shimmer_out["dda_shimmer"]
+            shm = extract_shimmer(
+                snd=sample,
+                floor=pitch_floor,
+                ceiling=pitch_ceiling,
+            )
+            out["local_shimmer"] = shm["local_shimmer"]
+            out["localDB_shimmer"] = shm["localDB_shimmer"]
+            out["apq3_shimmer"] = shm["apq3_shimmer"]
+            out["apq5_shimmer"] = shm["apq5_shimmer"]
+            out["apq11_shimmer"] = shm["apq11_shimmer"]
+            out["dda_shimmer"] = shm["dda_shimmer"]
 
-        extracted_data.append(feature_data)
+        return out
 
-    return extracted_data
+    @workflow.define
+    def _wf(
+        xs: Sequence[Audio],
+        time_step: float,
+        window_length: float,
+        pitch_unit: str,
+        speech_rate: bool,
+        intensity_descriptors: bool,
+        harmonicity_descriptors: bool,
+        formants: bool,
+        spectral_moments: bool,
+        pitch: bool,
+        slope_tilt: bool,
+        cpp_descriptors: bool,
+        duration: bool,
+        jitter: bool,
+        shimmer: bool,
+    ) -> List[Dict[str, Any]]:
+        # Bind constants; split only over the audios
+        t = _extract_all_for_sample(
+            time_step=time_step,
+            window_length=window_length,
+            pitch_unit=pitch_unit,
+            speech_rate=speech_rate,
+            intensity_descriptors=intensity_descriptors,
+            harmonicity_descriptors=harmonicity_descriptors,
+            formants=formants,
+            spectral_moments=spectral_moments,
+            pitch=pitch,
+            slope_tilt=slope_tilt,
+            cpp_descriptors=cpp_descriptors,
+            duration=duration,
+            jitter=jitter,
+            shimmer=shimmer,
+        ).split(sample=xs)
+
+        node = workflow.add(t, name="map_praat_parselmouth_features")
+        return node.out
+
+    # Map legacy plugin names to compose workers
+    worker = "debug" if plugin in ("serial", "debug") else plugin
+    worker_kwargs = plugin_args or {}
+
+    wf = _wf(
+        xs=audios,
+        time_step=time_step,
+        window_length=window_length,
+        pitch_unit=pitch_unit,
+        speech_rate=speech_rate,
+        intensity_descriptors=intensity_descriptors,
+        harmonicity_descriptors=harmonicity_descriptors,
+        formants=formants,
+        spectral_moments=spectral_moments,
+        pitch=pitch,
+        slope_tilt=slope_tilt,
+        cpp_descriptors=cpp_descriptors,
+        duration=duration,
+        jitter=jitter,
+        shimmer=shimmer,
+    )
+    res: Any = wf(worker=worker, cache_root=cache_dir, **worker_kwargs)
+    return list(res.out)

--- a/src/senselab/audio/tasks/features_extraction/torchaudio.py
+++ b/src/senselab/audio/tasks/features_extraction/torchaudio.py
@@ -274,7 +274,6 @@ def extract_pitch_from_audios(
     return pitches
 
 
-
 def extract_torchaudio_features_from_audios(
     audios: List[Audio],
     freq_low: int = 80,
@@ -289,29 +288,29 @@ def extract_torchaudio_features_from_audios(
     cache_dir: Optional[str | os.PathLike] = None,
 ) -> List[Dict[str, Any]]:
     """Extract torchaudio features from a list of audio objects using pydra.compose.
-    
+
     Args:
     audios (List[Audio]): List of Audio objects.
-    freq_low (int): Lowest detectable frequency (Hz). Must be > 0. 
+    freq_low (int): Lowest detectable frequency (Hz). Must be > 0.
         Default is 80.
-    freq_high (int): Highest detectable frequency (Hz). 
+    freq_high (int): Highest detectable frequency (Hz).
         Default is 500.
-    n_fft (int): Size of FFT; creates n_fft // 2 + 1 bins. 
+    n_fft (int): Size of FFT; creates n_fft // 2 + 1 bins.
         Default is 1024.
     n_mels (int): Number of mel filter banks. Default is 128.
     n_mfcc (int): Number of MFCC coefficients. Default is 40.
-    win_length (Optional[int]): Window size. If None, uses n_fft. 
+    win_length (Optional[int]): Window size. If None, uses n_fft.
         Default is None.
-    hop_length (Optional[int]): Hop length between STFT windows. If None, uses win_length // 2. 
+    hop_length (Optional[int]): Hop length between STFT windows. If None, uses win_length // 2.
         Default is None.
-    plugin (str): Pydra plugin to use. 
+    plugin (str): Pydra plugin to use.
         Default is "debug".
-    plugin_args (Optional[Dict[str, Any]]): Additional plugin arguments. 
+    plugin_args (Optional[Dict[str, Any]]): Additional plugin arguments.
         Default is None.
-    cache_dir (Optional[str | os.PathLike]): Directory for intermediate/cache files. 
+    cache_dir (Optional[str | os.PathLike]): Directory for intermediate/cache files.
         Default is None.
 
-    
+
     Returns:
     - List[Dict[str, Any]]: List of Dict objects containing features.
 
@@ -386,7 +385,7 @@ def extract_torchaudio_features_from_audios(
                 "mel_filter_bank": np.nan,
                 "mfcc": np.nan,
                 "mel_spectrogram": np.nan,
-                "spectrogram": np.nan, 
+                "spectrogram": np.nan,
             }
 
     # Map-style workflow over the list of audios

--- a/src/senselab/audio/tasks/features_extraction/torchaudio.py
+++ b/src/senselab/audio/tasks/features_extraction/torchaudio.py
@@ -1,11 +1,11 @@
 """This module provides the implementation of torchaudio utilities for audio features extraction."""
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 import numpy as np
-import pydra
 import torch
+from pydra.compose import python, workflow
 
 try:
     import torchaudio
@@ -274,6 +274,7 @@ def extract_pitch_from_audios(
     return pitches
 
 
+
 def extract_torchaudio_features_from_audios(
     audios: List[Audio],
     freq_low: int = 80,
@@ -283,117 +284,148 @@ def extract_torchaudio_features_from_audios(
     n_mfcc: int = 40,
     win_length: Optional[int] = None,
     hop_length: Optional[int] = None,
-    plugin: str = "serial",
-    plugin_args: Optional[Dict[str, Any]] = {},
+    plugin: str = "debug",
+    plugin_args: Optional[Dict[str, Any]] = None,
     cache_dir: Optional[str | os.PathLike] = None,
 ) -> List[Dict[str, Any]]:
-    """Extract torchaudio features from a list of audio objects.
-
+    """Extract torchaudio features from a list of audio objects using pydra.compose.
+    
     Args:
-        audios (List[Audio]): The list of audio objects to extract features from.
-        freq_low (int): Lowest frequency that can be detected (Hz). Should be bigger than 0.
-            (Default is 80).
-        freq_high (int): Highest frequency that can be detected (Hz).
-            (Default is 500).
-        n_fft (int): Size of FFT, creates n_fft // 2 + 1 bins. Default is 1024.
-        n_mels (int): Number of mel filter banks. Default is 128.
-        n_mfcc (int): Number of MFCCs. Default is 40.
-        win_length (int): Window size. Default is None, using n_fft.
-        hop_length (int): Length of hop between STFT windows. Default is None, using win_length // 2.
-        plugin (str): The plugin to use. Default is "serial".
-        plugin_args (Optional[Dict[str, Any]]): The arguments to pass to the plugin. Default is {}.
-        cache_dir (Optional[str | os.PathLike]): The directory to cache the results. Default is None.
+    audios (List[Audio]): List of Audio objects.
+    freq_low (int): Lowest detectable frequency (Hz). Must be > 0. 
+        Default is 80.
+    freq_high (int): Highest detectable frequency (Hz). 
+        Default is 500.
+    n_fft (int): Size of FFT; creates n_fft // 2 + 1 bins. 
+        Default is 1024.
+    n_mels (int): Number of mel filter banks. Default is 128.
+    n_mfcc (int): Number of MFCC coefficients. Default is 40.
+    win_length (Optional[int]): Window size. If None, uses n_fft. 
+        Default is None.
+    hop_length (Optional[int]): Hop length between STFT windows. If None, uses win_length // 2. 
+        Default is None.
+    plugin (str): Pydra plugin to use. 
+        Default is "debug".
+    plugin_args (Optional[Dict[str, Any]]): Additional plugin arguments. 
+        Default is None.
+    cache_dir (Optional[str | os.PathLike]): Directory for intermediate/cache files. 
+        Default is None.
 
+    
     Returns:
-        List[Dict[str, Any]]: The list of feature dictionaries for each audio.
+    - List[Dict[str, Any]]: List of Dict objects containing features.
+
+    Raises:
+    - ModuleNotFoundError: If `torchaudio` is not installed.
     """
-    extract_pitch_from_audios_pt = pydra.mark.task(extract_pitch_from_audios)
-    extract_mel_filter_bank_from_spectrograms_pt = pydra.mark.task(extract_mel_filter_bank_from_spectrograms)
-    extract_mfcc_from_audios_pt = pydra.mark.task(extract_mfcc_from_audios)
-    extract_mel_spectrogram_from_audios_pt = pydra.mark.task(extract_mel_spectrogram_from_audios)
-    extract_spectrogram_from_audios_pt = pydra.mark.task(extract_spectrogram_from_audios)
-
-    def _extract_sampling_rate(audios: List[Audio]) -> int:
-        """Extract the sampling rate from an Audio object."""
-        return audios[0].sampling_rate
-
-    _extract_sampling_rate_pt = pydra.mark.task(_extract_sampling_rate)
-
-    formatted_audios = [[audio] for audio in audios]
-    wf = pydra.Workflow(name="wf", input_spec=["x"], cache_dir=cache_dir)
-    wf.split("x", x=formatted_audios)
-    wf.add(_extract_sampling_rate_pt(name="_extract_sampling_rate_pt", audios=wf.lzin.x))
-    wf.add(
-        extract_pitch_from_audios_pt(
-            name="extract_pitch_from_audios_pt", audios=wf.lzin.x, freq_low=freq_low, freq_high=freq_high
+    if not TORCHAUDIO_AVAILABLE:
+        raise ModuleNotFoundError(
+            "`torchaudio` is not installed. "
+            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
         )
-    )
-    wf.add(
-        extract_spectrogram_from_audios_pt(
-            name="extract_spectrogram_from_audios_pt",
-            audios=wf.lzin.x,
+
+    # Per-sample task: compute all features for a single Audio
+    @python.define
+    def _extract_all(
+        sample: Audio,
+        freq_low: int,
+        freq_high: int,
+        n_fft: int,
+        n_mels: int,
+        n_mfcc: int,
+        win_length: Optional[int],
+        hop_length: Optional[int],
+    ) -> Dict[str, Any]:
+        # Defaults (match your helper behavior)
+        wl = n_fft if win_length is None else win_length
+        hl = wl // 2 if hop_length is None else hop_length
+        sr = sample.sampling_rate
+
+        try:
+            # Spectrogram
+            spec = torchaudio.transforms.Spectrogram(n_fft=n_fft, win_length=wl, hop_length=hl)(sample.waveform)
+            spec = spec.squeeze(0)
+
+            # Mel-spectrogram
+            melspec = torchaudio.transforms.MelSpectrogram(
+                sample_rate=sr, n_fft=n_fft, win_length=wl, hop_length=hl, n_mels=n_mels
+            )(sample.waveform)
+            melspec = melspec.squeeze(0)
+
+            # MFCC
+            mfcc = torchaudio.transforms.MFCC(
+                sample_rate=sr,
+                n_mfcc=n_mfcc,
+                melkwargs={"n_fft": n_fft, "win_length": wl, "hop_length": hl, "n_mels": n_mels},
+            )(sample.waveform)
+            mfcc = mfcc.squeeze(0)
+
+            # Mel filter bank from the spectrogram
+            n_stft = n_fft // 2 + 1
+            melfb = torchaudio.transforms.MelScale(sample_rate=sr, n_mels=n_mels, n_stft=n_stft)(spec)
+            melfb = melfb.squeeze(0)
+
+            # Pitch
+            if freq_low <= 0:
+                raise ValueError("freq_low should be bigger than 0")
+            pitch = torchaudio.functional.detect_pitch_frequency(
+                sample.waveform, sample_rate=sr, freq_low=freq_low, freq_high=freq_high
+            ).squeeze(0)
+
+            return {
+                "pitch": pitch,
+                "mel_filter_bank": melfb,
+                "mfcc": mfcc,
+                "mel_spectrogram": melspec,
+                "spectrogram": spec,
+            }
+        except RuntimeError:
+            # Return NaNs with the right keys if torchaudio blows up
+            return {
+                "pitch": torch.tensor(torch.nan),
+                "mel_filter_bank": np.nan,
+                "mfcc": np.nan,
+                "mel_spectrogram": np.nan,
+                "spectrogram": np.nan, 
+            }
+
+    # Map-style workflow over the list of audios
+    @workflow.define
+    def _wf(
+        xs: Sequence[Audio],
+        freq_low: int,
+        freq_high: int,
+        n_fft: int,
+        n_mels: int,
+        n_mfcc: int,
+        win_length: Optional[int],
+        hop_length: Optional[int],
+    ) -> List[Dict[str, Any]]:
+        task = _extract_all(
+            freq_low=freq_low,
+            freq_high=freq_high,
             n_fft=n_fft,
-            win_length=win_length,
-            hop_length=hop_length,
-        )
-    )
-    wf.add(
-        extract_mel_spectrogram_from_audios_pt(
-            name="extract_mel_spectrogram_from_audios_pt",
-            audios=wf.lzin.x,
             n_mels=n_mels,
-            n_fft=n_fft,
-            win_length=win_length,
-            hop_length=hop_length,
-        )
-    )
-    wf.add(
-        extract_mel_filter_bank_from_spectrograms_pt(
-            name="extract_mel_filter_bank_from_spectrograms_pt",
-            spectrograms=wf.extract_spectrogram_from_audios_pt.lzout.out,
-            sampling_rate=wf._extract_sampling_rate_pt.lzout.out,
-            n_mels=n_mels,
-            n_fft=n_fft,
-        )
-    )
-    wf.add(
-        extract_mfcc_from_audios_pt(
-            name="extract_mfcc_from_audios_pt",
-            audios=wf.lzin.x,
             n_mfcc=n_mfcc,
-            n_fft=n_fft,
-            n_mels=n_mels,
             win_length=win_length,
             hop_length=hop_length,
-        )
+        ).split(sample=xs)
+        node = workflow.add(task, name="map_torchaudio_feats")
+        return node.out
+
+    # Map legacy plugin to compose worker
+    worker = "debug" if plugin in ("serial", "debug") else plugin
+    worker_kwargs = plugin_args or {}
+
+    wf = _wf(
+        xs=audios,
+        freq_low=freq_low,
+        freq_high=freq_high,
+        n_fft=n_fft,
+        n_mels=n_mels,
+        n_mfcc=n_mfcc,
+        win_length=win_length,
+        hop_length=hop_length,
     )
-
-    # setting multiple workflow outputs
-    wf.set_output(
-        [
-            ("pitch_out", wf.extract_pitch_from_audios_pt.lzout.out),
-            ("mel_filter_bank_out", wf.extract_mel_filter_bank_from_spectrograms_pt.lzout.out),
-            ("mfcc_out", wf.extract_mfcc_from_audios_pt.lzout.out),
-            ("mel_spectrogram_out", wf.extract_mel_spectrogram_from_audios_pt.lzout.out),
-            ("spectrogram_out", wf.extract_spectrogram_from_audios_pt.lzout.out),
-        ]
-    )
-
-    with pydra.Submitter(plugin=plugin, **plugin_args) as sub:
-        sub(wf)
-
-    outputs = wf.result()
-
-    formatted_output: List[Dict[str, Any]] = []
-    for output in outputs:
-        formatted_output_item = {
-            "pitch": output.output.pitch_out[0]["pitch"],
-            "mel_filter_bank": output.output.mel_filter_bank_out[0]["mel_filter_bank"],
-            "mfcc": output.output.mfcc_out[0]["mfcc"],
-            "mel_spectrogram": output.output.mel_spectrogram_out[0]["mel_spectrogram"],
-            "spectrogram": output.output.spectrogram_out[0]["spectrogram"],
-        }
-
-        formatted_output.append(formatted_output_item)
-
-    return formatted_output
+    res: Any = wf(worker=worker, cache_root=cache_dir, **worker_kwargs)
+    return list(res.out)

--- a/src/senselab/audio/tasks/input_output/utils.py
+++ b/src/senselab/audio/tasks/input_output/utils.py
@@ -15,7 +15,7 @@ def read_audios(
     plugin_args: Optional[Dict[str, Any]] = None,
 ) -> List[Audio]:
     """Read and wrap a list of audio files as `Audio` objects via a Pydra workflow.
-    
+
     Args:
         file_paths: A list of audio file paths.
         cache_dir: The directory to use for caching the workflow. Default is None.
@@ -52,7 +52,7 @@ def save_audios(
     plugin_args: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Save a sequence of `(Audio, output_path)` pairs via a Pydra workflow.
-    
+
     Args:
         audio_tuples: A sequence of `(Audio, output_path)` pairs.
         save_params: A dictionary of parameters to pass to `Audio.save_to_file`.

--- a/src/senselab/audio/tasks/input_output/utils.py
+++ b/src/senselab/audio/tasks/input_output/utils.py
@@ -3,7 +3,7 @@
 import os
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
-import pydra
+from pydra.compose import python, workflow
 
 from senselab.audio.data_structures import Audio
 
@@ -11,109 +11,75 @@ from senselab.audio.data_structures import Audio
 def read_audios(
     file_paths: List[str | os.PathLike],
     cache_dir: Optional[Union[str, os.PathLike]] = None,
-    plugin: str = "serial",
-    plugin_args: Dict[str, Any] = {},
+    plugin: str = "debug",
+    plugin_args: Optional[Dict[str, Any]] = None,
 ) -> List[Audio]:
-    """Read and process a list of audio files using Pydra workflow.
-
+    """Read and wrap a list of audio files as `Audio` objects via a Pydra workflow.
+    
     Args:
-        file_paths (List[str]): List of paths to audio files.
-        cache_dir (str, optional): Directory for caching intermediate results. Defaults to None.
-        plugin (str, optional): Pydra plugin to use for workflow submission. Defaults to "serial".
-        plugin_args (dict, optional): Additional arguments for the Pydra plugin. Defaults to {}.
+        file_paths: A list of audio file paths.
+        cache_dir: The directory to use for caching the workflow. Default is None.
+        plugin: The Pydra plugin to use for workflow submission. Default is "debug".
+        plugin_args: Additional arguments to pass to the plugin. Default is None.
 
     Returns:
-        List[Audio]: A list of Audio objects containing the waveform and sample rate for each processed file.
+        A list of `Audio` objects.
     """
+    plugin_args = plugin_args or {}
 
-    @pydra.mark.task
-    def load_audio_file(file_path: str | os.PathLike) -> Any:  # noqa: ANN401
-        """Load an audio file and return an Audio object.
+    @python.define
+    def _load_audio_file(path: str | os.PathLike) -> Audio:
+        return Audio(filepath=path)
 
-        Args:
-            file_path (str): Path to the audio file.
+    @workflow.define
+    def _wf(xs: Sequence[str | os.PathLike]) -> List[Audio]:
+        node = workflow.add(
+            _load_audio_file().split(path=xs),
+            name="map_read_audio",
+        )
+        return node.out
 
-        Returns:
-            Audio: An instance of the Audio class containing the waveform and sample rate.
-        """
-        return Audio(filepath=file_path)
-
-    # Create the workflow
-    wf = pydra.Workflow(name="read_audio_files_workflow", input_spec=["x"], cache_dir=cache_dir)
-    wf.split("x", x=file_paths)
-    wf.add(load_audio_file(name="load_audio_file", file_path=wf.lzin.x))
-    wf.set_output([("processed_files", wf.load_audio_file.lzout.out)])
-
-    # Run the workflow
-    with pydra.Submitter(plugin=plugin, **plugin_args) as sub:
-        sub(wf)
-
-    # Collect and return the results
-    outputs = wf.result()
-    return [output.output.processed_files for output in outputs]
+    worker = "debug" if plugin in ("serial", "debug") else plugin
+    res = _wf(xs=file_paths)(worker=worker, cache_root=cache_dir, **plugin_args)
+    return list(res.out)
 
 
 def save_audios(
     audio_tuples: Sequence[Tuple[Audio, Union[str, os.PathLike]]],
-    save_params: Dict[str, Any] = {},
+    save_params: Optional[Dict[str, Any]] = None,
     cache_dir: Optional[Union[str, os.PathLike]] = None,
-    plugin: str = "serial",
-    plugin_args: Dict[str, Any] = {},
+    plugin: str = "debug",
+    plugin_args: Optional[Dict[str, Any]] = None,
 ) -> None:
-    """Save a list of Audio objects to specified files using Pydra workflow.
-
+    """Save a sequence of `(Audio, output_path)` pairs via a Pydra workflow.
+    
     Args:
-        audio_tuples (Sequence[Tuple[Audio, Union[str, os.PathLike]]): Sequence of tuples where each tuple contains
-            an Audio object, its output path (str or os.PathLike).
-        save_params (dict, optional): Additional parameters for saving audio files.
-            Defaults to {}
-        cache_dir (str, optional): Directory for caching intermediate results.
-            Defaults to None.
-        plugin (str, optional): Pydra plugin to use for workflow submission.
-            Defaults to "serial".
-        plugin_args (dict, optional): Additional arguments for the Pydra plugin.
-            Defaults to {}.
+        audio_tuples: A sequence of `(Audio, output_path)` pairs.
+        save_params: A dictionary of parameters to pass to `Audio.save_to_file`.
+        cache_dir: The directory to use for caching the workflow. Default is None.
+        plugin: The Pydra plugin to use for workflow submission. Default is "serial".
+        plugin_args: Additional arguments to pass to the plugin. Default is None.
 
-    Raises:
-        RuntimeError: If any output directory in the provided paths does not exist or is not writable.
+    Returns:
+        None
     """
+    save_params = save_params or {}
+    plugin_args = plugin_args or {}
 
-    @pydra.mark.task
-    def _extract_audio(audio_tuple: Tuple[Audio, Union[str, os.PathLike]]) -> Any:  # noqa: ANN401
-        """Extract the Audio object from the tuple."""
-        return audio_tuple[0]
+    @python.define
+    def _save_pair(pair: Tuple[Audio, Union[str, os.PathLike]], params: Dict[str, Any]) -> str:
+        audio, out_path = pair
+        audio.save_to_file(os.fspath(out_path), **params)
+        return os.fspath(out_path)
 
-    @pydra.mark.task
-    def _extract_output_path(audio_tuple: Tuple[Audio, Union[str, os.PathLike]]) -> Union[str, os.PathLike]:
-        """Extract the output path from the tuple."""
-        return audio_tuple[1]
-
-    @pydra.mark.task
-    def _save_audio(audio: Audio, file_path: str, save_params: Dict[str, Any]) -> None:
-        """Save an Audio object to a file.
-
-        Args:
-            audio (Audio): The Audio object to save.
-            file_path (str): Path to save the audio file.
-            save_params (dict): Additional parameters for saving audio files.
-        """
-        audio.save_to_file(file_path, **save_params)
-
-    # Create the workflow
-    wf = pydra.Workflow(name="save_audio_files_workflow", input_spec=["audio_tuples"], cache_dir=cache_dir)
-    wf.split("audio_tuples", audio_tuples=audio_tuples)
-    wf.add(_extract_audio(name="_extract_audio", audio_tuple=wf.lzin.audio_tuples))
-    wf.add(_extract_output_path(name="_extract_output_path", audio_tuple=wf.lzin.audio_tuples))
-    wf.add(
-        _save_audio(
-            name="_save_audio",
-            audio=wf._extract_audio.lzout.out,
-            file_path=wf._extract_output_path.lzout.out,
-            save_params=save_params,
+    @workflow.define
+    def _wf(pairs: Sequence[Tuple[Audio, Union[str, os.PathLike]]], params: Dict[str, Any]) -> List[str]:
+        node = workflow.add(
+            _save_pair(params=params).split(pair=pairs),
+            name="map_save_audio",
         )
-    )
-    wf.set_output([])
+        return node.out  # list of saved file paths
 
-    # Run the workflow
-    with pydra.Submitter(plugin=plugin, **plugin_args) as sub:
-        sub(wf)
+    worker = "debug" if plugin in ("serial", "debug") else plugin
+    # Execute and ignore returned paths to keep the original None-returning API
+    _ = _wf(pairs=audio_tuples, params=save_params)(worker=worker, cache_root=cache_dir, **plugin_args)

--- a/src/senselab/audio/tasks/speech_to_text/huggingface.py
+++ b/src/senselab/audio/tasks/speech_to_text/huggingface.py
@@ -54,15 +54,16 @@ class HuggingFaceASR:
             cls._pipelines[key] = cast(
                 Pipeline,
                 pipeline(  # type: ignore[call-overload]
-                task="automatic-speech-recognition",
-                model=model.path_or_uri,
-                revision=model.revision,
-                return_timestamps=return_timestamps,
-                max_new_tokens=max_new_tokens,
-                chunk_length_s=chunk_length_s,
-                batch_size=batch_size,
-                device=device.value,
-            ))
+                    task="automatic-speech-recognition",
+                    model=model.path_or_uri,
+                    revision=model.revision,
+                    return_timestamps=return_timestamps,
+                    max_new_tokens=max_new_tokens,
+                    chunk_length_s=chunk_length_s,
+                    batch_size=batch_size,
+                    device=device.value,
+                ),
+            )
         return cls._pipelines[key]
 
     @classmethod
@@ -136,7 +137,7 @@ class HuggingFaceASR:
             batch_size=batch_size,
             device=device,
         )
-        
+
         # Take the end time of the pipeline initialization
         end_time_pipeline = time.time()
         # Print the time taken for initialize the hugging face ASR pipeline
@@ -146,7 +147,7 @@ class HuggingFaceASR:
         feature_extractor = getattr(pipe, "feature_extractor", None)
         if feature_extractor is None:
             raise ValueError("Internal error: The Hugging Face pipeline does not have a feature extractor.")
-        
+
         # Retrieve the expected sampling rate from the Hugging Face model
         expected_sampling_rate = cast(int, getattr(feature_extractor, "sampling_rate", None))
         if expected_sampling_rate is None:

--- a/src/senselab/audio/tasks/speech_to_text/huggingface.py
+++ b/src/senselab/audio/tasks/speech_to_text/huggingface.py
@@ -6,9 +6,9 @@ function at once, rather than calling the function with one audio at a time.
 """
 
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
-from transformers import pipeline
+from transformers import Pipeline, pipeline
 
 from senselab.audio.data_structures import Audio
 from senselab.utils.data_structures import DeviceType, HFModel, Language, ScriptLine, _select_device_and_dtype
@@ -18,7 +18,7 @@ from senselab.utils.data_structures.logging import logger
 class HuggingFaceASR:
     """A factory for managing Hugging Face ASR pipelines."""
 
-    _pipelines: Dict[str, pipeline] = {}
+    _pipelines: Dict[str, Pipeline] = {}
 
     @classmethod
     def _get_hf_asr_pipeline(
@@ -29,7 +29,7 @@ class HuggingFaceASR:
         chunk_length_s: int,
         batch_size: int,
         device: Optional[DeviceType] = None,
-    ) -> pipeline:
+    ) -> Pipeline:
         """Get or create a Hugging Face ASR pipeline.
 
         Args:
@@ -41,7 +41,7 @@ class HuggingFaceASR:
             device (Optional[DeviceType]): The device to run the model on.
 
         Returns:
-            pipeline: The ASR pipeline.
+            Pipeline: The ASR pipeline.
         """
         device, _ = _select_device_and_dtype(
             user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]
@@ -51,8 +51,10 @@ class HuggingFaceASR:
             f"{max_new_tokens}-{chunk_length_s}-{batch_size}-{device.value}"
         )
         if key not in cls._pipelines:
-            cls._pipelines[key] = pipeline(
-                "automatic-speech-recognition",
+            cls._pipelines[key] = cast(
+                Pipeline,
+                pipeline(  # type: ignore[call-overload]
+                task="automatic-speech-recognition",
                 model=model.path_or_uri,
                 revision=model.revision,
                 return_timestamps=return_timestamps,
@@ -60,7 +62,7 @@ class HuggingFaceASR:
                 chunk_length_s=chunk_length_s,
                 batch_size=batch_size,
                 device=device.value,
-            )
+            ))
         return cls._pipelines[key]
 
     @classmethod
@@ -134,15 +136,21 @@ class HuggingFaceASR:
             batch_size=batch_size,
             device=device,
         )
-
+        
         # Take the end time of the pipeline initialization
         end_time_pipeline = time.time()
         # Print the time taken for initialize the hugging face ASR pipeline
         elapsed_time_pipeline = end_time_pipeline - start_time_pipeline
         logger.info(f"Time taken to initialize the hugging face ASR pipeline: {elapsed_time_pipeline:.2f} seconds")
 
+        feature_extractor = getattr(pipe, "feature_extractor", None)
+        if feature_extractor is None:
+            raise ValueError("Internal error: The Hugging Face pipeline does not have a feature extractor.")
+        
         # Retrieve the expected sampling rate from the Hugging Face model
-        expected_sampling_rate = pipe.feature_extractor.sampling_rate
+        expected_sampling_rate = cast(int, getattr(feature_extractor, "sampling_rate", None))
+        if expected_sampling_rate is None:
+            raise ValueError("Internal error: The Hugging Face model does not specify an expected sampling rate.")
 
         # Check that all audio objects are mono
         for audio in audios:
@@ -174,4 +182,4 @@ class HuggingFaceASR:
         transcriptions = _rename_key_recursive(transcriptions, "timestamp", "timestamps")
 
         # Convert the pipeline output to ScriptLine objects
-        return [ScriptLine.from_dict(t) for t in transcriptions]
+        return [ScriptLine.from_dict(cast(Dict[str, Any], t)) for t in transcriptions]

--- a/src/senselab/audio/tasks/ssl_embeddings/self_supervised_features.py
+++ b/src/senselab/audio/tasks/ssl_embeddings/self_supervised_features.py
@@ -108,16 +108,16 @@ class SSLEmbeddingsFactory:
         # Pre-process audio using the SSL mode feature extractor
         preprocessed_audios = [
             feat_extractor(  # type: ignore[operator]
-                audio.waveform, 
-                sampling_rate=sampling_rate, 
-                return_tensors="pt") for audio in audios
+                audio.waveform, sampling_rate=sampling_rate, return_tensors="pt"
+            )
+            for audio in audios
         ]
 
         # Extract embeddings (hidden states from all layers) from pre-trained model
         embeddings = [
             ssl_model(  # type: ignore[operator]
-                audio.input_values.squeeze(0).to(device.value), 
-                output_hidden_states=True)
+                audio.input_values.squeeze(0).to(device.value), output_hidden_states=True
+            )
             for audio in preprocessed_audios
         ]
         embeddings = [torch.cat(embedding.hidden_states) for embedding in embeddings]

--- a/src/senselab/audio/tasks/ssl_embeddings/self_supervised_features.py
+++ b/src/senselab/audio/tasks/ssl_embeddings/self_supervised_features.py
@@ -88,7 +88,13 @@ class SSLEmbeddingsFactory:
         )
         # Load feature extractor and model
         feat_extractor = cls._get_feature_extractor(model=model, cache_dir=cache_dir)
-        sampling_rate = feat_extractor.sampling_rate
+        sr = getattr(feat_extractor, "sampling_rate", None)
+        if not isinstance(sr, int):
+            raise AttributeError(
+                "The feature extractor doesn't expose an integer `sampling_rate`. "
+                "Please use a model with a known sampling rate."
+            )
+        sampling_rate: int = sr
         ssl_model = cls._load_model(model=model, cache_dir=cache_dir, device=device)
 
         # Check that all audio objects have the correct sampling rate
@@ -101,12 +107,17 @@ class SSLEmbeddingsFactory:
                 )
         # Pre-process audio using the SSL mode feature extractor
         preprocessed_audios = [
-            feat_extractor(audio.waveform, sampling_rate=sampling_rate, return_tensors="pt") for audio in audios
+            feat_extractor(  # type: ignore[operator]
+                audio.waveform, 
+                sampling_rate=sampling_rate, 
+                return_tensors="pt") for audio in audios
         ]
 
         # Extract embeddings (hidden states from all layers) from pre-trained model
         embeddings = [
-            ssl_model(audio.input_values.squeeze(0).to(device.value), output_hidden_states=True)
+            ssl_model(  # type: ignore[operator]
+                audio.input_values.squeeze(0).to(device.value), 
+                output_hidden_states=True)
             for audio in preprocessed_audios
         ]
         embeddings = [torch.cat(embedding.hidden_states) for embedding in embeddings]

--- a/src/senselab/audio/tasks/text_to_speech/huggingface.py
+++ b/src/senselab/audio/tasks/text_to_speech/huggingface.py
@@ -36,11 +36,12 @@ class HuggingFaceTTS:
             cls._pipelines[key] = cast(
                 Pipeline,
                 pipeline(  # type: ignore[call-overload]
-                task="text-to-speech",
-                model=model.path_or_uri,
-                revision=model.revision,
-                device=device.value,
-            ))
+                    task="text-to-speech",
+                    model=model.path_or_uri,
+                    revision=model.revision,
+                    device=device.value,
+                ),
+            )
         return cls._pipelines[key]
 
     @classmethod

--- a/src/senselab/audio/workflows/health_measurements/extract_health_measurements.py
+++ b/src/senselab/audio/workflows/health_measurements/extract_health_measurements.py
@@ -12,13 +12,13 @@ from senselab.audio.tasks.features_extraction.praat_parselmouth import extract_p
 
 
 def extract_health_measurements(
-    audios: List[Audio], plugin: str = "serial", plugin_args: Dict[str, Any] = {}, cache_dir: Optional[str] = None
+    audios: List[Audio], plugin: str = "debug", plugin_args: Dict[str, Any] = {}, cache_dir: Optional[str] = None
 ) -> List[Dict[str, Any]]:
     """Extract health measurements from audio files.
 
     Args:
         audios (List[Audio]): List of Audio objects.
-        plugin (str): Plugin to use for feature extraction. Defaults to "serial".
+        plugin (str): Plugin to use for feature extraction. Defaults to "debug".
         plugin_args (Dict[str, Any]): Dictionary of arguments for the feature extraction plugin.
         cache_dir (Optional[str]): Directory to use for caching by pydra. Defaults to None.
 

--- a/src/senselab/text/tasks/embeddings_extraction/huggingface.py
+++ b/src/senselab/text/tasks/embeddings_extraction/huggingface.py
@@ -4,6 +4,8 @@ from typing import Dict, List, Optional
 
 import torch
 from transformers import AutoModel, AutoTokenizer
+from transformers.modeling_utils import PreTrainedModel
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from senselab.utils.data_structures import DeviceType, HFModel, _select_device_and_dtype
 
@@ -11,21 +13,21 @@ from senselab.utils.data_structures import DeviceType, HFModel, _select_device_a
 class HFFactory:
     """A factory for managing self-supervised models from Hugging Face."""
 
-    _tokenizers: Dict[str, AutoTokenizer] = {}
-    _models: Dict[str, AutoModel] = {}
+    _tokenizers: Dict[str, PreTrainedTokenizerBase] = {}
+    _models: Dict[str, PreTrainedModel] = {}
 
     @classmethod
     def _get_tokenizer(
         cls,
         model: HFModel,
-    ) -> AutoTokenizer:
+    ) -> PreTrainedTokenizerBase:
         """Get or create a tokenizer for SSL model.
 
         Args:
             model (HFModel): The HuggingFace model.
 
         Returns:
-            AutoTokenizer: The tokenizer for the model.
+            PreTrainedTokenizerBase: The tokenizer for the model.
         """
         key = f"{model.path_or_uri}-{model.revision}"
         if key not in cls._tokenizers:
@@ -40,7 +42,7 @@ class HFFactory:
         cls,
         model: HFModel,
         device: DeviceType,
-    ) -> AutoModel:
+    ) -> PreTrainedModel:
         """Load weights of SSL model.
 
         Args:
@@ -48,7 +50,7 @@ class HFFactory:
             device (DeviceType): The device to run the model on.
 
         Returns:
-            AutoModel: The SSL model.
+            PreTrainedModel: The SSL model.
         """
         key = f"{model.path_or_uri}-{model.revision}-{device.value}"
         if key not in cls._models:

--- a/src/senselab/utils/data_structures/pydra_helpers.py
+++ b/src/senselab/utils/data_structures/pydra_helpers.py
@@ -17,6 +17,7 @@ try:
 except ModuleNotFoundError:
     OPENSMILE_AVAILABLE = False
 
+
 @register_serializer(torch.Tensor)
 def bytes_repr_arraylike(obj: torch.Tensor, cache: Cache) -> Iterator[bytes]:
     """Register a serializer for Torch tensors that allows Pydra to properly use them."""
@@ -27,6 +28,7 @@ def bytes_repr_arraylike(obj: torch.Tensor, cache: Cache) -> Iterator[bytes]:
         yield from bytes_repr_sequence_contents(iter(array.ravel()), cache)
     else:
         yield array.tobytes(order="C")
+
 
 @register_serializer(Audio)
 def bytes_repr_audio(obj: Audio, cache: Cache) -> Iterator[bytes]:
@@ -74,7 +76,6 @@ def bytes_repr_audio(obj: Audio, cache: Cache) -> Iterator[bytes]:
         md = "{}"
     yield b"md:"
     yield md.encode()
-
 
 
 if OPENSMILE_AVAILABLE:

--- a/src/senselab/utils/data_structures/pydra_helpers.py
+++ b/src/senselab/utils/data_structures/pydra_helpers.py
@@ -1,10 +1,14 @@
 """Functionality for Pydra."""
 
+import json
+import os
 from typing import Iterator
 
 import numpy as np
 import torch
 from pydra.utils.hash import Cache, bytes_repr_sequence_contents, register_serializer
+
+from senselab.audio.data_structures.audio import Audio
 
 try:
     import opensmile
@@ -12,7 +16,6 @@ try:
     OPENSMILE_AVAILABLE = True
 except ModuleNotFoundError:
     OPENSMILE_AVAILABLE = False
-
 
 @register_serializer(torch.Tensor)
 def bytes_repr_arraylike(obj: torch.Tensor, cache: Cache) -> Iterator[bytes]:
@@ -24,6 +27,54 @@ def bytes_repr_arraylike(obj: torch.Tensor, cache: Cache) -> Iterator[bytes]:
         yield from bytes_repr_sequence_contents(iter(array.ravel()), cache)
     else:
         yield array.tobytes(order="C")
+
+@register_serializer(Audio)
+def bytes_repr_audio(obj: Audio, cache: Cache) -> Iterator[bytes]:
+    """Stable hashing for senselab.Audio.
+
+    This is needed since Audio is a lazy-loaded object.
+
+    - File-backed: DO NOT depend on any fields that may be filled during lazy load
+      (e.g., sampling_rate). Only use filepath, file stat, loader params, metadata.
+    - Waveform-backed: hash waveform tensor bytes + sampling_rate + metadata.
+    """
+    yield b"Audio:"
+
+    fp = obj.filepath()
+    if fp:
+        # File-backed: avoid touching lazy-loaded fields entirely.
+        p = os.fspath(fp)
+        yield f"fp:{p}:".encode()
+
+        try:
+            st = os.stat(p)
+            # include mtime_ns + size for strong identity without content read
+            yield f"st:{int(st.st_mtime_ns)}:{st.st_size}:".encode()
+        except Exception:
+            yield b"st:unknown:"
+
+        # Loader params (stable)
+        yield f"off:{obj._offset_in_sec}:".encode()
+        yield f"dur:{obj._duration_in_sec}:".encode()
+        yield f"be:{obj._backend}:".encode()
+
+        # IMPORTANT: do NOT include sampling_rate here to avoid hash drift after lazy load
+        yield b"sr:NA:"
+    else:
+        # Waveform-backed: these are set at construction and won’t change
+        # Use the tensor serializer via cache for stability
+        yield f"sr:{obj._sampling_rate}:".encode()  # _sampling_rate is set in __init__ for waveform-backed
+        yield b"wf:"
+        yield from bytes_repr_sequence_contents([obj.waveform], cache)
+
+    # Metadata as sorted JSON
+    try:
+        md = json.dumps(obj.metadata or {}, sort_keys=True, separators=(",", ":"))
+    except Exception:
+        md = "{}"
+    yield b"md:"
+    yield md.encode()
+
 
 
 if OPENSMILE_AVAILABLE:
@@ -86,33 +137,3 @@ if OPENSMILE_AVAILABLE:
         yield f"params:{obj.params}".encode()
         yield f"process_func_applies_sliding_window:{obj.process_func_applies_sliding_window}".encode()
         yield f"win_dur:{obj.win_dur}".encode()
-
-
-# TODO: Ignore this for now but need to decide how to incorporate Pydra into the package
-# Pydra runner
-# need function that allows for marking a task (could be obfuscated internally)
-# need function that runs the actual code/does the parallelization
-# getting results is a bit clunky right now so could clean that up
-# internal Pydra wouldn't need obfuscations for add/split but external API might be useful
-# perhaps dictionary structure could be intuitive? linked list?
-
-# what if we had a simple split/run structure:
-# user: run X task with Y audios (Satra example); perhaps extraneous information of DeviceType, Model to use
-#   - kinda easy example of just create the pydra setup ourselves, no user worries
-# Senselab "pipelines"/Tasks:
-
-# example:
-# RAVDESS audios:
-# - need to resample
-# - perhaps run loudness normalization
-# - run SER
-# - run evaluation
-
-# get RAVDESS audios
-# split into batches
-#   - run batches through resmapling
-#   - pass to normalization
-#   - run SER
-#   - get partial evaluation
-# - combine evaluation
-# - give average

--- a/src/tests/audio/tasks/features_extraction_test.py
+++ b/src/tests/audio/tasks/features_extraction_test.py
@@ -16,6 +16,7 @@ from senselab.audio.tasks.features_extraction.praat_parselmouth import (
     extract_jitter,
     extract_pitch_descriptors,
     extract_pitch_values,
+    extract_praat_parselmouth_features_from_audios,
     extract_shimmer,
     extract_slope_tilt,
     extract_spectral_moments,
@@ -66,6 +67,163 @@ def test_missing_opensmile_dependency() -> None:
 
         OpenSmileFeatureExtractorFactory.get_opensmile_extractor("eGeMAPSv02", "Functionals")
 
+@pytest.mark.skipif(not OPENSMILE_AVAILABLE, reason="openSMILE is not installed.")
+def test_extract_opensmile_features_from_audios(resampled_mono_audio_sample: Audio) -> None:
+    """Test extraction of openSMILE features from audio."""
+    # Perform eGeMAPSv02 and Functionals features extraction
+    result = extract_opensmile_features_from_audios([resampled_mono_audio_sample], plugin="cf")
+    # Assert the result is a list of dictionaries, and check each dictionary
+    assert isinstance(result, list)
+    assert all(isinstance(features, dict) for features in result)
+
+    # Ensure that each dictionary contains the expected keys (e.g., certain features from eGeMAPS)
+    expected_keys = {"F0semitoneFrom27.5Hz_sma3nz_amean", "jitterLocal_sma3nz_amean", "shimmerLocaldB_sma3nz_amean"}
+    for features in result:
+        assert set(map(str.lower, features.keys())).issuperset(map(str.lower, expected_keys))
+
+    # Check the types of the values to ensure they are either floats or integers
+    for features in result:
+        assert all(isinstance(value, (float, int)) for value in features.values())
+
+
+@pytest.mark.skipif(TORCHAUDIO_AVAILABLE, reason="torchaudio is installed.")
+def test_missing_torchaudio_dependency() -> None:
+    """Test that a ModuleNotFoundError is raised when torchaudio is not installed."""
+    with pytest.raises(ModuleNotFoundError):
+        extract_torchaudio_features_from_audios([Audio(waveform=torch.rand(1, 16000), sampling_rate=16000)])
+
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_spectrogram_from_audios(resampled_mono_audio_sample: Audio) -> None:
+    """Test extraction of spectrogram from audio."""
+    result = extract_spectrogram_from_audios([resampled_mono_audio_sample])
+    assert isinstance(result, list)
+    assert all(isinstance(spec, dict) for spec in result)
+    assert all("spectrogram" in spec for spec in result)
+    assert all(isinstance(spec["spectrogram"], torch.Tensor) for spec in result)
+    # Spectrogram shape is (freq, time)
+    assert all(spec["spectrogram"].dim() == 2 for spec in result)
+    assert all(spec["spectrogram"].shape[0] == 513 for spec in result)
+
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_torchaudio_features_from_audios(resampled_mono_audio_sample: Audio) -> None:
+    """Test extraction of torchaudio features from audio."""
+    result = extract_torchaudio_features_from_audios([resampled_mono_audio_sample])
+    print(result[0].keys())
+    assert isinstance(result, list)
+    assert all(isinstance(spec, dict) for spec in result)
+    assert set(['pitch', 
+                'mel_filter_bank', 
+                'mfcc', 
+                'mel_spectrogram', 
+                'spectrogram']).issubset(set(result[0].keys()))
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_spectrogram_from_audios_specify_n_fft(resampled_mono_audio_sample: Audio) -> None:
+    """Test extraction of spectrogram from audio."""
+    n_fft = 400
+    result = extract_spectrogram_from_audios([resampled_mono_audio_sample], n_fft)
+    assert isinstance(result, list)
+    assert all(isinstance(spec, dict) for spec in result)
+    assert all("spectrogram" in spec for spec in result)
+    assert all(isinstance(spec["spectrogram"], torch.Tensor) for spec in result)
+    # Spectrogram shape is (freq, time)
+    assert all(spec["spectrogram"].dim() == 2 for spec in result)
+    assert all(spec["spectrogram"].shape[0] == 201 for spec in result)
+
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_mel_spectrogram_from_audios(resampled_mono_audio_sample: Audio) -> None:
+    """Test extraction of mel spectrogram from audio."""
+    result = extract_mel_spectrogram_from_audios([resampled_mono_audio_sample])
+    assert isinstance(result, list)
+    assert all(isinstance(spec, dict) for spec in result)
+    assert all("mel_spectrogram" in spec for spec in result)
+    assert all(isinstance(spec["mel_spectrogram"], torch.Tensor) for spec in result)
+    # Mel spectrogram shape is (n_mels, time)
+    assert all(spec["mel_spectrogram"].dim() == 2 for spec in result)
+    assert all(spec["mel_spectrogram"].shape[0] == 128 for spec in result)
+
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_mfcc_from_audios(resampled_mono_audio_sample: Audio) -> None:
+    """Test extraction of MFCC from audio."""
+    result = extract_mfcc_from_audios([resampled_mono_audio_sample])
+    assert isinstance(result, list)
+    assert all(isinstance(mfcc, dict) for mfcc in result)
+    assert all("mfcc" in mfcc for mfcc in result)
+    assert all(isinstance(mfcc["mfcc"], torch.Tensor) for mfcc in result)
+    # MFCC shape is (n_mfcc, time)
+    assert all(mfcc["mfcc"].dim() == 2 for mfcc in result)
+    assert all(mfcc["mfcc"].shape[0] == 40 for mfcc in result)
+
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_mel_filter_bank(resampled_mono_audio_sample: Audio) -> None:
+    """Test extraction of mel filter bank from audio."""
+    result = extract_mel_filter_bank_from_audios([resampled_mono_audio_sample])
+    assert isinstance(result, list)
+    assert all(isinstance(mel_fb, dict) for mel_fb in result)
+    assert all("mel_filter_bank" in mel_fb for mel_fb in result)
+    assert all(isinstance(mel_fb["mel_filter_bank"], torch.Tensor) for mel_fb in result)
+    # Mel filter bank shape is (n_mels, time)
+    assert all(mel_fb["mel_filter_bank"].dim() == 2 for mel_fb in result)
+    assert all(mel_fb["mel_filter_bank"].shape[0] == 128 for mel_fb in result)
+
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_pitch_from_audios(resampled_mono_audio_sample: Audio) -> None:
+    """Test extraction of pitch from audio."""
+    result = extract_pitch_from_audios([resampled_mono_audio_sample])
+    assert isinstance(result, list)
+    assert all(isinstance(pitch, dict) for pitch in result)
+    assert all("pitch" in pitch for pitch in result)
+    assert all(isinstance(pitch["pitch"], torch.Tensor) for pitch in result)
+    # Pitch shape is (time)
+    assert all(pitch["pitch"].dim() == 1 for pitch in result)
+
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_objective_quality_features_from_audios(resampled_mono_audio_sample: Audio) -> None:
+    """Test extraction of objective quality features from audio."""
+    result = extract_objective_quality_features_from_audios([resampled_mono_audio_sample])
+    assert isinstance(result, list)
+    assert isinstance(result[0], dict)
+    assert "stoi" in result[0]
+    assert "pesq" in result[0]
+    assert "si_sdr" in result[0]
+    assert isinstance(result[0]["stoi"], float)
+    assert isinstance(result[0]["pesq"], float)
+    assert isinstance(result[0]["si_sdr"], float)
+
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_objective_quality_features_from_audios_invalid_audio(mono_audio_sample: Audio) -> None:
+    """Test extraction of objective quality features from invalid audio."""
+    with pytest.raises(ValueError, match="Only 16000 Hz sampling rate is supported by Torchaudio-Squim model."):
+        extract_objective_quality_features_from_audios([mono_audio_sample])
+
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_subjective_quality_features_from_audios(resampled_mono_audio_sample: Audio) -> None:
+    """Test extraction of subjective quality features from audio."""
+    result = extract_subjective_quality_features_from_audios(
+        audios=[resampled_mono_audio_sample], non_matching_references=[resampled_mono_audio_sample]
+    )
+    assert isinstance(result, list)
+    assert isinstance(result[0], dict)
+    assert "mos" in result[0]
+    assert isinstance(result[0]["mos"], float)
+
+
+@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
+def test_extract_subjective_quality_features_invalid_audio(mono_audio_sample: Audio) -> None:
+    """Test extraction of subjective quality features from invalid audio."""
+    with pytest.raises(ValueError, match="Only 16000 Hz sampling rate is supported by Torchaudio-Squim model."):
+        extract_subjective_quality_features_from_audios(
+            audios=[mono_audio_sample], non_matching_references=[mono_audio_sample]
+        )
 
 @pytest.mark.skipif(PARSELMOUTH_AVAILABLE, reason="Praat-Parselmouth is installed.")
 def test_missing_parselmouth_dependency() -> None:
@@ -74,11 +232,6 @@ def test_missing_parselmouth_dependency() -> None:
         get_sound(audio=Path("path/to/audio.wav"))
 
 
-@pytest.mark.skipif(TORCHAUDIO_AVAILABLE, reason="torchaudio is installed.")
-def test_missing_torchaudio_dependency() -> None:
-    """Test that a ModuleNotFoundError is raised when torchaudio is not installed."""
-    with pytest.raises(ModuleNotFoundError):
-        extract_torchaudio_features_from_audios([Audio(waveform=torch.rand(1, 16000), sampling_rate=16000)])
 
 
 @pytest.mark.skipif(not PARSELMOUTH_AVAILABLE, reason="Praat-Parselmouth is not installed.")
@@ -210,144 +363,15 @@ def test_extract_shimmer(resampled_mono_audio_sample: Audio) -> None:
     assert all(isinstance(result[key], float) for key in result)
 
 
-@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
-def test_extract_spectrogram_from_audios(resampled_mono_audio_sample: Audio) -> None:
-    """Test extraction of spectrogram from audio."""
-    result = extract_spectrogram_from_audios([resampled_mono_audio_sample])
-    assert isinstance(result, list)
-    assert all(isinstance(spec, dict) for spec in result)
-    assert all("spectrogram" in spec for spec in result)
-    assert all(isinstance(spec["spectrogram"], torch.Tensor) for spec in result)
-    # Spectrogram shape is (freq, time)
-    assert all(spec["spectrogram"].dim() == 2 for spec in result)
-    assert all(spec["spectrogram"].shape[0] == 513 for spec in result)
-
-
-@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
-def test_extract_spectrogram_from_audios_specify_n_fft(resampled_mono_audio_sample: Audio) -> None:
-    """Test extraction of spectrogram from audio."""
-    n_fft = 400
-    result = extract_spectrogram_from_audios([resampled_mono_audio_sample], n_fft)
-    assert isinstance(result, list)
-    assert all(isinstance(spec, dict) for spec in result)
-    assert all("spectrogram" in spec for spec in result)
-    assert all(isinstance(spec["spectrogram"], torch.Tensor) for spec in result)
-    # Spectrogram shape is (freq, time)
-    assert all(spec["spectrogram"].dim() == 2 for spec in result)
-    assert all(spec["spectrogram"].shape[0] == 201 for spec in result)
-
-
-@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
-def test_extract_mel_spectrogram_from_audios(resampled_mono_audio_sample: Audio) -> None:
-    """Test extraction of mel spectrogram from audio."""
-    result = extract_mel_spectrogram_from_audios([resampled_mono_audio_sample])
-    assert isinstance(result, list)
-    assert all(isinstance(spec, dict) for spec in result)
-    assert all("mel_spectrogram" in spec for spec in result)
-    assert all(isinstance(spec["mel_spectrogram"], torch.Tensor) for spec in result)
-    # Mel spectrogram shape is (n_mels, time)
-    assert all(spec["mel_spectrogram"].dim() == 2 for spec in result)
-    assert all(spec["mel_spectrogram"].shape[0] == 128 for spec in result)
-
-
-@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
-def test_extract_mfcc_from_audios(resampled_mono_audio_sample: Audio) -> None:
-    """Test extraction of MFCC from audio."""
-    result = extract_mfcc_from_audios([resampled_mono_audio_sample])
-    assert isinstance(result, list)
-    assert all(isinstance(mfcc, dict) for mfcc in result)
-    assert all("mfcc" in mfcc for mfcc in result)
-    assert all(isinstance(mfcc["mfcc"], torch.Tensor) for mfcc in result)
-    # MFCC shape is (n_mfcc, time)
-    assert all(mfcc["mfcc"].dim() == 2 for mfcc in result)
-    assert all(mfcc["mfcc"].shape[0] == 40 for mfcc in result)
-
-
-@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
-def test_extract_mel_filter_bank(resampled_mono_audio_sample: Audio) -> None:
-    """Test extraction of mel filter bank from audio."""
-    result = extract_mel_filter_bank_from_audios([resampled_mono_audio_sample])
-    assert isinstance(result, list)
-    assert all(isinstance(mel_fb, dict) for mel_fb in result)
-    assert all("mel_filter_bank" in mel_fb for mel_fb in result)
-    assert all(isinstance(mel_fb["mel_filter_bank"], torch.Tensor) for mel_fb in result)
-    # Mel filter bank shape is (n_mels, time)
-    assert all(mel_fb["mel_filter_bank"].dim() == 2 for mel_fb in result)
-    assert all(mel_fb["mel_filter_bank"].shape[0] == 128 for mel_fb in result)
-
-
-@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
-def test_extract_pitch_from_audios(resampled_mono_audio_sample: Audio) -> None:
-    """Test extraction of pitch from audio."""
-    result = extract_pitch_from_audios([resampled_mono_audio_sample])
-    assert isinstance(result, list)
-    assert all(isinstance(pitch, dict) for pitch in result)
-    assert all("pitch" in pitch for pitch in result)
-    assert all(isinstance(pitch["pitch"], torch.Tensor) for pitch in result)
-    # Pitch shape is (time)
-    assert all(pitch["pitch"].dim() == 1 for pitch in result)
-
-
-@pytest.mark.skipif(not OPENSMILE_AVAILABLE, reason="openSMILE is not installed.")
-def test_extract_opensmile_features_from_audios(resampled_mono_audio_sample: Audio) -> None:
+@pytest.mark.skipif(not PARSELMOUTH_AVAILABLE, reason="Praat-Parselmouth is not installed.")
+def test_extract_praat_parselmouth_features_from_audios(resampled_mono_audio_sample: Audio) -> None:
     """Test extraction of openSMILE features from audio."""
-    # Perform eGeMAPSv02 and Functionals features extraction
-    result = extract_opensmile_features_from_audios([resampled_mono_audio_sample], plugin="cf")
-
+    # Extract Praat-Parselmouth features
+    result = extract_praat_parselmouth_features_from_audios([resampled_mono_audio_sample], plugin="cf")
     # Assert the result is a list of dictionaries, and check each dictionary
+    print(result)
     assert isinstance(result, list)
     assert all(isinstance(features, dict) for features in result)
-
-    # Ensure that each dictionary contains the expected keys (e.g., certain features from eGeMAPS)
-    expected_keys = {"F0semitoneFrom27.5Hz_sma3nz_amean", "jitterLocal_sma3nz_amean", "shimmerLocaldB_sma3nz_amean"}
-    for features in result:
-        assert set(map(str.lower, features.keys())).issuperset(map(str.lower, expected_keys))
-
-    # Check the types of the values to ensure they are either floats or integers
-    for features in result:
-        assert all(isinstance(value, (float, int)) for value in features.values())
-
-
-@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
-def test_extract_objective_quality_features_from_audios(resampled_mono_audio_sample: Audio) -> None:
-    """Test extraction of objective quality features from audio."""
-    result = extract_objective_quality_features_from_audios([resampled_mono_audio_sample])
-    assert isinstance(result, list)
-    assert isinstance(result[0], dict)
-    assert "stoi" in result[0]
-    assert "pesq" in result[0]
-    assert "si_sdr" in result[0]
-    assert isinstance(result[0]["stoi"], float)
-    assert isinstance(result[0]["pesq"], float)
-    assert isinstance(result[0]["si_sdr"], float)
-
-
-@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
-def test_extract_objective_quality_features_from_audios_invalid_audio(mono_audio_sample: Audio) -> None:
-    """Test extraction of objective quality features from invalid audio."""
-    with pytest.raises(ValueError, match="Only 16000 Hz sampling rate is supported by Torchaudio-Squim model."):
-        extract_objective_quality_features_from_audios([mono_audio_sample])
-
-
-@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
-def test_extract_subjective_quality_features_from_audios(resampled_mono_audio_sample: Audio) -> None:
-    """Test extraction of subjective quality features from audio."""
-    result = extract_subjective_quality_features_from_audios(
-        audios=[resampled_mono_audio_sample], non_matching_references=[resampled_mono_audio_sample]
-    )
-    assert isinstance(result, list)
-    assert isinstance(result[0], dict)
-    assert "mos" in result[0]
-    assert isinstance(result[0]["mos"], float)
-
-
-@pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
-def test_extract_subjective_quality_features_invalid_audio(mono_audio_sample: Audio) -> None:
-    """Test extraction of subjective quality features from invalid audio."""
-    with pytest.raises(ValueError, match="Only 16000 Hz sampling rate is supported by Torchaudio-Squim model."):
-        extract_subjective_quality_features_from_audios(
-            audios=[mono_audio_sample], non_matching_references=[mono_audio_sample]
-        )
 
 
 @pytest.mark.skipif(

--- a/src/tests/audio/tasks/features_extraction_test.py
+++ b/src/tests/audio/tasks/features_extraction_test.py
@@ -67,6 +67,7 @@ def test_missing_opensmile_dependency() -> None:
 
         OpenSmileFeatureExtractorFactory.get_opensmile_extractor("eGeMAPSv02", "Functionals")
 
+
 @pytest.mark.skipif(not OPENSMILE_AVAILABLE, reason="openSMILE is not installed.")
 def test_extract_opensmile_features_from_audios(resampled_mono_audio_sample: Audio) -> None:
     """Test extraction of openSMILE features from audio."""
@@ -113,11 +114,8 @@ def test_extract_torchaudio_features_from_audios(resampled_mono_audio_sample: Au
     print(result[0].keys())
     assert isinstance(result, list)
     assert all(isinstance(spec, dict) for spec in result)
-    assert set(['pitch', 
-                'mel_filter_bank', 
-                'mfcc', 
-                'mel_spectrogram', 
-                'spectrogram']).issubset(set(result[0].keys()))
+    assert set(["pitch", "mel_filter_bank", "mfcc", "mel_spectrogram", "spectrogram"]).issubset(set(result[0].keys()))
+
 
 @pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")
 def test_extract_spectrogram_from_audios_specify_n_fft(resampled_mono_audio_sample: Audio) -> None:
@@ -225,13 +223,12 @@ def test_extract_subjective_quality_features_invalid_audio(mono_audio_sample: Au
             audios=[mono_audio_sample], non_matching_references=[mono_audio_sample]
         )
 
+
 @pytest.mark.skipif(PARSELMOUTH_AVAILABLE, reason="Praat-Parselmouth is installed.")
 def test_missing_parselmouth_dependency() -> None:
     """Test that a ModuleNotFoundError is raised when Praat-Parselmouth is not installed."""
     with pytest.raises(ModuleNotFoundError):
         get_sound(audio=Path("path/to/audio.wav"))
-
-
 
 
 @pytest.mark.skipif(not PARSELMOUTH_AVAILABLE, reason="Praat-Parselmouth is not installed.")

--- a/src/tests/audio/tasks/input_output_test.py
+++ b/src/tests/audio/tasks/input_output_test.py
@@ -27,7 +27,7 @@ except ModuleNotFoundError:
 def test_read_audios_torchaudio_not_installed() -> None:
     """Tests the read_audios function when torchaudio is not installed."""
     with pytest.raises(ModuleNotFoundError):
-        audios = read_audios(file_paths=[MONO_AUDIO_PATH], plugin="serial")
+        audios = read_audios(file_paths=[MONO_AUDIO_PATH], plugin="debug")
         audios[0].waveform
 
 
@@ -46,7 +46,7 @@ def test_read_audios_torchaudio_not_installed() -> None:
 def test_read_audios(audio_paths: List[str | os.PathLike]) -> None:
     """Tests the read_audios function with actual mono and stereo audio files."""
     # Run the function with real audio file paths
-    processed_audios = read_audios(file_paths=audio_paths, plugin="serial")
+    processed_audios = read_audios(file_paths=audio_paths, plugin="debug")
 
     # Validate results
     assert len(processed_audios) == len(audio_paths), "Incorrect number of processed files."

--- a/src/tests/utils/data_structures/pydra_helpers_test.py
+++ b/src/tests/utils/data_structures/pydra_helpers_test.py
@@ -14,6 +14,7 @@ import senselab  # noqa: F401  # ignore unused import (kept to ensure package in
 
 def test_pydra() -> None:
     """Test Pydra workflow submission and execution."""
+
     @python.define
     def pydra_task(test_input: torch.Tensor) -> torch.Tensor:
         return test_input + 2

--- a/src/tests/utils/data_structures/pydra_helpers_test.py
+++ b/src/tests/utils/data_structures/pydra_helpers_test.py
@@ -1,31 +1,35 @@
-"""Tests Pydra Helping functions."""
+"""Unit tests for Pydra helper functions.
 
-import pydra
+This test defines a trivial Pydra task and a workflow that splits over a list
+of tensors, then verifies the outputs after execution in debug (serial) mode.
+"""
+
+from typing import Any, Sequence
+
 import torch
+from pydra.compose import python, workflow
 
-
-@pydra.mark.task
-@pydra.mark.annotate({"return": {"out": torch.Tensor}})
-def pydra_task(test_input: torch.Tensor) -> torch.Tensor:
-    """Task function for Pydra workflow to run."""
-    return test_input + 2
+import senselab  # noqa: F401  # ignore unused import (kept to ensure package init side-effects)
 
 
 def test_pydra() -> None:
-    """Test simple tensor pydra workflow."""
-    wf = pydra.Workflow(name="wf_test", input_spec=["x"])
-    wf.split("x", x=[torch.tensor([[3, 4], [5, 6]]), torch.tensor([[0, 1], [1, 2]])])
+    """Test Pydra workflow submission and execution."""
+    @python.define
+    def pydra_task(test_input: torch.Tensor) -> torch.Tensor:
+        return test_input + 2
 
-    wf.add(pydra_task(name="test_task_task", test_input=wf.lzin.x))
-    wf.set_output([("wf_out", wf.test_task_task.lzout.out)])
+    @workflow.define
+    def wf_test(x: Sequence[torch.Tensor]) -> Any:  # noqa: ANN401
+        node = workflow.add(pydra_task().split(test_input=x))
+        return node.out
 
-    with pydra.Submitter(plugin="serial", n_procs=1) as sub:
-        sub(wf)
+    tensors: list[torch.Tensor] = [
+        torch.tensor([[3, 4], [5, 6]]),
+        torch.tensor([[0, 1], [1, 2]]),
+    ]
 
-    results = wf.result()
-    assert results[0].output.wf_out.equal(
-        torch.tensor([[5, 6], [7, 8]])
-    ), f"Expected Tensor of [[5,6],[7,8]] but got {results[0].output.wf_out}"
-    assert results[1].output.wf_out.equal(
-        torch.tensor([[2, 3], [3, 4]])
-    ), f"Expected Tensor of [[2,3],[3,4]] but got {results[1].output.wf_out}"
+    wf = wf_test(x=tensors)
+    res: Any = wf(worker="debug")
+
+    assert res.out[0].equal(torch.tensor([[5, 6], [7, 8]]))
+    assert res.out[1].equal(torch.tensor([[2, 3], [3, 4]]))


### PR DESCRIPTION
## Description
This PR updates the codebase to use [Pydra v1](https://nipype.github.io/pydra/tutorial/6-workflow.html) and makes related adjustments.

### Changes
- [x] Dropped Python 3.10 support. Pydra v1 does not support Python 3.10 (likely due to its upcoming EOL in Oct 2026 per [NumPy’s deprecation policy](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule)).
- [x] Updated CI to remove Python 3.10 from the test matrix.
- [x] Made audiomentations and torch_audiomentations now run under Pydra workflows.
- [x] Migrated to the new Pydra API for feature extraction and audio I/O (Kept backwards compatibility in terms of interface for the user).
- [x] Added a serializer for the Audio object (needed because it’s lazy-loaded).

#### Miscellaneous 
- [x] Fixed some mypy type issues, especially for transformers types.

## Related Issue(s)
https://github.com/sensein/senselab/issues/301

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.