### PR TITLE
feat: add conversation analysis workflow

### DIFF
--- a/docs/conversation-analysis-workflow-plan.md
+++ b/docs/conversation-analysis-workflow-plan.md
@@ -1,0 +1,176 @@
+# Conversation Analysis Workflow Plan
+
+## Goal
+
+Build a Zoom-oriented conversation analysis workflow that composes existing Senselab capabilities to produce:
+
+- transcripts with heuristic accuracy estimates
+- diarization and speaker-level turn summaries
+- acoustic, linguistic, emotional, and engagement-related features
+- turn-taking dynamics and interruption statistics
+- sparse phonetic posteriorgram summaries with onset/offset timing
+- environment/context summaries from captured audio conditions
+- automated checks for each processing step
+
+## Existing Senselab Capabilities We Should Reuse
+
+- `senselab.audio.tasks.speech_to_text.transcribe_audios`
+- `senselab.audio.tasks.speaker_diarization.diarize_audios`
+- `senselab.audio.tasks.features_extraction.extract_features_from_audios`
+- `senselab.audio.tasks.features_extraction.extract_ppgs_from_audios`
+- `senselab.audio.tasks.speaker_embeddings.extract_speaker_embeddings_from_audios`
+- `senselab.audio.tasks.ssl_embeddings.extract_ssl_embeddings_from_audios`
+- `senselab.audio.tasks.classification.speech_emotion_recognition.classify_emotions_from_speech`
+- `senselab.audio.tasks.quality_control` metrics/checks for environmental and preprocessing validation
+- `senselab.video.tasks.input_output` patterns for extracting audio from video recordings
+- existing `explore_conversation` workflow as the nearest workflow baseline
+
+## Proposed Workflow
+
+### Inputs
+
+- one or more Zoom recordings as audio or video files
+- optional explicit model choices for ASR, diarization, speech emotion recognition, speaker embeddings, and SSL embeddings
+- optional toggles for PPG extraction, speaker embeddings, SSL embeddings, and environment context evaluation
+
+### Processing Stages
+
+1. Ingest
+   - accept local audio/video paths
+   - extract audio from video when needed
+   - validate file existence and supported extensions
+
+2. Preprocessing
+   - read audio
+   - downmix to mono
+   - resample to 16 kHz
+   - record preprocessing checks
+
+3. Recording-level checks
+   - silence/clipping/headroom/dynamic range/SNR checks
+   - summarize environment context from QC metrics
+
+4. Diarization and turn segmentation
+   - diarize recording into speaker turns
+   - extract turn-level audio segments
+   - compute turn duration, pause/gap, overlap, interruption, speaker-switch statistics
+
+5. Transcription
+   - transcribe each turn
+   - support one or more ASR models
+   - estimate transcript accuracy heuristically:
+     - multi-model transcript consensus when multiple ASR models are used
+     - timestamp-coverage heuristic when only one model is used
+
+6. Turn-level features
+   - acoustic features from Parselmouth/OpenSMILE/torchaudio outputs
+   - linguistic features from transcripts:
+     - lexical richness
+     - word choice markers
+     - syntax-lite sentence/utterance statistics
+     - discourse markers
+   - dialogue act heuristics:
+     - question
+     - command/request
+     - acknowledgement
+     - greeting/closing
+     - statement
+   - engagement markers:
+     - backchanneling
+     - politeness cues
+     - short acknowledgement turns
+   - emotional states:
+     - lexical sentiment heuristic
+     - optional speech emotion recognition model output
+
+7. Optional speaker/representation outputs
+   - speaker embeddings
+   - SSL embeddings
+   - sparse PPG summaries with phoneme-like onset/offset segments
+
+8. Recording-level summary
+   - speaker inventory and speaker statistics
+   - turn-taking summary
+   - emotion summary
+   - engagement summary
+   - environment/context summary
+   - checks by step
+
+## Output Shape
+
+Return one dictionary per input recording with:
+
+- `source_file`
+- `derived_audio_file` when video extraction is used
+- `checks`
+- `environment_context`
+- `speaker_summary`
+- `turn_taking`
+- `turns`
+- `transcript_summary`
+
+Each turn should include:
+
+- `speaker_id`
+- `start`
+- `end`
+- `duration_seconds`
+- `transcripts`
+- `transcript_accuracy_estimate`
+- `transcript_accuracy_estimate_method`
+- `acoustic_features`
+- `linguistic_features`
+- `dialogue_acts`
+- `engagement_markers`
+- `emotion`
+- `speaker_embeddings`
+- `ssl_embeddings`
+- `ppg_summary`
+- `checks`
+
+## TDD Implementation Plan
+
+- [ ] Add a design doc and task checklist
+- [ ] Add CPU-safe unit tests for text and turn-taking analytics helpers
+- [ ] Add CPU-safe workflow orchestration tests using mocks for heavy models
+- [ ] Implement recording/turn summary helpers
+- [ ] Implement automated step checks
+- [ ] Implement the new conversation-analysis workflow
+- [ ] Export the workflow from `senselab.audio.workflows`
+- [ ] Run targeted CPU-safe tests
+- [ ] Mark heavy integration smoke tests for later CUDA validation when useful
+
+## Testing Strategy
+
+### CPU-safe now
+
+- helper tests for linguistic features, dialogue acts, engagement markers, transcript consensus, turn-taking statistics, and PPG summarization
+- orchestration tests with monkeypatched task backends
+- error handling tests for invalid paths and empty inputs
+
+### CUDA follow-up
+
+No part of the orchestration layer strictly requires a GPU, but full end-to-end smoke tests with large pretrained backends are still best validated when CUDA is available:
+
+- diarization smoke tests
+- multi-model ASR smoke tests
+- speech emotion recognition smoke tests
+- speaker embedding/SSL embedding smoke tests
+- PPG extraction smoke tests
+
+These should be treated as integration validation, not blockers for CPU-first unit coverage.
+
+## Key Design Decisions
+
+- Prefer a new workflow over overloading `explore_conversation`, so we can preserve backward compatibility while adding richer outputs.
+- Keep text analytics heuristic and dependency-light for the first version.
+- Treat transcript accuracy as an estimate, not a ground-truth metric.
+- Reuse existing feature extractors instead of introducing new model dependencies unless clearly necessary.
+- Represent automated checks explicitly at both recording and turn granularity so failures are inspectable.
+
+## Risks
+
+- Zoom recordings can be video-only, audio-only, mono, stereo, or noisy, so ingestion and preprocessing checks must be robust.
+- Some downstream models are heavy and slow on CPU; unit tests must mock them.
+- Dialogue-act and politeness detection will begin as heuristics and should be labeled accordingly in outputs and docs.
+- PPG tensor shapes can vary, so summarization should be shape-tolerant and degrade gracefully.

