### PR TITLE
fix torch version to 2.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ mypy = "~=1.9"
 pre-commit = "~=4.0"
 ruff = "~=0.3"
 codespell = "~=2.3"
-uvloop = "~=0.21"
+uvloop = "~=0.22"
 types-requests = "~=2.32"
 python-dotenv = "~=1.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ requires-poetry = ">=2.0"
 version = "0.0.0"
 
 [tool.poetry.dependencies]
-torch = {version = "~=2.8", markers = "sys_platform != 'darwin' or platform_machine == 'arm64'"}
-torchvision = "~=0.23"
+torch = {version = "~=2.8.0", markers = "sys_platform != 'darwin' or platform_machine == 'arm64'"}
+torchvision = "~=0.23.0"
 transformers = "^4.51"
 datasets = "~=3.6"
 pydra = ">=1.0a3"
@@ -46,7 +46,7 @@ umap-learn = "~=0.5"
 python-ffmpeg = "~=2.0"
 nest-asyncio = "~=1.6"
 matplotlib = "~=3.10"
-torchaudio = {version = "~=2.8", optional = true}
+torchaudio = {version = "~=2.8.0", optional = true}
 praat-parselmouth = {version = "~=0.4", optional = true}
 audiomentations = {version = "~=0.42", optional = true}
 torch-audiomentations = {version = "~=0.12", optional = true}

--- a/src/tests/utils/data_structures/uvloop_test.py
+++ b/src/tests/utils/data_structures/uvloop_test.py
@@ -29,8 +29,7 @@ def test_senselab_init_with_uvloop() -> None:
             """Dummy async function."""
             return 42
 
-        loop = asyncio.get_event_loop()
-        result = loop.run_until_complete(dummy())
+        result = asyncio.run(dummy())
         assert result == 42
 
     except Exception as e:

--- a/src/tests/utils/data_structures/uvloop_test.py
+++ b/src/tests/utils/data_structures/uvloop_test.py
@@ -9,14 +9,14 @@ try:
     import uvloop
 
     UVLOOP_AVAILABLE = True
-except ImportError:
+except Exception:
     UVLOOP_AVAILABLE = False
 
 
 @pytest.mark.skipif(not UVLOOP_AVAILABLE, reason="uvloop not available")
 def test_senselab_init_with_uvloop() -> None:
     """Test senselab init with uvloop."""
-    # Force the use of uvloop in the test
+    # Force uvloop policy
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
     try:
@@ -24,13 +24,20 @@ def test_senselab_init_with_uvloop() -> None:
         sys.modules.pop("senselab", None)
         import senselab  # noqa: F401
 
-        # If we reach here, the init did not crash due to uvloop conflict
         async def dummy() -> int:
-            """Dummy async function."""
             return 42
 
-        result = asyncio.run(dummy())
-        assert result == 42
+        # Create and set the loop explicitly (works with uvloop + 3.11)
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            result = loop.run_until_complete(dummy())
+            assert result == 42
+        finally:
+            # Clean up
+            if not loop.is_closed():
+                loop.close()
+            asyncio.set_event_loop(None)
 
     except Exception as e:
         pytest.fail(f"senselab __init__ raised an unexpected error with uvloop: {e}")


### PR DESCRIPTION
## Description
fix torch version to 2.8

As a minor thing, this PR also fixes a uvloop unit test, which was failing otherwise

## Related Issue(s)
This is a temporary fix to https://github.com/sensein/senselab/issues/389

## Motivation and Context
torch 2.9 is particularly disruptive, causing errors in senselab and any projects requiring senselab as a dependency

## How Has This Been Tested?
Unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
