### PR TITLE
FIX: issue with `poetry build` generating `0.0.0` releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,12 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent"
 ]
-version = "0.0.0"
+
 
 [tool.poetry]
 packages = [{include = "senselab", from = "src"}]
 requires-poetry = ">=2.0"
+version = "0.0.0"
 
 [tool.poetry.dependencies]
 torch = {version = "~=2.8.0", markers = "sys_platform != 'darwin' or platform_machine == 'arm64'"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 
-
 [tool.poetry]
 packages = [{include = "senselab", from = "src"}]
 requires-poetry = ">=2.0"


### PR DESCRIPTION
## Description
This fixes the issue with `poetry build` generating `0.0.0` releases. I will manually build and push the last two releases so that they are available on pypi. However, we should also figure out how we can update the versions in the source files created by auto. `poetry build` access the git tag history to know what release it is. if someone uses source from github releases, pip won't know what version it is installing. this is not encoded anywhere in the metadata of the source.

closes #424 

## Motivation and Context
the PyPI pushes have failed since 1.2.0

## How Has This Been Tested?
tested locally on computer.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