--- a/src/senselab/audio/workflows/__init__.py
+++ b/src/senselab/audio/workflows/__init__.py
@@ -1,3 +1,17 @@
 """Workflows and pipelines for audio processing and analysis."""
 
-from .explore_conversation import explore_conversation  # noqa: F401
+from typing import Any
+
+
+def analyze_conversation_recordings(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy export for the conversation analysis workflow."""
+    from .conversation_analysis import analyze_conversation_recordings as _analyze_conversation_recordings
+
+    return _analyze_conversation_recordings(*args, **kwargs)
+
+
+def explore_conversation(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy export for the original conversation exploration workflow."""
+    from .explore_conversation import explore_conversation as _explore_conversation
+
+    return _explore_conversation(*args, **kwargs)

--- a/src/senselab/audio/workflows/conversation_analysis.py
+++ b/src/senselab/audio/workflows/conversation_analysis.py
@@ -1,0 +1,833 @@
+"""Conversation analysis workflow for multi-speaker recordings."""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from collections import Counter, defaultdict
+from difflib import SequenceMatcher
+from pathlib import Path
+from statistics import mean
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+import torch
+
+from senselab.audio.data_structures import Audio, AudioClassificationResult
+from senselab.audio.tasks.quality_control.metrics import (
+    amplitude_headroom_metric,
+    dynamic_range_metric,
+    proportion_clipped_metric,
+    proportion_silent_metric,
+    spectral_gating_snr_metric,
+)
+from senselab.utils.data_structures import DeviceType, HFModel, ScriptLine
+
+AUDIO_EXTENSIONS = {".wav", ".mp3", ".m4a", ".flac", ".ogg", ".aac"}
+VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv", ".webm", ".avi", ".m4v"}
+
+BACKCHANNEL_CUES = {
+    "yeah",
+    "yep",
+    "right",
+    "okay",
+    "ok",
+    "uh-huh",
+    "mm-hmm",
+    "sure",
+    "got it",
+}
+DISCOURSE_MARKERS = {
+    "well",
+    "so",
+    "like",
+    "actually",
+    "basically",
+    "anyway",
+    "however",
+    "therefore",
+    "because",
+}
+POLITENESS_CUES = {"please", "thanks", "thank", "sorry", "excuse"}
+POSITIVE_SENTIMENT_CUES = {"good", "great", "happy", "glad", "love", "excellent", "thanks"}
+NEGATIVE_SENTIMENT_CUES = {"bad", "sad", "angry", "upset", "hate", "worry", "problem"}
+QUESTION_PREFIXES = {"who", "what", "when", "where", "why", "how", "can", "could", "would", "will", "do", "did"}
+REQUEST_PREFIXES = {"please", "can", "could", "would", "help", "let", "let's"}
+COMMAND_PREFIXES = {"please", "do", "tell", "show", "look", "check", "start", "stop"}
+
+
+def read_audios(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy wrapper for audio loading."""
+    from senselab.audio.tasks.input_output.utils import read_audios as _read_audios
+
+    return _read_audios(*args, **kwargs)
+
+
+def downmix_audios_to_mono(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy wrapper for mono downmixing."""
+    from senselab.audio.tasks.preprocessing.preprocessing import downmix_audios_to_mono as _downmix
+
+    return _downmix(*args, **kwargs)
+
+
+def resample_audios(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy wrapper for resampling."""
+    from senselab.audio.tasks.preprocessing.preprocessing import resample_audios as _resample
+
+    return _resample(*args, **kwargs)
+
+
+def extract_segments(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy wrapper for segment extraction."""
+    from senselab.audio.tasks.preprocessing.preprocessing import extract_segments as _extract_segments
+
+    return _extract_segments(*args, **kwargs)
+
+
+def diarize_audios(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy wrapper for speaker diarization."""
+    from senselab.audio.tasks.speaker_diarization import diarize_audios as _diarize_audios
+
+    return _diarize_audios(*args, **kwargs)
+
+
+def transcribe_audios(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy wrapper for transcription."""
+    from senselab.audio.tasks.speech_to_text import transcribe_audios as _transcribe_audios
+
+    return _transcribe_audios(*args, **kwargs)
+
+
+def extract_features_from_audios(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy wrapper for multi-backend acoustic features."""
+    from senselab.audio.tasks.features_extraction import extract_features_from_audios as _extract_features
+
+    return _extract_features(*args, **kwargs)
+
+
+def extract_ppgs_from_audios(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy wrapper for PPG extraction."""
+    from senselab.audio.tasks.features_extraction.ppg import extract_ppgs_from_audios as _extract_ppgs
+
+    return _extract_ppgs(*args, **kwargs)
+
+
+def classify_emotions_from_speech(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy wrapper for speech emotion recognition."""
+    from senselab.audio.tasks.classification.speech_emotion_recognition import (
+        classify_emotions_from_speech as _classify_emotions,
+    )
+
+    return _classify_emotions(*args, **kwargs)
+
+
+def extract_speaker_embeddings_from_audios(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy wrapper for speaker embeddings."""
+    from senselab.audio.tasks.speaker_embeddings import (
+        extract_speaker_embeddings_from_audios as _extract_speaker_embeddings,
+    )
+
+    return _extract_speaker_embeddings(*args, **kwargs)
+
+
+def extract_ssl_embeddings_from_audios(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+    """Lazy wrapper for SSL embeddings."""
+    from senselab.audio.tasks.ssl_embeddings import extract_ssl_embeddings_from_audios as _extract_ssl_embeddings
+
+    return _extract_ssl_embeddings(*args, **kwargs)
+
+
+def analyze_conversation_recordings(
+    recording_file_paths: Sequence[str | os.PathLike],
+    diarization_model: Optional[Any] = None,  # noqa: ANN401
+    transcription_models: Optional[Sequence[Any]] = None,  # noqa: ANN401
+    features_config: Optional[Dict[str, Any]] = None,
+    speaker_embeddings_models: Optional[Sequence[Any]] = None,  # noqa: ANN401
+    ssl_embeddings_models: Optional[Sequence[Any]] = None,  # noqa: ANN401
+    emotion_model: Optional[Any] = None,  # noqa: ANN401
+    include_ppgs: bool = False,
+    device: Optional[DeviceType] = None,
+) -> List[Dict[str, Any]]:
+    """Analyze multi-speaker conversation recordings.
+
+    Args:
+        recording_file_paths: Audio or video recordings to analyze.
+        diarization_model: Optional diarization model. Defaults to Pyannote community diarization.
+        transcription_models: Optional ASR model list. Defaults to Whisper tiny.
+        features_config: Optional feature backend configuration.
+        speaker_embeddings_models: Optional speaker embedding models. If omitted, speaker embeddings are skipped.
+        ssl_embeddings_models: Optional SSL embedding models. If omitted, SSL embeddings are skipped.
+        emotion_model: Optional speech emotion recognition model.
+        include_ppgs: Whether to attempt PPG extraction.
+        device: Optional device for model-backed stages.
+
+    Returns:
+        One result dictionary per input recording.
+    """
+    if not recording_file_paths:
+        return []
+
+    resolved_source_paths = [str(Path(path).expanduser().resolve()) for path in recording_file_paths]
+    prepared_audio_paths = _prepare_recording_audio_files(resolved_source_paths)
+
+    if transcription_models is None:
+        transcription_models = [HFModel(path_or_uri="openai/whisper-tiny")]
+    if features_config is None:
+        features_config = {"opensmile": True, "parselmouth": True, "torchaudio": False, "torchaudio_squim": False}
+
+    recording_audios = read_audios(prepared_audio_paths)
+    recording_audios = downmix_audios_to_mono(recording_audios)
+    recording_audios = resample_audios(recording_audios, resample_rate=16000)
+
+    recording_checks = [_build_recording_checks(audio) for audio in recording_audios]
+    diarization_results = diarize_audios(audios=recording_audios, model=diarization_model, device=device)
+    segments_info = _collect_segment_boundaries(recording_audios, diarization_results)
+    segmented_audios_list = extract_segments(segments_info)
+    flattened_segments = [segment for group in segmented_audios_list for segment in group]
+
+    transcript_outputs: Dict[str, List[ScriptLine]] = {}
+    for model in transcription_models:
+        model_name = getattr(model, "path_or_uri", str(model))
+        transcript_outputs[str(model_name)] = transcribe_audios(
+            audios=flattened_segments,
+            model=model,
+            device=device,
+        )
+
+    feature_outputs = extract_features_from_audios(
+        audios=flattened_segments,
+        opensmile=features_config.get("opensmile", True),
+        parselmouth=features_config.get("parselmouth", True),
+        torchaudio=features_config.get("torchaudio", False),
+        torchaudio_squim=bool(features_config.get("torchaudio_squim", False)),
+        device=device,
+        sparc=features_config.get("sparc"),
+        ppgs=False,
+    )
+
+    emotion_outputs: Optional[List[AudioClassificationResult]] = None
+    emotion_error: Optional[str] = None
+    if emotion_model is not None and flattened_segments:
+        try:
+            emotion_outputs = classify_emotions_from_speech(flattened_segments, model=emotion_model, device=device)
+        except Exception as exc:  # pragma: no cover - defensive orchestration
+            emotion_error = str(exc)
+
+    speaker_embedding_outputs: Dict[str, List[List[float]]] = {}
+    speaker_embedding_error: Optional[str] = None
+    if speaker_embeddings_models:
+        try:
+            for model in speaker_embeddings_models:
+                model_name = str(getattr(model, "path_or_uri", model))
+                embeddings = extract_speaker_embeddings_from_audios(
+                    audios=flattened_segments,
+                    model=model,
+                    device=device,
+                )
+                speaker_embedding_outputs[model_name] = [_tensor_to_list(embedding) for embedding in embeddings]
+        except Exception as exc:  # pragma: no cover - defensive orchestration
+            speaker_embedding_error = str(exc)
+
+    ssl_embedding_outputs: Dict[str, List[List[float]]] = {}
+    ssl_embedding_error: Optional[str] = None
+    if ssl_embeddings_models:
+        try:
+            for model in ssl_embeddings_models:
+                model_name = str(getattr(model, "path_or_uri", model))
+                embeddings = extract_ssl_embeddings_from_audios(audios=flattened_segments, model=model, device=device)
+                ssl_embedding_outputs[model_name] = [_pool_embedding(embedding) for embedding in embeddings]
+        except Exception as exc:  # pragma: no cover - defensive orchestration
+            ssl_embedding_error = str(exc)
+
+    ppg_outputs: Optional[List[Dict[str, Any]]] = None
+    ppg_error: Optional[str] = None
+    if include_ppgs and flattened_segments:
+        try:
+            ppg_tensors = extract_ppgs_from_audios(flattened_segments, device=device)
+            ppg_outputs = [
+                _summarize_ppg_segments(audio=audio, posteriorgram=posteriorgram)
+                for audio, posteriorgram in zip(flattened_segments, ppg_tensors)
+            ]
+        except Exception as exc:  # pragma: no cover - defensive orchestration
+            ppg_error = str(exc)
+
+    results: List[Dict[str, Any]] = []
+    offset = 0
+    primary_model_name = next(iter(transcript_outputs.keys()))
+
+    for index, (source_file, audio_file, recording_audio, diarization_lines, segment_group) in enumerate(
+        zip(resolved_source_paths, prepared_audio_paths, recording_audios, diarization_results, segmented_audios_list)
+    ):
+        turns: List[Dict[str, Any]] = []
+
+        for local_index, (segment, diarization_line) in enumerate(zip(segment_group, diarization_lines)):
+            global_index = offset + local_index
+            transcript_map = {
+                model_name: (lines[global_index].text or "")
+                for model_name, lines in transcript_outputs.items()
+            }
+            primary_script_line = transcript_outputs[primary_model_name][global_index]
+            transcript_accuracy = _estimate_transcript_accuracy(transcript_map, primary_script_line)
+            primary_text = transcript_map[primary_model_name]
+
+            linguistic_features = _extract_linguistic_features(primary_text)
+            dialogue_acts = _extract_dialogue_acts(primary_text)
+            engagement_markers = _extract_engagement_markers(primary_text)
+            acoustic_features = _extract_acoustic_features(feature_outputs[global_index])
+            lexical_sentiment = _estimate_lexical_sentiment(primary_text)
+            speech_emotion = (
+                _format_emotion_result(emotion_outputs[global_index]) if emotion_outputs is not None else None
+            )
+            emotion_summary = {
+                "top_label": speech_emotion["top_label"] if speech_emotion else lexical_sentiment["label"],
+                "top_score": speech_emotion["top_score"] if speech_emotion else lexical_sentiment["score"],
+                "lexical_sentiment": lexical_sentiment,
+                "speech_emotion": speech_emotion,
+            }
+
+            turn_result = {
+                "speaker_id": diarization_line.speaker,
+                "start": diarization_line.start,
+                "end": diarization_line.end,
+                "duration_seconds": _segment_duration_seconds(diarization_line),
+                "transcripts": transcript_map,
+                "transcript_accuracy_estimate": transcript_accuracy["score"],
+                "transcript_accuracy_estimate_method": transcript_accuracy["method"],
+                "transcript_accuracy_details": transcript_accuracy,
+                "acoustic_features": acoustic_features,
+                "linguistic_features": linguistic_features,
+                "dialogue_acts": dialogue_acts,
+                "engagement_markers": engagement_markers,
+                "emotion": emotion_summary,
+                "speaker_embeddings": {
+                    model_name: values[global_index] for model_name, values in speaker_embedding_outputs.items()
+                },
+                "ssl_embeddings": {
+                    model_name: values[global_index] for model_name, values in ssl_embedding_outputs.items()
+                },
+                "ppg_summary": ppg_outputs[global_index] if ppg_outputs is not None else None,
+                "checks": _build_turn_checks(
+                    transcript_text=primary_text,
+                    acoustic_features=acoustic_features,
+                    ppg_summary=ppg_outputs[global_index] if ppg_outputs is not None else None,
+                ),
+            }
+            turns.append(turn_result)
+
+        offset += len(segment_group)
+        checks = dict(recording_checks[index])
+        checks["diarization"] = {"passed": len(diarization_lines) > 0, "turn_count": len(diarization_lines)}
+        checks["transcription"] = {
+            "passed": len(turns) == len(segment_group),
+            "model_count": len(transcript_outputs),
+        }
+        checks["features"] = {"passed": len(segment_group) == len(turns)}
+        checks["emotion"] = {"passed": emotion_error is None, "error": emotion_error}
+        checks["speaker_embeddings"] = {"passed": speaker_embedding_error is None, "error": speaker_embedding_error}
+        checks["ssl_embeddings"] = {"passed": ssl_embedding_error is None, "error": ssl_embedding_error}
+        checks["ppgs"] = {"passed": ppg_error is None, "error": ppg_error}
+
+        results.append(
+            {
+                "source_file": source_file,
+                "derived_audio_file": None if source_file == audio_file else audio_file,
+                "checks": checks,
+                "environment_context": _summarize_environment_context(checks),
+                "speaker_summary": _summarize_speakers(turns),
+                "turn_taking": _summarize_turn_taking(turns),
+                "turns": turns,
+                "transcript_summary": _summarize_transcripts(turns, primary_model_name),
+                "recording_duration_seconds": _audio_duration_seconds(recording_audio),
+            }
+        )
+
+    return results
+
+
+def _prepare_recording_audio_files(recording_file_paths: Sequence[str | os.PathLike]) -> List[str]:
+    """Resolve recordings to audio files, extracting video audio when needed."""
+    prepared_audio_paths: List[str] = []
+
+    for file_path in recording_file_paths:
+        path = Path(file_path).expanduser().resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"Recording file does not exist: {path}")
+
+        suffix = path.suffix.lower()
+        if suffix in AUDIO_EXTENSIONS:
+            prepared_audio_paths.append(str(path))
+            continue
+        if suffix in VIDEO_EXTENSIONS:
+            prepared_audio_paths.append(_extract_audio_from_video(path))
+            continue
+
+        raise ValueError(f"Unsupported recording format: {path.suffix}")
+
+    return prepared_audio_paths
+
+
+def _extract_audio_from_video(video_path: Path) -> str:
+    """Extract a mono WAV audio track from a local video recording."""
+    import ffmpeg
+
+    output_dir = Path(tempfile.mkdtemp(prefix="senselab-conversation-audio-"))
+    output_path = output_dir / f"{video_path.stem}.wav"
+
+    audio_stream = ffmpeg.input(str(video_path)).audio.output(str(output_path), format="wav", acodec="pcm_s16le")
+    ffmpeg.run(audio_stream, overwrite_output=True, quiet=True)
+    return str(output_path)
+
+
+def _collect_segment_boundaries(
+    audios: Sequence[Audio],
+    diarization_results: Sequence[Sequence[ScriptLine]],
+) -> List[tuple[Audio, List[tuple[float, float]]]]:
+    """Collect segment boundaries suitable for `extract_segments`."""
+    segments_info: List[tuple[Audio, List[tuple[float, float]]]] = []
+
+    for audio, script_lines in zip(audios, diarization_results):
+        boundaries = [
+            (line.start, line.end)
+            for line in script_lines
+            if line.start is not None and line.end is not None and line.end > line.start
+        ]
+        segments_info.append((audio, boundaries))
+
+    return segments_info
+
+
+def _estimate_transcript_accuracy(
+    transcripts: Dict[str, str],
+    primary_script_line: Optional[ScriptLine] = None,
+) -> Dict[str, Any]:
+    """Estimate transcript reliability from model agreement or timestamp coverage."""
+    normalized_transcripts = {
+        model_name: " ".join(_tokenize_text(text))
+        for model_name, text in transcripts.items()
+        if text and _tokenize_text(text)
+    }
+
+    if len(normalized_transcripts) > 1:
+        model_names = list(normalized_transcripts.keys())
+        similarities: List[float] = []
+        for index, model_name in enumerate(model_names):
+            for comparison_name in model_names[index + 1 :]:
+                similarities.append(
+                    SequenceMatcher(
+                        None,
+                        normalized_transcripts[model_name],
+                        normalized_transcripts[comparison_name],
+                    ).ratio()
+                )
+        score = float(mean(similarities)) if similarities else 0.0
+        return {
+            "score": round(score, 4),
+            "method": "multi_model_consensus",
+            "model_count": len(normalized_transcripts),
+            "pairwise_similarity_mean": round(score, 4),
+        }
+
+    if primary_script_line is not None:
+        tokens = _tokenize_text(primary_script_line.text or "")
+        if tokens and primary_script_line.chunks:
+            chunk_count = sum(1 for chunk in primary_script_line.chunks if chunk.text)
+            score = min(1.0, chunk_count / max(len(tokens), 1))
+            return {
+                "score": round(score, 4),
+                "method": "timestamp_coverage",
+                "timestamped_chunk_count": chunk_count,
+                "token_count": len(tokens),
+            }
+
+    text = next(iter(transcripts.values()), "")
+    token_count = len(_tokenize_text(text))
+    score = min(0.75, 0.35 + 0.05 * token_count) if token_count else 0.0
+    return {
+        "score": round(score, 4),
+        "method": "single_model_heuristic",
+        "token_count": token_count,
+    }
+
+
+def _extract_linguistic_features(text: str) -> Dict[str, Any]:
+    """Extract lightweight lexical and syntax-oriented transcript features."""
+    tokens = _tokenize_text(text)
+    lower_tokens = [token.lower() for token in tokens]
+    token_counter = Counter(lower_tokens)
+    sentence_fragments = [fragment for fragment in re.split(r"[.!?]+", text) if fragment.strip()]
+
+    discourse_markers = sorted({token for token in lower_tokens if token in DISCOURSE_MARKERS})
+    politeness_cues = sorted({token for token in lower_tokens if token in POLITENESS_CUES})
+
+    return {
+        "token_count": len(lower_tokens),
+        "unique_token_count": len(set(lower_tokens)),
+        "type_token_ratio": round(len(set(lower_tokens)) / len(lower_tokens), 4) if lower_tokens else 0.0,
+        "mean_token_length": round(mean(len(token) for token in lower_tokens), 4) if lower_tokens else 0.0,
+        "sentence_count": len(sentence_fragments) or (1 if text.strip() else 0),
+        "mean_sentence_length_tokens": round(
+            len(lower_tokens) / max(len(sentence_fragments), 1),
+            4,
+        )
+        if lower_tokens
+        else 0.0,
+        "pronoun_count": sum(token_counter[token] for token in {"i", "you", "we", "they", "he", "she"}),
+        "discourse_markers": discourse_markers,
+        "politeness_cues": politeness_cues,
+    }
+
+
+def _extract_dialogue_acts(text: str) -> List[str]:
+    """Infer coarse dialogue acts from transcript text."""
+    tokens = _tokenize_text(text)
+    lower_tokens = [token.lower() for token in tokens]
+    if not lower_tokens:
+        return []
+
+    stripped_text = text.strip().lower()
+    acts: List[str] = []
+
+    if text.strip().endswith("?") or lower_tokens[0] in QUESTION_PREFIXES:
+        acts.append("question")
+    if any(token in POLITENESS_CUES for token in lower_tokens) or lower_tokens[0] in REQUEST_PREFIXES:
+        acts.append("request")
+    if lower_tokens[0] in COMMAND_PREFIXES and "question" not in acts:
+        acts.append("command")
+    if stripped_text in {"hi", "hello", "hey"} or lower_tokens[0] in {"hi", "hello", "hey"}:
+        acts.append("greeting")
+    if any(cue in stripped_text for cue in {"bye", "goodbye", "see you"}):
+        acts.append("closing")
+    if any(token in BACKCHANNEL_CUES for token in lower_tokens):
+        acts.append("acknowledgement")
+    if not acts:
+        acts.append("statement")
+
+    return sorted(set(acts))
+
+
+def _extract_engagement_markers(text: str) -> Dict[str, Any]:
+    """Infer engagement-related cues from transcript text."""
+    lower_tokens = [token.lower() for token in _tokenize_text(text)]
+    backchannel_cues = sorted({token for token in lower_tokens if token in BACKCHANNEL_CUES})
+    politeness_cues = sorted({token for token in lower_tokens if token in POLITENESS_CUES})
+
+    is_backchannel = bool(backchannel_cues) and len(lower_tokens) <= 4
+    return {
+        "is_backchannel": is_backchannel,
+        "backchannel_cues": backchannel_cues,
+        "politeness_cues": politeness_cues,
+        "engagement_score": round(min(1.0, 0.25 * len(backchannel_cues) + 0.25 * len(politeness_cues)), 4),
+    }
+
+
+def _estimate_lexical_sentiment(text: str) -> Dict[str, Any]:
+    """Estimate lexical sentiment from simple polarity cues."""
+    lower_tokens = [token.lower() for token in _tokenize_text(text)]
+    positive = sum(1 for token in lower_tokens if token in POSITIVE_SENTIMENT_CUES)
+    negative = sum(1 for token in lower_tokens if token in NEGATIVE_SENTIMENT_CUES)
+
+    if positive > negative:
+        label = "positive"
+    elif negative > positive:
+        label = "negative"
+    else:
+        label = "neutral"
+
+    total = max(len(lower_tokens), 1)
+    score = abs(positive - negative) / total
+    return {
+        "label": label,
+        "score": round(score, 4),
+        "positive_cue_count": positive,
+        "negative_cue_count": negative,
+    }
+
+
+def _extract_acoustic_features(feature_bundle: Dict[str, Any]) -> Dict[str, Any]:
+    """Map backend-specific features onto conversation-oriented acoustic summaries."""
+    praat_features = feature_bundle.get("praat_parselmouth", {})
+    opensmile_features = feature_bundle.get("opensmile", {})
+
+    return {
+        "pitch_hz": _first_present(praat_features, ["mean_f0_hertz", "pitch_floor"]),
+        "energy_db": _first_present(praat_features, ["mean_intensity_db"]),
+        "speech_rate": _first_present(praat_features, ["speaking_rate", "articulation_rate"]),
+        "pause_duration_seconds": _first_present(praat_features, ["mean_pause_duration", "mean_pause_dur"]),
+        "pause_rate": _first_present(praat_features, ["pause_rate"]),
+        "loudness": _first_present(opensmile_features, ["loudness_sma3_amean"]),
+        "raw_features": feature_bundle,
+    }
+
+
+def _summarize_turn_taking(turns: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """Summarize turn-taking dynamics for a recording."""
+    if not turns:
+        return {
+            "turn_count": 0,
+            "speaker_switch_count": 0,
+            "interruption_count": 0,
+            "overlap_count": 0,
+            "mean_gap_duration_seconds": 0.0,
+            "mean_turn_duration_seconds": 0.0,
+        }
+
+    sorted_turns = sorted(turns, key=lambda turn: (turn.get("start") or 0.0, turn.get("end") or 0.0))
+    speaker_switch_count = 0
+    interruption_count = 0
+    overlap_count = 0
+    gap_durations: List[float] = []
+
+    for current_turn, next_turn in zip(sorted_turns, sorted_turns[1:]):
+        if current_turn.get("speaker_id") != next_turn.get("speaker_id"):
+            speaker_switch_count += 1
+
+        current_end = current_turn.get("end") or 0.0
+        next_start = next_turn.get("start") or 0.0
+        gap = next_start - current_end
+        gap_durations.append(max(gap, 0.0))
+
+        if gap < 0:
+            overlap_count += 1
+            if current_turn.get("speaker_id") != next_turn.get("speaker_id"):
+                interruption_count += 1
+
+    return {
+        "turn_count": len(sorted_turns),
+        "speaker_switch_count": speaker_switch_count,
+        "interruption_count": interruption_count,
+        "overlap_count": overlap_count,
+        "mean_gap_duration_seconds": round(mean(gap_durations), 4) if gap_durations else 0.0,
+        "mean_turn_duration_seconds": round(
+            mean(float(turn.get("duration_seconds") or 0.0) for turn in sorted_turns),
+            4,
+        ),
+    }
+
+
+def _summarize_speakers(turns: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """Summarize speaker-level participation."""
+    speaker_stats: Dict[str, Dict[str, Any]] = defaultdict(
+        lambda: {"turn_count": 0, "total_duration_seconds": 0.0, "word_count": 0}
+    )
+
+    for turn in turns:
+        speaker_id = turn.get("speaker_id") or "unknown"
+        speaker_stats[speaker_id]["turn_count"] += 1
+        speaker_stats[speaker_id]["total_duration_seconds"] += float(turn.get("duration_seconds") or 0.0)
+        primary_transcript = next(iter((turn.get("transcripts") or {}).values()), "")
+        speaker_stats[speaker_id]["word_count"] += len(_tokenize_text(primary_transcript))
+
+    for stats in speaker_stats.values():
+        stats["mean_turn_duration_seconds"] = round(
+            stats["total_duration_seconds"] / max(stats["turn_count"], 1),
+            4,
+        )
+
+    return {
+        "speaker_count": len(speaker_stats),
+        "speakers": dict(speaker_stats),
+    }
+
+
+def _summarize_transcripts(turns: Sequence[Dict[str, Any]], primary_model_name: str) -> Dict[str, Any]:
+    """Summarize transcript outputs across a recording."""
+    primary_texts = [turn["transcripts"].get(primary_model_name, "") for turn in turns]
+    accuracy_scores = [float(turn.get("transcript_accuracy_estimate") or 0.0) for turn in turns]
+
+    return {
+        "primary_model": primary_model_name,
+        "full_text": " ".join(text.strip() for text in primary_texts if text.strip()),
+        "turn_count": len(turns),
+        "mean_accuracy_estimate": round(mean(accuracy_scores), 4) if accuracy_scores else 0.0,
+    }
+
+
+def _summarize_ppg_segments(audio: Audio, posteriorgram: torch.Tensor) -> Dict[str, Any]:
+    """Convert framewise posteriorgrams into sparse onset/offset segments."""
+    if not isinstance(posteriorgram, torch.Tensor) or posteriorgram.ndim != 2 or posteriorgram.numel() == 0:
+        return {"frame_count": 0, "segment_count": 0, "segments": []}
+
+    if torch.isnan(posteriorgram).all():
+        return {"frame_count": 0, "segment_count": 0, "segments": []}
+
+    frame_count = int(posteriorgram.shape[0])
+    duration_seconds = _audio_duration_seconds(audio)
+    seconds_per_frame = duration_seconds / max(frame_count, 1)
+
+    best_labels = posteriorgram.argmax(dim=1).tolist()
+    best_scores = posteriorgram.max(dim=1).values.tolist()
+
+    segments: List[Dict[str, Any]] = []
+    start_index = 0
+    current_label = best_labels[0]
+    current_scores = [float(best_scores[0])]
+
+    for frame_index in range(1, frame_count):
+        if best_labels[frame_index] == current_label:
+            current_scores.append(float(best_scores[frame_index]))
+            continue
+
+        segments.append(
+            {
+                "label_index": int(current_label),
+                "start_frame": start_index,
+                "end_frame": frame_index - 1,
+                "start_seconds": round(start_index * seconds_per_frame, 6),
+                "end_seconds": round(frame_index * seconds_per_frame, 6),
+                "mean_confidence": round(mean(current_scores), 6),
+            }
+        )
+        start_index = frame_index
+        current_label = best_labels[frame_index]
+        current_scores = [float(best_scores[frame_index])]
+
+    segments.append(
+        {
+            "label_index": int(current_label),
+            "start_frame": start_index,
+            "end_frame": frame_count - 1,
+            "start_seconds": round(start_index * seconds_per_frame, 6),
+            "end_seconds": round(duration_seconds, 6),
+            "mean_confidence": round(mean(current_scores), 6),
+        }
+    )
+
+    return {"frame_count": frame_count, "segment_count": len(segments), "segments": segments}
+
+
+def _build_recording_checks(audio: Audio) -> Dict[str, Any]:
+    """Build automated checks for an input recording."""
+    duration_seconds = _audio_duration_seconds(audio)
+    silence_ratio = _safe_metric(proportion_silent_metric, audio)
+    clipped_ratio = _safe_metric(proportion_clipped_metric, audio)
+    headroom = _safe_metric(amplitude_headroom_metric, audio)
+    snr_db = _safe_metric(spectral_gating_snr_metric, audio)
+    dynamic_range = _safe_metric(dynamic_range_metric, audio)
+
+    return {
+        "input": {
+            "passed": duration_seconds > 0.0,
+            "duration_seconds": round(duration_seconds, 4),
+        },
+        "preprocessing": {
+            "passed": audio.waveform.shape[0] == 1 and audio.sampling_rate == 16000,
+            "channel_count": int(audio.waveform.shape[0]),
+            "sampling_rate": int(audio.sampling_rate),
+        },
+        "environment": {
+            "passed": (clipped_ratio or 0.0) < 0.01 and (silence_ratio or 0.0) < 0.98,
+            "silence_ratio": silence_ratio,
+            "clipped_ratio": clipped_ratio,
+            "headroom": headroom,
+            "snr_db": snr_db,
+            "dynamic_range": dynamic_range,
+        },
+    }
+
+
+def _summarize_environment_context(checks: Dict[str, Any]) -> Dict[str, Any]:
+    """Summarize environmental recording conditions from QC checks."""
+    environment = checks.get("environment", {})
+    snr_db = environment.get("snr_db")
+
+    if snr_db is None:
+        noise_level = "unknown"
+    elif snr_db < 10:
+        noise_level = "high"
+    elif snr_db < 20:
+        noise_level = "moderate"
+    else:
+        noise_level = "low"
+
+    clipped_ratio = environment.get("clipped_ratio")
+    if clipped_ratio is None:
+        clipping = "unknown"
+    elif clipped_ratio > 0:
+        clipping = "present"
+    else:
+        clipping = "not_detected"
+
+    return {
+        "noise_level": noise_level,
+        "clipping": clipping,
+        "silence_ratio": environment.get("silence_ratio"),
+        "snr_db": snr_db,
+        "dynamic_range": environment.get("dynamic_range"),
+    }
+
+
+def _build_turn_checks(
+    transcript_text: str,
+    acoustic_features: Dict[str, Any],
+    ppg_summary: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build per-turn automated checks."""
+    return {
+        "transcript_present": bool(transcript_text.strip()),
+        "speech_rate_available": acoustic_features.get("speech_rate") is not None,
+        "pitch_available": acoustic_features.get("pitch_hz") is not None,
+        "ppg_available": bool(ppg_summary and ppg_summary.get("segment_count", 0) > 0),
+    }
+
+
+def _format_emotion_result(result: AudioClassificationResult) -> Dict[str, Any]:
+    """Format an emotion classification result for workflow output."""
+    return {
+        "top_label": result.top_label(),
+        "top_score": float(result.top_score()),
+        "labels": result.get_labels(),
+        "scores": [float(score) for score in result.get_scores()],
+    }
+
+
+def _tokenize_text(text: str) -> List[str]:
+    """Tokenize text into simple word-like units."""
+    return re.findall(r"[A-Za-z']+", text.lower())
+
+
+def _first_present(values: Dict[str, Any], keys: Iterable[str]) -> Any:  # noqa: ANN401
+    """Return the first non-null value found among candidate keys."""
+    for key in keys:
+        if key in values and values[key] is not None:
+            return values[key]
+    return None
+
+
+def _tensor_to_list(value: Any) -> List[float]:  # noqa: ANN401
+    """Convert tensor-like values to plain Python lists."""
+    if isinstance(value, torch.Tensor):
+        return [float(item) for item in value.detach().cpu().flatten().tolist()]
+    return [float(item) for item in value]
+
+
+def _pool_embedding(value: Any) -> List[float]:  # noqa: ANN401
+    """Mean-pool embedding tensors onto a single vector."""
+    if isinstance(value, torch.Tensor):
+        pooled = value
+        if value.ndim > 1:
+            pooled = value.mean(dim=0)
+        return [float(item) for item in pooled.detach().cpu().flatten().tolist()]
+    return [float(item) for item in value]
+
+
+def _audio_duration_seconds(audio: Audio) -> float:
+    """Return audio duration in seconds."""
+    if audio.sampling_rate == 0:
+        return 0.0
+    return float(audio.waveform.shape[-1] / audio.sampling_rate)
+
+
+def _segment_duration_seconds(line: ScriptLine) -> float:
+    """Return ScriptLine duration."""
+    if line.start is None or line.end is None:
+        return 0.0
+    return float(max(line.end - line.start, 0.0))
+
+
+def _safe_metric(metric_fn: Any, audio: Audio) -> Optional[float]:  # noqa: ANN401
+    """Compute a metric defensively."""
+    try:
+        value = metric_fn(audio)
+    except Exception:
+        return None
+    return float(value) if value is not None else None

--- a/src/tests/audio/workflows/conversation_analysis_test.py
+++ b/src/tests/audio/workflows/conversation_analysis_test.py
@@ -1,0 +1,267 @@
+"""Tests for the conversation analysis workflow."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List
+
+import pytest
+import torch
+
+from senselab.audio.data_structures import Audio, AudioClassificationResult
+from senselab.utils.data_structures import ScriptLine
+
+
+def _word_chunk(text: str, start: float, end: float) -> ScriptLine:
+    """Create a word-level script chunk for tests."""
+    return ScriptLine(text=text, start=start, end=end)
+
+
+def test_estimate_transcript_accuracy_uses_consensus() -> None:
+    """Multi-model agreement should yield a high consensus estimate."""
+    from senselab.audio.workflows.conversation_analysis import _estimate_transcript_accuracy
+
+    estimate = _estimate_transcript_accuracy(
+        {
+            "asr-a": "please help me with this",
+            "asr-b": "please help me with this",
+            "asr-c": "please help with this",
+        }
+    )
+
+    assert estimate["method"] == "multi_model_consensus"
+    assert 0.8 <= estimate["score"] <= 1.0
+
+
+def test_extract_dialogue_acts_and_engagement_markers() -> None:
+    """Question, request, politeness, and backchannel cues should be surfaced."""
+    from senselab.audio.workflows.conversation_analysis import (
+        _extract_dialogue_acts,
+        _extract_engagement_markers,
+        _extract_linguistic_features,
+    )
+
+    question_text = "Please can you help me with this?"
+    backchannel_text = "yeah right"
+
+    linguistic = _extract_linguistic_features(question_text)
+    dialogue_acts = _extract_dialogue_acts(question_text)
+    engagement = _extract_engagement_markers(backchannel_text)
+
+    assert "please" in linguistic["politeness_cues"]
+    assert "question" in dialogue_acts
+    assert "request" in dialogue_acts
+    assert engagement["is_backchannel"] is True
+    assert "yeah" in engagement["backchannel_cues"]
+
+
+def test_summarize_turn_taking_counts_interruptions() -> None:
+    """Overlapping turns should contribute to interruption statistics."""
+    from senselab.audio.workflows.conversation_analysis import _summarize_turn_taking
+
+    turns = [
+        {"speaker_id": "spk0", "start": 0.0, "end": 1.0, "duration_seconds": 1.0},
+        {"speaker_id": "spk1", "start": 0.9, "end": 1.7, "duration_seconds": 0.8},
+        {"speaker_id": "spk0", "start": 2.0, "end": 2.5, "duration_seconds": 0.5},
+    ]
+
+    summary = _summarize_turn_taking(turns)
+
+    assert summary["turn_count"] == 3
+    assert summary["speaker_switch_count"] == 2
+    assert summary["interruption_count"] == 1
+    assert summary["overlap_count"] == 1
+    assert summary["mean_gap_duration_seconds"] == pytest.approx(0.15, abs=1e-3)
+
+
+def test_summarize_ppg_segments_builds_sparse_segments() -> None:
+    """PPG summaries should collapse frame-wise peaks into sparse onset/offset segments."""
+    from senselab.audio.workflows.conversation_analysis import _summarize_ppg_segments
+
+    audio = Audio(waveform=torch.ones(1, 16000), sampling_rate=16000)
+    posteriorgram = torch.tensor(
+        [
+            [0.9, 0.1],
+            [0.8, 0.2],
+            [0.2, 0.8],
+            [0.1, 0.9],
+        ],
+        dtype=torch.float32,
+    )
+
+    summary = _summarize_ppg_segments(audio=audio, posteriorgram=posteriorgram)
+
+    assert summary["frame_count"] == 4
+    assert len(summary["segments"]) == 2
+    assert summary["segments"][0]["label_index"] == 0
+    assert summary["segments"][1]["label_index"] == 1
+    assert summary["segments"][0]["start_seconds"] == pytest.approx(0.0)
+    assert summary["segments"][1]["end_seconds"] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_analyze_conversation_recordings_returns_structured_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The workflow should assemble recording, turn, and check outputs from reused tasks."""
+    from senselab.audio.workflows import conversation_analysis as workflow_module
+
+    recording_path = tmp_path / "zoom_session.wav"
+    recording_path.write_bytes(b"audio")
+
+    recording_audio = Audio(waveform=torch.ones(1, 32000), sampling_rate=16000)
+    segment_a = Audio(waveform=torch.ones(1, 12800), sampling_rate=16000)
+    segment_b = Audio(waveform=torch.ones(1, 11200), sampling_rate=16000)
+
+    asr_models = [SimpleNamespace(path_or_uri="asr-a"), SimpleNamespace(path_or_uri="asr-b")]
+    speaker_embedding_model = [SimpleNamespace(path_or_uri="speaker-emb-a")]
+    ssl_embedding_model = [SimpleNamespace(path_or_uri="ssl-emb-a")]
+    emotion_model = SimpleNamespace(path_or_uri="emotion-a")
+
+    diarization = [
+        [
+            ScriptLine(speaker="spk0", start=0.0, end=0.8),
+            ScriptLine(speaker="spk1", start=0.75, end=1.45),
+        ]
+    ]
+
+    def fake_transcribe_audios(
+        audios: List[Audio],
+        model: SimpleNamespace,
+        **kwargs: object,
+    ) -> List[ScriptLine]:
+        if model.path_or_uri == "asr-a":
+            return [
+                ScriptLine(
+                    text="Please can you help me?",
+                    start=0.0,
+                    end=0.8,
+                    chunks=[
+                        _word_chunk("Please", 0.0, 0.2),
+                        _word_chunk("can", 0.2, 0.3),
+                        _word_chunk("you", 0.3, 0.4),
+                        _word_chunk("help", 0.4, 0.6),
+                        _word_chunk("me", 0.6, 0.75),
+                    ],
+                ),
+                ScriptLine(
+                    text="Yeah thanks",
+                    start=0.75,
+                    end=1.45,
+                    chunks=[_word_chunk("Yeah", 0.8, 1.0), _word_chunk("thanks", 1.0, 1.2)],
+                ),
+            ]
+        return [
+            ScriptLine(text="Please can you help me", start=0.0, end=0.8),
+            ScriptLine(text="Yeah, thanks", start=0.75, end=1.45),
+        ]
+
+    monkeypatch.setattr(
+        workflow_module,
+        "_prepare_recording_audio_files",
+        lambda recording_file_paths: recording_file_paths,
+    )
+    monkeypatch.setattr(workflow_module, "read_audios", lambda paths: [recording_audio])
+    monkeypatch.setattr(workflow_module, "downmix_audios_to_mono", lambda audios: audios)
+    monkeypatch.setattr(workflow_module, "resample_audios", lambda audios, resample_rate: audios)
+    monkeypatch.setattr(workflow_module, "diarize_audios", lambda audios, model=None, device=None: diarization)
+    monkeypatch.setattr(workflow_module, "extract_segments", lambda segments_info: [[segment_a, segment_b]])
+    monkeypatch.setattr(workflow_module, "transcribe_audios", fake_transcribe_audios)
+    monkeypatch.setattr(
+        workflow_module,
+        "extract_features_from_audios",
+        lambda audios, **kwargs: [
+            {
+                "praat_parselmouth": {
+                    "speaking_rate": 3.4,
+                    "articulation_rate": 4.0,
+                    "pause_rate": 0.2,
+                    "mean_pause_duration": 0.15,
+                    "mean_f0_hertz": 180.0,
+                    "mean_intensity_db": 63.0,
+                },
+                "opensmile": {"loudness_sma3_amean": 0.51},
+            },
+            {
+                "praat_parselmouth": {
+                    "speaking_rate": 2.1,
+                    "articulation_rate": 2.6,
+                    "pause_rate": 0.1,
+                    "mean_pause_duration": 0.05,
+                    "mean_f0_hertz": 155.0,
+                    "mean_intensity_db": 58.0,
+                },
+                "opensmile": {"loudness_sma3_amean": 0.32},
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "classify_emotions_from_speech",
+        lambda audios, model, device=None: [
+            AudioClassificationResult(labels=["joy", "neutral"], scores=[0.8, 0.2]),
+            AudioClassificationResult(labels=["neutral", "joy"], scores=[0.7, 0.3]),
+        ],
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "extract_speaker_embeddings_from_audios",
+        lambda audios, model, device=None: [torch.tensor([0.1, 0.2]), torch.tensor([0.3, 0.4])],
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "extract_ssl_embeddings_from_audios",
+        lambda audios, model, device=None: [torch.tensor([[0.1, 0.2]]), torch.tensor([[0.3, 0.4]])],
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "extract_ppgs_from_audios",
+        lambda audios, device=None: [
+            torch.tensor([[0.9, 0.1], [0.8, 0.2], [0.2, 0.8]]),
+            torch.tensor([[0.1, 0.9], [0.2, 0.8], [0.7, 0.3]]),
+        ],
+    )
+    monkeypatch.setattr(
+        workflow_module,
+        "_build_recording_checks",
+        lambda audio: {
+            "input": {"passed": True},
+            "preprocessing": {"passed": True},
+            "environment": {"passed": True, "snr_db": 22.5},
+        },
+    )
+
+    result = workflow_module.analyze_conversation_recordings(
+        recording_file_paths=[recording_path],
+        transcription_models=asr_models,
+        emotion_model=emotion_model,
+        speaker_embeddings_models=speaker_embedding_model,
+        ssl_embeddings_models=ssl_embedding_model,
+        include_ppgs=True,
+    )
+
+    assert len(result) == 1
+    recording = result[0]
+    assert recording["source_file"] == str(recording_path.resolve())
+    assert recording["turn_taking"]["interruption_count"] == 1
+    assert recording["speaker_summary"]["speaker_count"] == 2
+    assert recording["checks"]["environment"]["snr_db"] == pytest.approx(22.5)
+    assert len(recording["turns"]) == 2
+
+    first_turn = recording["turns"][0]
+    assert first_turn["speaker_id"] == "spk0"
+    assert "question" in first_turn["dialogue_acts"]
+    assert "request" in first_turn["dialogue_acts"]
+    assert first_turn["transcript_accuracy_estimate"] > 0.9
+    assert first_turn["emotion"]["top_label"] == "joy"
+    assert first_turn["engagement_markers"]["politeness_cues"] == ["please"]
+    assert first_turn["ppg_summary"]["segment_count"] >= 1
+
+
+def test_analyze_conversation_recordings_rejects_missing_files(tmp_path: Path) -> None:
+    """Missing recordings should fail fast before any model work starts."""
+    from senselab.audio.workflows.conversation_analysis import analyze_conversation_recordings
+
+    missing_path = tmp_path / "missing.wav"
+
+    with pytest.raises(FileNotFoundError):
+        analyze_conversation_recordings([missing_path])


### PR DESCRIPTION
## Summary
- add a new Zoom-oriented conversation analysis workflow that composes diarization, ASR, acoustic features, linguistic heuristics, engagement markers, optional emotion/embedding/PPG outputs, and automated step checks
- add a design doc with the implementation plan, task checklist, testing strategy, and GPU follow-up notes
- add CPU-safe workflow tests built with mocks and export the workflow lazily from the audio workflows package

## Testing
- MPLCONFIGDIR=.matplotlib XDG_CACHE_HOME=.cache .venv/bin/ruff check src/senselab/audio/workflows/conversation_analysis.py src/senselab/audio/workflows/__init__.py src/tests/audio/workflows/conversation_analysis_test.py
- MPLCONFIGDIR=.matplotlib XDG_CACHE_HOME=.cache .venv/bin/python -m pytest src/tests/audio/workflows/conversation_analysis_test.py -q

## Notes
- this PR is intentionally stacked on top of enh/uv-refactor
- full model-backed smoke tests for diarization, ASR, SER, embeddings, and PPG extraction should still be run when CUDA is available