### PR TITLE
Alignment to what's described in the paper's draft

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,7 +40,7 @@ jobs:
       shell: bash
     - name: Install dependencies with Poetry
       run: |
-        poetry install --extras "audio articulatory text video senselab-ai" --with dev,docs
+        poetry install --extras "articulatory text video senselab-ai" --with dev,docs
       shell: bash
     - name: Build docs
       env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Install dependencies with Poetry
       run: |
         poetry env use ${{ matrix.python-version }}
-        poetry install --extras "audio text video" --with dev
+        poetry install --extras "text video" --with dev
         poetry env info
       shell: bash
     - name: check files
@@ -94,7 +94,7 @@ jobs:
     - name: Install dependencies with Poetry
       run: |
         poetry env use ${{ matrix.python-version }}
-        poetry install --extras "audio text video" --with dev
+        poetry install --extras "text video" --with dev
         poetry env info
       shell: bash
     - name: Install pre-commit
@@ -380,7 +380,7 @@ jobs:
       run: |
         cd senselab
         poetry env use ${{ matrix.python-version }}
-        poetry install --extras "audio text video" --with dev
+        poetry install --extras "text video" --with dev
       shell: bash
     - name: Check poetry info
       run: |
@@ -548,7 +548,7 @@ jobs:
       run: |
         cd senselab
         poetry env use ${{ matrix.python-version }}
-        poetry install --extras "audio text video" --with dev
+        poetry install --extras "text video" --with dev
       shell: bash
     - name: Check poetry info
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,11 +61,6 @@ repos:
     args: [--skip=*.ipynb]
     additional_dependencies:
     - tomli
-- repo: https://github.com/hija/clean-dotenv
-  rev: v0.0.7
-  hooks:
-  - id: clean-dotenv
-
 - repo: local
   hooks:
   - id: yaml-file-extension

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Please follow the official installation instructions for your platform: [Install
 
 
 5b. **Install all required dependencies** (we recommend to test your code both with all extras and the minimum required set of extras):
-  - ```poetry install --extras "audio text video" --with dev,docs```
+  - ```poetry install --extras "articulatory text video senselab-ai" --with dev,docs```
 
 5c. **Set up your HuggingFace token** (required for some models).
 Many models used in senselab are hosted on HuggingFace and require authentication or acceptance of a model license.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ pip install 'git+https://github.com/sensein/senselab.git#egg=senselab[all]'
 
 If you want to install only audio dependencies, you do:
 ```sh
-pip install 'senselab[audio]'
+pip install 'senselab'
 ```
 
 To install articulatory, video, text, and senselab-ai extras, please do:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,15 +46,16 @@ umap-learn = "~=0.5"
 python-ffmpeg = "~=2.0"
 nest-asyncio = "~=1.6"
 matplotlib = "~=3.10"
-torchaudio = {version = "~=2.8.0", optional = true}
-praat-parselmouth = {version = "~=0.4", optional = true}
-audiomentations = {version = "~=0.42", optional = true}
-torch-audiomentations = {version = "~=0.12", optional = true}
-speechbrain = {version = "~=1", optional = true}
-pyannote-audio = {version = "~=3.3", optional = true}
-opensmile = {version = "~=2.6", optional = true}
-vocos = {version = "~=0.1", optional = true}
-coqui-tts = {version = "~=0.27", optional = true}
+torchaudio = {version = "~=2.8.0"}
+praat-parselmouth = {version = "~=0.4"}
+audiomentations = {version = "~=0.42"}
+torch-audiomentations = {version = "~=0.12"}
+speechbrain = {version = "~=1"}
+pyannote-audio = {version = "~=3.3"}
+opensmile = {version = "~=2.6"}
+vocos = {version = "~=0.1"}
+coqui-tts = {version = "~=0.27"}
+nemo-toolkit = {version = "~=2.3", extras = ["asr"]}
 speech-articulatory-coding = {version = "~=0.1", optional = true}
 jiwer = {version = "^3.0", optional = true}
 nltk = {version = "~=3.9", optional = true}
@@ -63,7 +64,6 @@ pylangacq = {version = "~=0.19", optional = true}
 opencv-python-headless = {version = "~=4.11", optional = true}
 ultralytics = {version = "~=8.3", optional = true}
 av = {version = "~=15", optional = true}
-nemo-toolkit = {version = "~=2.3", optional = true, extras = ["asr"]}
 notebook-intelligence = {version = "~=2.3.2", optional = true}
 ipywidgets = {version = "~=8.1", optional = true}
 ipykernel = {version = "~=6.3", optional = true}
@@ -72,20 +72,6 @@ nbss-upload = {version = "~=0.1", optional = true}
 jupyterlab = {version = "^4.4", optional = true}
 
 [tool.poetry.extras]
-audio = [
-  "torchaudio",
-  "praat-parselmouth",
-  "audiomentations",
-  "torch-audiomentations",
-  "speechbrain",
-  "pyannote-audio",
-  "opensmile",
-  "vocos",
-  "jiwer",
-  "nltk",
-  "coqui-tts",
-  "nemo-toolkit"
-]
 articulatory = [
   "speech-articulatory-coding"
 ]

--- a/src/senselab/audio/data_structures/audio.py
+++ b/src/senselab/audio/data_structures/audio.py
@@ -177,7 +177,7 @@ class Audio(BaseModel):
         if not TORCHAUDIO_AVAILABLE:
             raise ModuleNotFoundError(
                 "`torchaudio` is not installed. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+                "Please install senselab audio dependencies using `pip install senselab`."
             )
 
         info = torchaudio.info(filepath)
@@ -295,7 +295,7 @@ class Audio(BaseModel):
         if not TORCHAUDIO_AVAILABLE:
             raise ModuleNotFoundError(
                 "`torchaudio` is not installed. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+                "Please install senselab audio dependencies using `pip install senselab`."
             )
 
         if self.waveform.ndim != 2:
@@ -345,7 +345,7 @@ class Audio(BaseModel):
         if not SOUNDFILE_AVAILABLE:
             raise ModuleNotFoundError(
                 "`soundfile` is not installed. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+                "Please install senselab audio dependencies using `pip install senselab`."
             )
 
         if isinstance(stream_source, (os.PathLike, str)) and not os.path.exists(stream_source):

--- a/src/senselab/audio/tasks/data_augmentation/api.py
+++ b/src/senselab/audio/tasks/data_augmentation/api.py
@@ -86,12 +86,12 @@ def augment_audios(
     if not AUDIOMENTATIONS_AVAILABLE:
         raise ModuleNotFoundError(
             "`audiomentations` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`"
+            "Please install senselab audio dependencies using `pip install senselab`"
         )
     if not TORCH_AUDIOMENTATIONS_AVAILABLE:
         raise ModuleNotFoundError(
             "`torch-audiomentations` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`"
+            "Please install senselab audio dependencies using `pip install senselab`"
         )
     if isinstance(augmentation, TorchAudiomentationsCompose):
         return augment_audios_with_torch_audiomentations(audios, augmentation, device)

--- a/src/senselab/audio/tasks/data_augmentation/audiomentations.py
+++ b/src/senselab/audio/tasks/data_augmentation/audiomentations.py
@@ -82,7 +82,7 @@ def augment_audios_with_audiomentations(
     if not AUDIOMENTATIONS_AVAILABLE:
         raise ModuleNotFoundError(
             "`audiomentations` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     # Serialize augmentation deterministically

--- a/src/senselab/audio/tasks/data_augmentation/torch_audiomentations.py
+++ b/src/senselab/audio/tasks/data_augmentation/torch_audiomentations.py
@@ -35,7 +35,7 @@ def augment_audios_with_torch_audiomentations(
     if not TORCH_AUDIOMENTATIONS_AVAILABLE:
         raise ModuleNotFoundError(
             "`torch-audiomentations` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`"
+            "Please install senselab audio dependencies using `pip install senselab`"
         )
     if not isinstance(augmentation, _TACompose):
         raise TypeError("`augmentation` must be an instance of torch_audiomentations.Compose")

--- a/src/senselab/audio/tasks/features_extraction/opensmile.py
+++ b/src/senselab/audio/tasks/features_extraction/opensmile.py
@@ -63,7 +63,7 @@ class OpenSmileFeatureExtractorFactory:
         if not OPENSMILE_AVAILABLE:
             raise ModuleNotFoundError(
                 "`opensmile` is not installed. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio]'`"
+                "Please install senselab audio dependencies using `pip install senselab`"
             )
 
         key = f"{feature_set}-{feature_level}"
@@ -103,8 +103,7 @@ def extract_opensmile_features_from_audios(
     """
     if not OPENSMILE_AVAILABLE:
         raise ModuleNotFoundError(
-            "`opensmile` is not installed. Please install the necessary dependencies using:\n"
-            "`pip install 'senselab[audio]'`"
+            "`opensmile` is not installed. Please install the necessary dependencies using:\n" "`pip install senselab`"
         )
 
     @python.define

--- a/src/senselab/audio/tasks/features_extraction/praat_parselmouth.py
+++ b/src/senselab/audio/tasks/features_extraction/praat_parselmouth.py
@@ -62,7 +62,7 @@ def get_sound(audio: Union[Path, Audio], sampling_rate: int = 16000) -> parselmo
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     try:
@@ -126,7 +126,7 @@ def extract_speech_rate(snd: Union[parselmouth.Sound, Path, Audio]) -> Dict[str,
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     try:
@@ -396,7 +396,7 @@ def extract_pitch_values(snd: Union[parselmouth.Sound, Path, Audio]) -> Dict[str
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     try:
@@ -475,7 +475,7 @@ def extract_pitch_descriptors(
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     try:
@@ -535,7 +535,7 @@ def extract_intensity_descriptors(
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     try:
@@ -599,7 +599,7 @@ def extract_harmonicity_descriptors(
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     try:
@@ -658,7 +658,7 @@ def extract_slope_tilt(snd: Union[parselmouth.Sound, Path, Audio], floor: float,
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     try:
@@ -728,7 +728,7 @@ def extract_cpp_descriptors(
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     try:
@@ -856,7 +856,7 @@ def measure_f1f2_formants_bandwidths(
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     try:
@@ -970,7 +970,7 @@ def extract_spectral_moments(
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     try:
@@ -1069,7 +1069,7 @@ def extract_audio_duration(snd: Union[parselmouth.Sound, Path, Audio]) -> Dict[s
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     # Check if the input is a Path, in which case we load the audio from the file
@@ -1112,7 +1112,7 @@ def extract_jitter(snd: Union[parselmouth.Sound, Path, Audio], floor: float, cei
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     # Check if the input is a Path or Audio, and convert to Parselmouth Sound if necessary
@@ -1168,7 +1168,7 @@ def extract_shimmer(snd: Union[parselmouth.Sound, Path, Audio], floor: float, ce
     if not PARSELMOUTH_AVAILABLE:
         raise ModuleNotFoundError(
             "`parselmouth` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     # Check if the input is a Path or Audio, and convert to Parselmouth Sound if necessary

--- a/src/senselab/audio/tasks/features_extraction/torchaudio.py
+++ b/src/senselab/audio/tasks/features_extraction/torchaudio.py
@@ -36,8 +36,7 @@ def extract_spectrogram_from_audios(
     """
     if not TORCHAUDIO_AVAILABLE:
         raise ModuleNotFoundError(
-            "`torchaudio` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`torchaudio` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     if win_length is None:
@@ -79,8 +78,7 @@ def extract_mel_spectrogram_from_audios(
     """
     if not TORCHAUDIO_AVAILABLE:
         raise ModuleNotFoundError(
-            "`torchaudio` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`torchaudio` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     if win_length is None:
@@ -129,8 +127,7 @@ def extract_mfcc_from_audios(
     """
     if not TORCHAUDIO_AVAILABLE:
         raise ModuleNotFoundError(
-            "`torchaudio` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`torchaudio` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     if win_length is None:
@@ -175,8 +172,7 @@ def extract_mel_filter_bank_from_audios(
     """
     if not TORCHAUDIO_AVAILABLE:
         raise ModuleNotFoundError(
-            "`torchaudio` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`torchaudio` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     if win_length is None:
@@ -216,8 +212,7 @@ def extract_mel_filter_bank_from_spectrograms(
     """
     if not TORCHAUDIO_AVAILABLE:
         raise ModuleNotFoundError(
-            "`torchaudio` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`torchaudio` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     mel_filter_banks = []
@@ -252,8 +247,7 @@ def extract_pitch_from_audios(
     """
     if not TORCHAUDIO_AVAILABLE:
         raise ModuleNotFoundError(
-            "`torchaudio` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`torchaudio` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     if freq_low <= 0:
@@ -319,8 +313,7 @@ def extract_torchaudio_features_from_audios(
     """
     if not TORCHAUDIO_AVAILABLE:
         raise ModuleNotFoundError(
-            "`torchaudio` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`torchaudio` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     # Per-sample task: compute all features for a single Audio

--- a/src/senselab/audio/tasks/features_extraction/torchaudio_squim.py
+++ b/src/senselab/audio/tasks/features_extraction/torchaudio_squim.py
@@ -34,8 +34,7 @@ def extract_objective_quality_features_from_audios(audios: List["Audio"]) -> Lis
     """
     if not TORCHAUDIO_AVAILABLE:
         raise ModuleNotFoundError(
-            "`torchaudio` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`torchaudio` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     if any(audio.waveform.shape[0] != 1 for audio in audios):
@@ -79,8 +78,7 @@ def extract_subjective_quality_features_from_audios(
     """
     if not TORCHAUDIO_AVAILABLE:
         raise ModuleNotFoundError(
-            "`torchaudio` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`torchaudio` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     # Check if any audio is not mono

--- a/src/senselab/audio/tasks/forced_alignment/forced_alignment.py
+++ b/src/senselab/audio/tasks/forced_alignment/forced_alignment.py
@@ -52,8 +52,7 @@ def _preprocess_segments(
     """
     if not NLTK_AVAILABLE:
         raise ModuleNotFoundError(
-            "`nltk` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`nltk` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     total_segments = len(transcript)

--- a/src/senselab/audio/tasks/preprocessing/preprocessing.py
+++ b/src/senselab/audio/tasks/preprocessing/preprocessing.py
@@ -100,7 +100,7 @@ def resample_audios(
     if not SPEECHBRAIN_AVAILABLE:
         raise ModuleNotFoundError(
             "`speechbrain` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
     plugin_args = plugin_args or {}
 

--- a/src/senselab/audio/tasks/speaker_diarization/nvidia.py
+++ b/src/senselab/audio/tasks/speaker_diarization/nvidia.py
@@ -52,7 +52,7 @@ class NvidiaSortformerDiarization:
         if not NEMO_SORTFORMER_AVAILABLE:
             raise ModuleNotFoundError(
                 "`nemo_toolkit` is not installed. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+                "Please install senselab audio dependencies using `pip install senselab`."
             )
 
         device, _ = _select_device_and_dtype(
@@ -119,7 +119,7 @@ def diarize_audios_with_nvidia_sortformer(
     if not NEMO_SORTFORMER_AVAILABLE:
         raise ModuleNotFoundError(
             "`nemo_toolkit` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     # Initialize model

--- a/src/senselab/audio/tasks/speaker_diarization/pyannote.py
+++ b/src/senselab/audio/tasks/speaker_diarization/pyannote.py
@@ -51,7 +51,7 @@ class PyannoteDiarization:
         if not PYANNOTEAUDIO_AVAILABLE:
             raise ModuleNotFoundError(
                 "`pyannote-audio` is not installed. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+                "Please install senselab audio dependencies using `pip install senselab`."
             )
 
         device, _ = _select_device_and_dtype(
@@ -145,7 +145,7 @@ def diarize_audios_with_pyannote(
     if not PYANNOTEAUDIO_AVAILABLE:
         raise ModuleNotFoundError(
             "`pyannote-audio` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     if model is None:

--- a/src/senselab/audio/tasks/speaker_diarization_evaluation/utils.py
+++ b/src/senselab/audio/tasks/speaker_diarization_evaluation/utils.py
@@ -41,7 +41,7 @@ def calculate_diarization_error_rate(
     if not PYANNOTEAUDIO_AVAILABLE:
         raise ModuleNotFoundError(
             "`pyannote-audio` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     hypothesis_annotation = Annotation()

--- a/src/senselab/audio/tasks/speaker_embeddings/speechbrain.py
+++ b/src/senselab/audio/tasks/speaker_embeddings/speechbrain.py
@@ -85,6 +85,9 @@ class SpeechBrainEmbeddings:
                 "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
             )
 
+        if len(audios) == 0:
+            return []
+
         if model is None:
             model = SpeechBrainModel(path_or_uri="speechbrain/spkrec-ecapa-voxceleb", revision="main")
 

--- a/src/senselab/audio/tasks/speaker_embeddings/speechbrain.py
+++ b/src/senselab/audio/tasks/speaker_embeddings/speechbrain.py
@@ -43,7 +43,7 @@ class SpeechBrainEmbeddings:
         if not SPEECHBRAIN_AVAILABLE:
             raise ModuleNotFoundError(
                 "`speechbrain` is not installed. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+                "Please install senselab audio dependencies using `pip install senselab`."
             )
 
         device, _ = _select_device_and_dtype(
@@ -82,7 +82,7 @@ class SpeechBrainEmbeddings:
         if not SPEECHBRAIN_AVAILABLE:
             raise ModuleNotFoundError(
                 "`speechbrain` is not installed. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+                "Please install senselab audio dependencies using `pip install senselab`."
             )
 
         if len(audios) == 0:

--- a/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
+++ b/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
@@ -47,7 +47,7 @@ class SpeechBrainEnhancer:
         if not SPEECHBRAIN_AVAILABLE:
             raise ModuleNotFoundError(
                 "`speechbrain` is not installed. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+                "Please install senselab audio dependencies using `pip install senselab`."
             )
 
         device, dtype = _select_device_and_dtype(
@@ -89,7 +89,7 @@ class SpeechBrainEnhancer:
         if not SPEECHBRAIN_AVAILABLE:
             raise ModuleNotFoundError(
                 "`speechbrain` is not installed. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+                "Please install senselab audio dependencies using `pip install senselab`."
             )
 
         if model is None:

--- a/src/senselab/audio/tasks/speech_to_text_evaluation/utils.py
+++ b/src/senselab/audio/tasks/speech_to_text_evaluation/utils.py
@@ -26,8 +26,7 @@ def calculate_wer(reference: str, hypothesis: str) -> float:
     """
     if not JIWER_AVAILABLE:
         raise ModuleNotFoundError(
-            "`jiwer` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`jiwer` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     return jiwer.wer(reference, hypothesis)
@@ -49,8 +48,7 @@ def calculate_mer(reference: str, hypothesis: str) -> float:
     """
     if not JIWER_AVAILABLE:
         raise ModuleNotFoundError(
-            "`jiwer` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`jiwer` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
     return jiwer.mer(reference, hypothesis)
 
@@ -71,8 +69,7 @@ def calculate_wil(reference: str, hypothesis: str) -> float:
     """
     if not JIWER_AVAILABLE:
         raise ModuleNotFoundError(
-            "`jiwer` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`jiwer` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
     return jiwer.wil(reference, hypothesis)
 
@@ -93,8 +90,7 @@ def calculate_wip(reference: str, hypothesis: str) -> float:
     """
     if not JIWER_AVAILABLE:
         raise ModuleNotFoundError(
-            "`jiwer` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`jiwer` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
     return jiwer.wip(reference, hypothesis)
 
@@ -115,8 +111,7 @@ def calculate_cer(reference: str, hypothesis: str) -> float:
     """
     if not JIWER_AVAILABLE:
         raise ModuleNotFoundError(
-            "`jiwer` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "`jiwer` is not installed. " "Please install senselab audio dependencies using `pip install senselab`."
         )
     cer_value = jiwer.cer(reference, hypothesis)
     if isinstance(cer_value, dict):

--- a/src/senselab/audio/tasks/voice_cloning/coqui.py
+++ b/src/senselab/audio/tasks/voice_cloning/coqui.py
@@ -26,7 +26,7 @@ class CoquiVoiceCloner:
         if not TTS_AVAILABLE:
             raise ModuleNotFoundError(
                 "`coqui-tts` is not available. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+                "Please install senselab audio dependencies using `pip install senselab`."
             )
         device, _ = _select_device_and_dtype(
             user_preference=user_preference, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]

--- a/src/senselab/audio/tasks/voice_cloning/sparc.py
+++ b/src/senselab/audio/tasks/voice_cloning/sparc.py
@@ -26,7 +26,7 @@ class SparcVoiceCloner:
         if not SPARC_AVAILABLE:
             raise ModuleNotFoundError(
                 "`sparc` is not available. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio,articulatory]'`."
+                "Please install senselab audio dependencies using `pip install 'senselab[articulatory]'`."
             )
         device, _ = _select_device_and_dtype(
             user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]
@@ -72,7 +72,7 @@ class SparcVoiceCloner:
         if not SPARC_AVAILABLE:
             raise ModuleNotFoundError(
                 "`sparc` is not available. "
-                "Please install senselab audio dependencies using `pip install 'senselab[audio,articulatory]'`."
+                "Please install senselab audio dependencies using `pip install 'senselab[articulatory]'`."
             )
 
         if len(source_audios) != len(target_audios):

--- a/src/senselab/audio/workflows/__init__.py
+++ b/src/senselab/audio/workflows/__init__.py
@@ -1,1 +1,3 @@
 """Workflows and pipelines for audio processing and analysis."""
+
+from .explore_conversation import explore_conversation  # noqa: F401

--- a/src/senselab/audio/workflows/explore_conversation.py
+++ b/src/senselab/audio/workflows/explore_conversation.py
@@ -129,8 +129,8 @@ def explore_conversation(
         audios=flattened_segments,
         opensmile=features_config.get("opensmile", True),
         parselmouth=features_config.get("parselmouth", True),
-        torchaudio=features_config.get("torchaudio", True),
-        torchaudio_squim=bool(features_config.get("torchaudio_squim", True)),
+        torchaudio=features_config.get("torchaudio", False),
+        torchaudio_squim=bool(features_config.get("torchaudio_squim", False)),
     )
     for seg, feats in zip(flattened_segments, feat_out):
         seg.metadata["features"] = feats

--- a/src/senselab/audio/workflows/explore_conversation.py
+++ b/src/senselab/audio/workflows/explore_conversation.py
@@ -1,0 +1,185 @@
+"""This module provides the `explore_conversation` function for conversational data exploration on audio files."""
+
+import os
+from typing import Any, Dict, List, Optional, Type, Union
+
+from senselab.audio.data_structures import Audio
+from senselab.audio.tasks.features_extraction import extract_features_from_audios
+from senselab.audio.tasks.input_output.utils import read_audios
+from senselab.audio.tasks.preprocessing.preprocessing import (
+    downmix_audios_to_mono,
+    extract_segments,
+    resample_audios,
+)
+from senselab.audio.tasks.speaker_diarization import diarize_audios
+from senselab.audio.tasks.speaker_embeddings import extract_speaker_embeddings_from_audios
+from senselab.audio.tasks.speech_to_text import transcribe_audios
+from senselab.audio.tasks.ssl_embeddings import extract_ssl_embeddings_from_audios
+from senselab.utils.data_structures.model import HFModel, SenselabModel, SpeechBrainModel
+
+
+def explore_conversation(
+    audio_file_paths: List[str | os.PathLike],
+    speaker_diarization_model: Optional[SenselabModel] = None,
+    transcription_models: Optional[List[SenselabModel]] = None,
+    features_config: Optional[Dict[str, Union[bool, Dict[str, Any]]]] = None,
+    speaker_embeddings_models: Optional[List[SpeechBrainModel]] = None,
+    ssl_embeddings_models: Optional[List[SenselabModel]] = None,
+    plugin: str = "debug",
+) -> List[List[Dict[str, Any]]]:
+    """Perform conversational data exploration on audio files.
+
+    This function processes audio files by performing speaker diarization, transcription,
+    feature extraction, speaker embeddings, and SSL embeddings extraction. The results
+    are assembled into a list of JSON-serializable dictionaries, one per speaker turn.
+
+    Args:
+        audio_file_paths (List[str]): List of paths to audio files.
+        speaker_diarization_model (SenselabModel): Model for speaker diarization.
+            If None, defaults to HFModel(path_or_uri="nvidia/diar_sortformer_4spk-v1").
+        transcription_models (List[SenselabModel]): List of models for transcription.
+            If None, defaults to [HFModel(path_or_uri="openai/whisper-tiny")].
+        features_config (Dict[str, Union[bool, Dict[str, Any]]]): Configuration for feature extraction backends.
+            Keys can include 'opensmile', 'parselmouth', 'torchaudio', 'torchaudio_squim'.
+            Values are either bool (enable/disable) or dict (backend-specific config).
+            If None, defaults to {'opensmile': True, 'parselmouth': True, 'torchaudio': False,
+            'torchaudio_squim': False}.
+        speaker_embeddings_models (List[SpeechBrainModel]): List of models for speaker embeddings.
+            If None, defaults to [SpeechBrainModel(path_or_uri="speechbrain/spkrec-ecapa-voxceleb")].
+        ssl_embeddings_models (List[SenselabModel]): List of models for SSL embeddings.
+            If None, defaults to [HFModel(path_or_uri="microsoft/wavlm-base")].
+        plugin (str): The pydra plugin to use for task execution.
+            Defaults to "debug". "cf" is for concurrent futures.
+
+    Returns:
+        List[Dict[str, Any]]: List of JSON-serializable dicts, one per speaker segment.
+    """
+    if speaker_diarization_model is None:
+        speaker_diarization_model = HFModel(path_or_uri="nvidia/diar_sortformer_4spk-v1")
+    if transcription_models is None:
+        transcription_models = [HFModel(path_or_uri="openai/whisper-tiny")]
+    if speaker_embeddings_models is None:
+        speaker_embeddings_models = [SpeechBrainModel(path_or_uri="speechbrain/spkrec-ecapa-voxceleb")]
+    if ssl_embeddings_models is None:
+        ssl_embeddings_models = [HFModel(path_or_uri="microsoft/wavlm-base")]
+    if features_config is None:
+        features_config = {"opensmile": True, "parselmouth": True, "torchaudio": False, "torchaudio_squim": False}
+
+    # 1. Resolve absolute paths for all audio files
+    abs_paths = [os.path.abspath(p) for p in audio_file_paths]
+
+    # 2. Load audio files into Audio objects
+    audios = read_audios(abs_paths, plugin=plugin)
+
+    # 3. Downmix to mono and resample to 16kHz
+    audios = downmix_audios_to_mono(audios, plugin=plugin)
+    target_sr = 16000
+    audios = resample_audios(audios, resample_rate=target_sr, plugin=plugin)
+
+    # 4. Speaker diarization
+    diarization_results = diarize_audios(
+        audios=audios,
+        model=speaker_diarization_model,
+    )
+
+    # 5. Build (Audio, segment_times) pairs
+    segments_info = []
+    for audio, script_lines in zip(audios, diarization_results):
+        times = []
+        for line in script_lines:
+            # Only include segments where start and end are not None
+            if line.start is not None and line.end is not None:
+                times.append((line.start, line.end))
+        segments_info.append((audio, times))
+
+    # 6. Extract segments
+    segmented_audios_list = extract_segments(segments_info)
+
+    # 7. Populate segment metadata
+    for i, (segments, lines) in enumerate(zip(segmented_audios_list, diarization_results)):
+        src_path = abs_paths[i] if i < len(abs_paths) else None
+        n = min(len(segments), len(lines))
+        for j in range(n):
+            seg = segments[j]
+            line = lines[j]
+            md = seg.metadata
+            md["original_file"] = src_path
+            md["sampling_rate"] = seg.sampling_rate
+            md["speaker_id"] = getattr(line, "speaker", None)
+            md["segment_start"] = getattr(line, "start", None)
+            md["segment_end"] = getattr(line, "end", None)
+
+    # 8. Flatten segments
+    flattened_segments = [seg for group in segmented_audios_list for seg in group]
+
+    # 9. Transcribe segments with all provided models
+    transcripts_by_model = {}
+    print("transcription_models:", transcription_models)
+    for model in transcription_models:
+        trans_out = transcribe_audios(audios=flattened_segments, model=model)
+        transcripts_by_model[model.path_or_uri] = [t.text for t in trans_out]
+
+    for idx, seg in enumerate(flattened_segments):
+        seg.metadata["transcripts"] = {
+            model_name: transcripts_by_model[model_name][idx] for model_name in transcripts_by_model
+        }
+
+    # 10. Extract features
+    feat_out = extract_features_from_audios(
+        audios=flattened_segments,
+        opensmile=features_config.get("opensmile", True),
+        parselmouth=features_config.get("parselmouth", True),
+        torchaudio=features_config.get("torchaudio", True),
+        torchaudio_squim=bool(features_config.get("torchaudio_squim", True)),
+    )
+    for seg, feats in zip(flattened_segments, feat_out):
+        seg.metadata["features"] = feats
+
+    # 11. Extract speaker embeddings for all provided models
+    speaker_embeddings_by_model = {}
+    for model in speaker_embeddings_models:
+        emb_out = extract_speaker_embeddings_from_audios(audios=flattened_segments, model=model)
+        speaker_embeddings_by_model[model.path_or_uri] = [e.tolist() for e in emb_out]
+
+    for idx, seg in enumerate(flattened_segments):
+        seg.metadata["speaker_embeddings"] = {
+            model_name: speaker_embeddings_by_model[model_name][idx] for model_name in speaker_embeddings_by_model
+        }
+
+    # 12. Extract SSL embeddings for all provided models
+    ssl_embeddings_by_model = {}
+    for model in ssl_embeddings_models:
+        ssl_out = extract_ssl_embeddings_from_audios(audios=flattened_segments, model=model)
+        # Mean-pool over time dimension if needed
+        pooled = [emb.mean(dim=1).squeeze().tolist() if hasattr(emb, "mean") else emb for emb in ssl_out]
+        ssl_embeddings_by_model[model.path_or_uri] = pooled
+
+    for idx, seg in enumerate(flattened_segments):
+        seg.metadata["ssl_embeddings"] = {
+            model_name: ssl_embeddings_by_model[model_name][idx] for model_name in ssl_embeddings_by_model
+        }
+
+    # 13. Build JSON output per segment
+    def build_json_from_segment(seg: Audio) -> Dict[str, Any]:
+        md = getattr(seg, "metadata", {}) or {}
+        return {
+            "original_file": md.get("original_file"),
+            "sampling_rate": md.get("sampling_rate"),
+            "speaker_id": md.get("speaker_id"),
+            "start": md.get("segment_start"),
+            "end": md.get("segment_end"),
+            "transcripts": md.get("transcripts"),
+            "features": md.get("features"),
+            "speaker_embeddings": md.get("speaker_embeddings"),
+            "ssl_embeddings": md.get("ssl_embeddings"),
+        }
+
+    # Group segments by input audio file
+    segments_by_audio: List[List[Dict[str, Any]]] = [[] for _ in abs_paths]
+    for seg in flattened_segments:
+        md = getattr(seg, "metadata", {}) or {}
+        original_file = md.get("original_file")
+        if original_file in abs_paths:
+            idx = abs_paths.index(original_file)
+            segments_by_audio[idx].append(build_json_from_segment(seg))
+    return segments_by_audio

--- a/src/senselab/audio/workflows/explore_conversation.py
+++ b/src/senselab/audio/workflows/explore_conversation.py
@@ -73,7 +73,7 @@ def explore_conversation(
 
     # 3. Downmix to mono and resample to 16kHz
     audios = downmix_audios_to_mono(audios, plugin=plugin)
-    target_sr = 16000
+    target_sr = 16000  # Target sampling rate for most of our supported models
     audios = resample_audios(audios, resample_rate=target_sr, plugin=plugin)
 
     # 4. Speaker diarization
@@ -114,7 +114,6 @@ def explore_conversation(
 
     # 9. Transcribe segments with all provided models
     transcripts_by_model = {}
-    print("transcription_models:", transcription_models)
     for model in transcription_models:
         trans_out = transcribe_audios(audios=flattened_segments, model=model)
         transcripts_by_model[model.path_or_uri] = [t.text for t in trans_out]

--- a/src/senselab/text/tasks/embeddings_extraction/huggingface.py
+++ b/src/senselab/text/tasks/embeddings_extraction/huggingface.py
@@ -57,8 +57,8 @@ class HFFactory:
             m = AutoModel.from_pretrained(
                 model.path_or_uri,
                 revision=model.revision,
-                low_cpu_mem_usage=True,   
-            ).eval()                  
+                low_cpu_mem_usage=True,
+            ).eval()
             if device == DeviceType.CUDA:
                 try:
                     torch.cuda.empty_cache()
@@ -67,8 +67,7 @@ class HFFactory:
                     m = m.to("cpu")
             cls._models[key] = m
         return cls._models[key]
-    
-    
+
     @classmethod
     def extract_text_embeddings(
         cls,

--- a/src/senselab/text/tasks/embeddings_extraction/huggingface.py
+++ b/src/senselab/text/tasks/embeddings_extraction/huggingface.py
@@ -4,8 +4,6 @@ from typing import Dict, List, Optional
 
 import torch
 from transformers import AutoModel, AutoTokenizer
-from transformers.modeling_utils import PreTrainedModel
-from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from senselab.utils.data_structures import DeviceType, HFModel, _select_device_and_dtype
 
@@ -13,27 +11,28 @@ from senselab.utils.data_structures import DeviceType, HFModel, _select_device_a
 class HFFactory:
     """A factory for managing self-supervised models from Hugging Face."""
 
-    _tokenizers: Dict[str, PreTrainedTokenizerBase] = {}
-    _models: Dict[str, PreTrainedModel] = {}
+    _tokenizers: Dict[str, AutoTokenizer] = {}
+    _models: Dict[str, AutoModel] = {}
 
     @classmethod
     def _get_tokenizer(
         cls,
         model: HFModel,
-    ) -> PreTrainedTokenizerBase:
+    ) -> AutoTokenizer:
         """Get or create a tokenizer for SSL model.
 
         Args:
             model (HFModel): The HuggingFace model.
 
         Returns:
-            PreTrainedTokenizerBase: The tokenizer for the model.
+            AutoTokenizer: The tokenizer for the model.
         """
         key = f"{model.path_or_uri}-{model.revision}"
         if key not in cls._tokenizers:
             cls._tokenizers[key] = AutoTokenizer.from_pretrained(
                 pretrained_model_name_or_path=model.path_or_uri,
                 revision=model.revision,
+                use_fast=True,
             )
         return cls._tokenizers[key]
 
@@ -42,7 +41,7 @@ class HFFactory:
         cls,
         model: HFModel,
         device: DeviceType,
-    ) -> PreTrainedModel:
+    ) -> AutoModel:
         """Load weights of SSL model.
 
         Args:
@@ -50,13 +49,26 @@ class HFFactory:
             device (DeviceType): The device to run the model on.
 
         Returns:
-            PreTrainedModel: The SSL model.
+            AutoModel: The SSL model.
         """
         key = f"{model.path_or_uri}-{model.revision}-{device.value}"
-        if key not in cls._models:
-            cls._models[key] = AutoModel.from_pretrained(model.path_or_uri, revision=model.revision).to(device.value)
-        return cls._models[key]
 
+        if key not in cls._models:
+            m = AutoModel.from_pretrained(
+                model.path_or_uri,
+                revision=model.revision,
+                low_cpu_mem_usage=True,   
+            ).eval()                  
+            if device == DeviceType.CUDA:
+                try:
+                    torch.cuda.empty_cache()
+                    m = m.to("cuda", non_blocking=True)
+                except torch.cuda.OutOfMemoryError:
+                    m = m.to("cpu")
+            cls._models[key] = m
+        return cls._models[key]
+    
+    
     @classmethod
     def extract_text_embeddings(
         cls,
@@ -81,8 +93,6 @@ class HFFactory:
         device, _ = _select_device_and_dtype(
             user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]
         )
-
-        print(f"Using device: {device}")
 
         # Load tokenizer and model
         tokenizer = cls._get_tokenizer(model=model)

--- a/src/senselab/utils/data_structures/model.py
+++ b/src/senselab/utils/data_structures/model.py
@@ -136,7 +136,7 @@ class CoquiTTSModel(SenselabModel[PROVIDER_T]):
             raise ModuleNotFoundError(
                 "`coqui-tts` is not installed. "
                 "Please install senselab audio dependencies using "
-                "`pip install 'senselab[audio]'`."
+                "`pip install senselab`."
             )
         if not isinstance(value, Path):
             model_ids = TTS().list_models()
@@ -192,7 +192,7 @@ def check_torchaudio_model_exists(model_id: str) -> bool:
         raise ModuleNotFoundError(
             "`torchaudio` is not installed. "
             "Please install senselab audio dependencies using "
-            "`pip install 'senselab[audio]'`."
+            "`pip install senselab`."
         )
 
     try:

--- a/src/senselab/utils/tasks/eer.py
+++ b/src/senselab/utils/tasks/eer.py
@@ -78,7 +78,7 @@ def compute_eer(predictions: torch.Tensor, targets: torch.Tensor) -> Tuple[float
     if not SPEECHBRAIN_AVAILABLE:
         raise ModuleNotFoundError(
             "`speechbrain` is not installed. "
-            "Please install senselab audio dependencies using `pip install 'senselab[audio]'`."
+            "Please install senselab audio dependencies using `pip install senselab`."
         )
 
     return EER(predictions, targets)

--- a/src/tests/audio/tasks/speaker_embeddings_test.py
+++ b/src/tests/audio/tasks/speaker_embeddings_test.py
@@ -45,6 +45,17 @@ def resnet_model() -> SpeechBrainModel:
     not TORCHAUDIO_AVAILABLE or not SPEECHBRAIN_AVAILABLE, reason="SpeechBrain or torchaudio are not installed"
 )
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU is not available")
+def test_extract_speaker_embeddings_from_empty_audio_list(ecapa_model: SpeechBrainModel) -> None:
+    """Test extracting speaker embeddings from an empty audio list returns an empty list."""
+    embeddings = extract_speaker_embeddings_from_audios(audios=[], model=ecapa_model)
+    assert isinstance(embeddings, list)
+    assert len(embeddings) == 0
+
+
+@pytest.mark.skipif(
+    not TORCHAUDIO_AVAILABLE or not SPEECHBRAIN_AVAILABLE, reason="SpeechBrain or torchaudio are not installed"
+)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU is not available")
 def test_extract_speaker_embeddings_from_audio(
     resampled_mono_audio_sample: Audio,
     ecapa_model: SpeechBrainModel,

--- a/src/tests/audio/workflows/__init__.py
+++ b/src/tests/audio/workflows/__init__.py
@@ -1,0 +1,1 @@
+"""This module contains the tests of the audio workflows."""

--- a/src/tests/audio/workflows/explore_conversation_test.py
+++ b/src/tests/audio/workflows/explore_conversation_test.py
@@ -1,0 +1,36 @@
+"""Unit tests for the explore_conversation utility.
+
+These tests focus on verifying:
+- Output structure
+- Argument handling
+- Edge cases
+"""
+
+import pytest
+
+from senselab.audio.workflows.explore_conversation import explore_conversation
+
+
+def test_explore_conversation_empty_input() -> None:
+    """Test explore_conversation with an empty list of audio files.
+
+    Should return an empty list.
+    """
+    result = explore_conversation(audio_file_paths=[])
+    assert isinstance(result, list)
+    assert len(result) == 0
+
+
+def test_explore_conversation_invalid_file() -> None:
+    """Test explore_conversation with invalid file paths."""
+    with pytest.raises(FileNotFoundError):
+        explore_conversation(audio_file_paths=["nonexistent.wav"])
+
+
+def test_explore_conversation_default_args() -> None:
+    """Test that default arguments are handled correctly."""
+    result = explore_conversation(
+        audio_file_paths=["src/tests/data_for_testing/english_conversation_higgs_audio_v2.wav"]
+    )
+    assert isinstance(result, list)
+    assert len(result) == 1

--- a/tutorials/audio/00_getting_started.ipynb
+++ b/tutorials/audio/00_getting_started.ipynb
@@ -31,7 +31,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 1,
+            "execution_count": null,
             "metadata": {
                 "id": "R-CBmYPgkRJT",
                 "vscode": {
@@ -283,7 +283,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/audio/audio_data_augmentation.ipynb
+++ b/tutorials/audio/audio_data_augmentation.ipynb
@@ -268,7 +268,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/audio/extract_speaker_embeddings.ipynb
+++ b/tutorials/audio/extract_speaker_embeddings.ipynb
@@ -266,7 +266,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/audio/features_extraction.ipynb
+++ b/tutorials/audio/features_extraction.ipynb
@@ -261,7 +261,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/audio/forced_alignment.ipynb
+++ b/tutorials/audio/forced_alignment.ipynb
@@ -264,7 +264,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/audio/speaker_diarization.ipynb
+++ b/tutorials/audio/speaker_diarization.ipynb
@@ -260,7 +260,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/audio/speaker_verification.ipynb
+++ b/tutorials/audio/speaker_verification.ipynb
@@ -262,7 +262,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/audio/speech_emotion_recognition.ipynb
+++ b/tutorials/audio/speech_emotion_recognition.ipynb
@@ -52,7 +52,7 @@
                 "        return False\n",
                 "\n",
                 "if is_colab():\n",
-                "    %pip install 'senselab[audio]'\n",
+                "    %pip install senselab\n",
                 "else:\n",
                 "    print(\"Not running on Colab. Skipping installation.\")"
             ]

--- a/tutorials/audio/speech_enhancement.ipynb
+++ b/tutorials/audio/speech_enhancement.ipynb
@@ -262,7 +262,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/audio/speech_to_text.ipynb
+++ b/tutorials/audio/speech_to_text.ipynb
@@ -268,7 +268,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/audio/text_to_speech.ipynb
+++ b/tutorials/audio/text_to_speech.ipynb
@@ -270,7 +270,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/audio/voice_activity_detection.ipynb
+++ b/tutorials/audio/voice_activity_detection.ipynb
@@ -262,7 +262,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/audio/voice_cloning.ipynb
+++ b/tutorials/audio/voice_cloning.ipynb
@@ -267,7 +267,7 @@
                 }
             ],
             "source": [
-                "%pip install 'senselab[audio]'"
+                "%pip install senselab"
             ]
         },
         {

--- a/tutorials/senselab-ai/senselab_ai_intro.ipynb
+++ b/tutorials/senselab-ai/senselab_ai_intro.ipynb
@@ -24,7 +24,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 1,
+            "execution_count": null,
             "id": "fea76c55",
             "metadata": {
                 "vscode": {
@@ -370,7 +370,7 @@
                 }
             ],
             "source": [
-                "pip install \"senselab[senselab-ai,audio]\""
+                "pip install \"senselab[senselab-ai]\""
             ]
         },
         {


### PR DESCRIPTION
## Description
- integrate audio dependencies into the core
- remove clean-dotenv from pre-commit hooks
- add explore_conversation workflow
- add vocal tract estimate features

## Related Issue(s)
- vocal track estimate feats are related to [this issue](https://github.com/sensein/senselab/issues/193)

## Motivation and Context
- aligned with the paper's draft, senselab is mainly a voice and speech analysis toolkit (with some multimodal utilities). for this reason, it makes sense to have the audio dependencies as part of its core
- clean-dotenv keeps adding a .env.example file, but we already have env.example file
- explore_conversation is a nice pipeline for doing speaker diarization, feats and embeddings extraction, and transcription under one single command
- it's a good thing to extend the list of supported audio features

## How Has This Been Tested?
unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue - this is the case of extracting speaker embeddings from an empty list of audio objects)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change - pip install senselab installs all audio dependencies now)

## Checklist:
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.