### PR TITLE
Add PPG phoneme duration summaries and timeline plot

### DIFF
--- a/ppg-mean-phoneme-duration-plan.md
+++ b/ppg-mean-phoneme-duration-plan.md
@@ -1,0 +1,20 @@
+# PPG Mean Phoneme Duration Task
+
+## Goal
+
+Add a feature-extraction task that summarizes mean phoneme durations from PPG model output, while also allowing optional `start_times` and `end_times` windows for PPG extraction.
+
+## Plan
+
+- [x] Branch from `enh/uv-refactor`
+- [x] Add stable unit tests for PPG extraction without relying on remote model downloads
+- [x] Add a task that converts posteriorgrams into mean phoneme duration summaries
+- [x] Support optional per-audio `start_times` and `end_times`
+- [x] Add a synthesized-phrase test path that exercises TTS -> PPG duration extraction
+- [x] Run focused validation and capture any follow-up cleanup
+
+## Notes
+
+- The duration summary normalizes raw PPG tensor layouts to frame-major form before decoding the dominant phoneme per frame.
+- Time-window support is implemented before model inference so duration summaries naturally reflect the requested slice.
+- The synthesized-phrase coverage uses mocked model backends to keep tests deterministic and offline-friendly.

--- a/src/senselab/audio/tasks/features_extraction/__init__.py
+++ b/src/senselab/audio/tasks/features_extraction/__init__.py
@@ -1,3 +1,8 @@
 """.. include:: ./doc.md"""  # noqa: D415
 
 from .api import extract_features_from_audios  # noqa: F401
+from .ppg import (  # noqa: F401
+    extract_mean_phoneme_durations_from_audios,
+    extract_ppgs_from_audios,
+    plot_ppg_phoneme_timeline,
+)

--- a/src/senselab/audio/tasks/features_extraction/ppg.py
+++ b/src/senselab/audio/tasks/features_extraction/ppg.py
@@ -1,12 +1,15 @@
 """This module provides the implementation of Phonetic Posteriorgrams (PPGs) for audio features extraction."""
 
 import traceback
+from collections import defaultdict
+from statistics import mean
 from typing import Any, Dict, List, Optional
 
-import numpy as np
 import torch
+from matplotlib.figure import Figure
 
 from senselab.audio.data_structures import Audio
+from senselab.audio.tasks.preprocessing import chunk_audios
 from senselab.utils.data_structures import DeviceType, _select_device_and_dtype, logger
 
 try:
@@ -17,12 +20,19 @@ except ModuleNotFoundError:
     PPGS_AVAILABLE = False
 
 
-def extract_ppgs_from_audios(audios: List["Audio"], device: Optional[DeviceType] = None) -> List[torch.Tensor]:
+def extract_ppgs_from_audios(
+    audios: List["Audio"],
+    device: Optional[DeviceType] = None,
+    start_times: Optional[List[Optional[float]]] = None,
+    end_times: Optional[List[Optional[float]]] = None,
+) -> List[torch.Tensor]:
     """Extracts phonetic posteriorgrams (PPGs) from every audio.
 
     Args:
         audios (List[Audio]): The audios to extract PPGs from
         device (Optional[DeviceType]): Device to use for extracting PPGs
+        start_times (Optional[List[Optional[float]]]): Optional per-audio start times in seconds
+        end_times (Optional[List[Optional[float]]]): Optional per-audio end times in seconds
 
     Returns:
         List[Tensor]: The PPG for each input audio
@@ -33,11 +43,13 @@ def extract_ppgs_from_audios(audios: List["Audio"], device: Optional[DeviceType]
         )
 
     device, _ = _select_device_and_dtype(user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU])
-    if any(audio.waveform.shape[0] != 1 for audio in audios):
+    prepared_audios = _slice_audios_for_ppg_extraction(audios=audios, start_times=start_times, end_times=end_times)
+
+    if any(audio.waveform.shape[0] != 1 for audio in prepared_audios):
         raise ValueError("Only mono audio is supported by ppgs model.")
 
     posteriorgrams = []
-    for audio in audios:
+    for audio in prepared_audios:
         try:
             posteriorgrams.append(
                 ppgs.from_audio(
@@ -53,3 +65,257 @@ def extract_ppgs_from_audios(audios: List["Audio"], device: Optional[DeviceType]
             posteriorgrams.append(torch.tensor(torch.nan))
 
     return posteriorgrams
+
+
+def extract_mean_phoneme_durations(audio: Audio, posteriorgram: torch.Tensor) -> Dict[str, Any]:
+    """Summarize mean phoneme durations from a posteriorgram.
+
+    Args:
+        audio (Audio): Audio corresponding to the posteriorgram.
+        posteriorgram (torch.Tensor): Raw model output, typically shaped
+            ``(1, phonemes, frames)`` or ``(phonemes, frames)``.
+
+    Returns:
+        Dict[str, Any]: Aggregate duration statistics per phoneme.
+    """
+    frame_major = _to_frame_major_posteriorgram(posteriorgram)
+    if frame_major is None:
+        return {
+            "frame_count": 0,
+            "phoneme_count": 0,
+            "analysis_duration_seconds": 0.0,
+            "seconds_per_frame": 0.0,
+            "mean_segment_duration_seconds": 0.0,
+            "phoneme_durations": [],
+        }
+
+    segments = _extract_ppg_segments(audio=audio, frame_major_posteriorgram=frame_major)
+    frame_count = int(frame_major.shape[0])
+    analysis_duration_seconds = float(audio.waveform.shape[1] / audio.sampling_rate)
+    seconds_per_frame = analysis_duration_seconds / max(frame_count, 1)
+
+    durations_by_phoneme: dict[int, list[float]] = defaultdict(list)
+    segment_durations: list[float] = []
+    for segment in segments:
+        segment_duration = float(segment["duration_seconds"])
+        segment_durations.append(segment_duration)
+        durations_by_phoneme[int(segment["phoneme_index"])].append(segment_duration)
+
+    phoneme_durations = []
+    for phoneme_index, phoneme in enumerate(ppgs.PHONEMES):
+        durations = durations_by_phoneme.get(phoneme_index)
+        if not durations:
+            continue
+        phoneme_durations.append(
+            {
+                "phoneme": phoneme,
+                "count": len(durations),
+                "mean_duration_seconds": round(mean(durations), 6),
+                "total_duration_seconds": round(sum(durations), 6),
+            }
+        )
+
+    return {
+        "frame_count": frame_count,
+        "phoneme_count": len(phoneme_durations),
+        "analysis_duration_seconds": round(analysis_duration_seconds, 6),
+        "seconds_per_frame": round(seconds_per_frame, 6),
+        "mean_segment_duration_seconds": round(mean(segment_durations), 6) if segment_durations else 0.0,
+        "phoneme_durations": phoneme_durations,
+    }
+
+
+def plot_ppg_phoneme_timeline(
+    audio: Audio,
+    posteriorgram: torch.Tensor,
+    title: str = "PPG phoneme timeline",
+    show: bool = True,
+) -> Figure:
+    """Plot contiguous PPG phoneme segments with onset and offset markers.
+
+    Args:
+        audio (Audio): Audio corresponding to the posteriorgram.
+        posteriorgram (torch.Tensor): Raw model output, typically shaped
+            ``(1, phonemes, frames)`` or ``(phonemes, frames)``.
+        title (str): Figure title.
+        show (bool): Whether to display the figure with ``plt.show(block=False)``.
+
+    Returns:
+        matplotlib.figure.Figure: The created figure.
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError("`matplotlib` is required for PPG timeline plotting.") from exc
+
+    frame_major = _to_frame_major_posteriorgram(posteriorgram)
+    if frame_major is None:
+        raise ValueError("Cannot plot an empty or NaN-only posteriorgram.")
+
+    segments = _extract_ppg_segments(audio=audio, frame_major_posteriorgram=frame_major)
+    present_indices = sorted({int(segment["phoneme_index"]) for segment in segments})
+    y_positions = {phoneme_index: position for position, phoneme_index in enumerate(present_indices)}
+    colors = plt.get_cmap("tab20", len(present_indices))
+
+    figure_height = max(6.0, len(present_indices) * 0.35)
+    fig, ax = plt.subplots(figsize=(18, figure_height))
+
+    for segment in segments:
+        phoneme_index = int(segment["phoneme_index"])
+        y_position = y_positions[phoneme_index]
+        start_seconds = float(segment["start_seconds"])
+        duration_seconds = float(segment["duration_seconds"])
+        color = colors(y_position)
+        ax.broken_barh(
+            [(start_seconds, duration_seconds)],
+            (y_position - 0.35, 0.7),
+            facecolors=color,
+            edgecolors=color,
+            alpha=0.85,
+        )
+        ax.plot(
+            [start_seconds, start_seconds + duration_seconds],
+            [y_position, y_position],
+            "|",
+            color="black",
+            markersize=8,
+            markeredgewidth=1,
+        )
+
+    duration_seconds = float(audio.waveform.shape[1] / audio.sampling_rate)
+    ax.set_title(title)
+    ax.set_xlabel("Time [s]")
+    ax.set_ylabel("Phoneme")
+    ax.set_xlim(0, duration_seconds)
+    ax.set_ylim(-1, len(present_indices))
+    ax.set_yticks(range(len(present_indices)))
+    ax.set_yticklabels([ppgs.PHONEMES[index] for index in present_indices])
+    ax.grid(axis="x", linestyle="--", alpha=0.3)
+    fig.tight_layout()
+
+    if show:
+        plt.show(block=False)
+
+    return fig
+
+
+def extract_mean_phoneme_durations_from_audios(
+    audios: List["Audio"],
+    device: Optional[DeviceType] = None,
+    start_times: Optional[List[Optional[float]]] = None,
+    end_times: Optional[List[Optional[float]]] = None,
+) -> List[Dict[str, Any]]:
+    """Extract mean phoneme duration summaries for a batch of audios.
+
+    Args:
+        audios (List[Audio]): Input audios to summarize.
+        device (Optional[DeviceType]): Device used for PPG extraction.
+        start_times (Optional[List[Optional[float]]]): Optional per-audio start times in seconds.
+        end_times (Optional[List[Optional[float]]]): Optional per-audio end times in seconds.
+
+    Returns:
+        List[Dict[str, Any]]: One duration summary per audio.
+    """
+    prepared_audios = _slice_audios_for_ppg_extraction(audios=audios, start_times=start_times, end_times=end_times)
+    posteriorgrams = extract_ppgs_from_audios(prepared_audios, device=device)
+    return [
+        extract_mean_phoneme_durations(audio=audio, posteriorgram=posteriorgram)
+        for audio, posteriorgram in zip(prepared_audios, posteriorgrams)
+    ]
+
+
+def _slice_audios_for_ppg_extraction(
+    audios: List["Audio"],
+    start_times: Optional[List[Optional[float]]],
+    end_times: Optional[List[Optional[float]]],
+) -> List[Audio]:
+    """Slice audios to optional per-item windows before PPG extraction."""
+    if start_times is None and end_times is None:
+        return audios
+
+    if start_times is not None and len(start_times) != len(audios):
+        raise ValueError("start_times should have the same length as audios.")
+    if end_times is not None and len(end_times) != len(audios):
+        raise ValueError("end_times should have the same length as audios.")
+
+    chunk_specs = []
+    for index, audio in enumerate(audios):
+        duration_seconds = float(audio.waveform.shape[1] / audio.sampling_rate)
+        start_time = 0.0 if start_times is None or start_times[index] is None else float(start_times[index])
+        end_time = duration_seconds if end_times is None or end_times[index] is None else float(end_times[index])
+        chunk_specs.append((audio, (start_time, end_time)))
+
+    return chunk_audios(chunk_specs)
+
+
+def _to_frame_major_posteriorgram(posteriorgram: torch.Tensor) -> Optional[torch.Tensor]:
+    """Normalize a posteriorgram to ``(frames, phonemes)`` layout."""
+    if not isinstance(posteriorgram, torch.Tensor) or posteriorgram.numel() == 0:
+        return None
+    if torch.isnan(posteriorgram).all():
+        return None
+
+    normalized = posteriorgram.detach().cpu()
+    if normalized.ndim == 3:
+        if normalized.shape[0] != 1:
+            raise ValueError("Expected batched posteriorgrams to contain exactly one audio item.")
+        normalized = normalized.squeeze(0)
+
+    if normalized.ndim != 2:
+        raise ValueError("Expected posteriorgram to have 2 or 3 dimensions.")
+
+    phoneme_count = len(ppgs.PHONEMES)
+    if normalized.shape[0] == phoneme_count:
+        return normalized.transpose(0, 1)
+    if normalized.shape[1] == phoneme_count:
+        return normalized
+
+    raise ValueError(
+        "Expected one posteriorgram dimension to match the PPG phoneme inventory size "
+        f"({phoneme_count}), received shape {tuple(normalized.shape)}."
+    )
+
+
+def _extract_ppg_segments(audio: Audio, frame_major_posteriorgram: torch.Tensor) -> List[Dict[str, Any]]:
+    """Extract contiguous argmax phoneme segments from a frame-major posteriorgram."""
+    frame_count = int(frame_major_posteriorgram.shape[0])
+    duration_seconds = float(audio.waveform.shape[1] / audio.sampling_rate)
+    seconds_per_frame = duration_seconds / max(frame_count, 1)
+    best_labels = frame_major_posteriorgram.argmax(dim=1).tolist()
+
+    segments: List[Dict[str, Any]] = []
+    start_index = 0
+    current_label = int(best_labels[0])
+
+    for frame_index in range(1, frame_count):
+        label_index = int(best_labels[frame_index])
+        if label_index == current_label:
+            continue
+
+        segments.append(
+            {
+                "phoneme": ppgs.PHONEMES[current_label],
+                "phoneme_index": current_label,
+                "start_frame": start_index,
+                "end_frame": frame_index - 1,
+                "start_seconds": round(start_index * seconds_per_frame, 6),
+                "end_seconds": round(frame_index * seconds_per_frame, 6),
+                "duration_seconds": round((frame_index - start_index) * seconds_per_frame, 6),
+            }
+        )
+        start_index = frame_index
+        current_label = label_index
+
+    segments.append(
+        {
+            "phoneme": ppgs.PHONEMES[current_label],
+            "phoneme_index": current_label,
+            "start_frame": start_index,
+            "end_frame": frame_count - 1,
+            "start_seconds": round(start_index * seconds_per_frame, 6),
+            "end_seconds": round(duration_seconds, 6),
+            "duration_seconds": round((frame_count - start_index) * seconds_per_frame, 6),
+        }
+    )
+
+    return segments

--- a/src/tests/audio/tasks/features_extraction_test.py
+++ b/src/tests/audio/tasks/features_extraction_test.py
@@ -1,14 +1,23 @@
 """This script contains unit tests for the features extraction tasks."""
 
+import math
 from pathlib import Path
+from typing import Any
+from unittest.mock import patch
 
 import pytest
 import torch
+from matplotlib.figure import Figure
 
 from senselab.audio.data_structures import Audio
 from senselab.audio.tasks.features_extraction import extract_features_from_audios
 from senselab.audio.tasks.features_extraction.opensmile import extract_opensmile_features_from_audios
-from senselab.audio.tasks.features_extraction.ppg import extract_ppgs_from_audios
+from senselab.audio.tasks.features_extraction.ppg import (
+    extract_mean_phoneme_durations,
+    extract_mean_phoneme_durations_from_audios,
+    extract_ppgs_from_audios,
+    plot_ppg_phoneme_timeline,
+)
 from senselab.audio.tasks.features_extraction.praat_parselmouth import (
     extract_audio_duration,
     extract_cpp_descriptors,
@@ -38,6 +47,9 @@ from senselab.audio.tasks.features_extraction.torchaudio_squim import (
     extract_objective_quality_features_from_audios,
     extract_subjective_quality_features_from_audios,
 )
+from senselab.audio.tasks.text_to_speech import synthesize_texts
+from senselab.audio.tasks.text_to_speech.huggingface import HuggingFaceTTS
+from senselab.utils.data_structures import DeviceType, HFModel
 
 try:
     import opensmile
@@ -73,6 +85,14 @@ try:
     SPARC_AVAILABLE = True
 except ModuleNotFoundError:
     SPARC_AVAILABLE = False
+
+
+def _build_ppg_posteriorgram(labels: list[str]) -> torch.Tensor:
+    """Build a deterministic frame-major argmax pattern in raw PPG output layout."""
+    posteriorgram = torch.full((len(ppgs.PHONEMES), len(labels)), -1000.0)
+    for frame_index, phoneme in enumerate(labels):
+        posteriorgram[ppgs.PHONEME_TO_INDEX_MAPPING[phoneme], frame_index] = 10.0
+    return posteriorgram
 
 
 @pytest.mark.skipif(OPENSMILE_AVAILABLE, reason="openSMILE is installed.")
@@ -394,12 +414,121 @@ def test_missing_ppg_dependency() -> None:
 
 
 @pytest.mark.skipif(not PPGS_AVAILABLE, reason="ppgs is not installed.")
-def test_extract_ppgs_from_audios(resampled_mono_audio_sample: Audio) -> None:
+def test_extract_ppgs_from_audios(
+    monkeypatch: pytest.MonkeyPatch, resampled_mono_audio_sample: Audio
+) -> None:
     """Test extraction of ppgs from audio."""
-    result = extract_ppgs_from_audios([resampled_mono_audio_sample])
-    # Assert the result is a list of tensors
+    observed: dict[str, tuple[int, ...]] = {}
+
+    def fake_from_audio(audio: torch.Tensor, sample_rate: int, gpu: int | None = None) -> torch.Tensor:
+        observed["audio_shape"] = tuple(audio.shape)
+        observed["sample_rate"] = sample_rate
+        observed["gpu"] = gpu
+        return torch.ones((1, len(ppgs.PHONEMES), 8), dtype=torch.float32)
+
+    monkeypatch.setattr(ppgs, "from_audio", fake_from_audio)
+
+    result = extract_ppgs_from_audios(
+        [resampled_mono_audio_sample],
+        device=DeviceType.CPU,
+        start_times=[0.25],
+        end_times=[0.5],
+    )
+
     assert isinstance(result, list)
     assert all(isinstance(features, torch.Tensor) for features in result)
+    assert observed["audio_shape"] == (1, 1, 4000)
+    assert observed["sample_rate"] == ppgs.SAMPLE_RATE
+    assert observed["gpu"] is None
+    assert result[0].shape == (1, len(ppgs.PHONEMES), 8)
+
+
+@pytest.mark.skipif(not PPGS_AVAILABLE, reason="ppgs is not installed.")
+def test_extract_mean_phoneme_durations() -> None:
+    """Test summarizing mean phoneme durations from raw PPG model output."""
+    audio = Audio(waveform=torch.zeros(1, 16000), sampling_rate=16000)
+    posteriorgram = _build_ppg_posteriorgram(
+        ["aa", "aa", "aa", "b", "b", "aa", "aa", "<silent>", "<silent>", "<silent>"]
+    )
+
+    summary = extract_mean_phoneme_durations(audio=audio, posteriorgram=posteriorgram)
+    phonemes = {item["phoneme"]: item for item in summary["phoneme_durations"]}
+
+    assert summary["frame_count"] == 10
+    assert summary["phoneme_count"] == 3
+    assert summary["analysis_duration_seconds"] == pytest.approx(1.0)
+    assert summary["seconds_per_frame"] == pytest.approx(0.1)
+    assert summary["mean_segment_duration_seconds"] == pytest.approx(0.25)
+    assert phonemes["aa"]["count"] == 2
+    assert phonemes["aa"]["mean_duration_seconds"] == pytest.approx(0.25)
+    assert phonemes["aa"]["total_duration_seconds"] == pytest.approx(0.5)
+    assert phonemes["b"]["count"] == 1
+    assert phonemes["b"]["mean_duration_seconds"] == pytest.approx(0.2)
+    assert phonemes["<silent>"]["count"] == 1
+    assert phonemes["<silent>"]["mean_duration_seconds"] == pytest.approx(0.3)
+
+
+@pytest.mark.skipif(not PPGS_AVAILABLE, reason="ppgs is not installed.")
+def test_plot_ppg_phoneme_timeline() -> None:
+    """Test plotting phoneme segments with onset and offset markers."""
+    audio = Audio(waveform=torch.zeros(1, 16000), sampling_rate=16000)
+    posteriorgram = _build_ppg_posteriorgram(["aa", "aa", "b", "b", "<silent>", "<silent>"])
+
+    figure = plot_ppg_phoneme_timeline(audio=audio, posteriorgram=posteriorgram, title="PPG Timeline", show=False)
+
+    assert isinstance(figure, Figure)
+    assert figure.axes[0].get_title() == "PPG Timeline"
+    assert figure.axes[0].get_xlabel() == "Time [s]"
+    assert figure.axes[0].get_ylabel() == "Phoneme"
+    assert [tick.get_text() for tick in figure.axes[0].get_yticklabels()] == ["aa", "b", "<silent>"]
+    assert len(figure.axes[0].collections) == 3
+    assert len(figure.axes[0].lines) == 3
+
+
+@pytest.mark.skipif(not PPGS_AVAILABLE, reason="ppgs is not installed.")
+def test_extract_mean_phoneme_durations_from_synthesized_phrase(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test mean phoneme duration extraction on synthesized audio."""
+
+    class FakePipeline:
+        def __call__(self, texts: list[str], forward_params: dict[str, str] | None = None) -> list[dict[str, Any]]:
+            synthesized = []
+            for text in texts:
+                sample_count = 16000
+                timeline = torch.linspace(0, 1, sample_count)
+                base_frequency = 180 + 10 * len(text.split())
+                waveform = 0.1 * torch.sin(2 * math.pi * base_frequency * timeline)
+                synthesized.append({"audio": waveform.unsqueeze(0), "sampling_rate": 16000})
+            return synthesized
+
+    def fake_get_hf_tts_pipeline(
+        cls: type[HuggingFaceTTS], model: HFModel, device: DeviceType | None = None
+    ) -> FakePipeline:
+        return FakePipeline()
+
+    def fake_from_audio(audio: torch.Tensor, sample_rate: int, gpu: int | None = None) -> torch.Tensor:
+        return _build_ppg_posteriorgram(["w", "w", "iy", "iy", "t", "t", "<silent>", "<silent>"]).unsqueeze(0)
+
+    monkeypatch.setattr(HuggingFaceTTS, "_get_hf_tts_pipeline", classmethod(fake_get_hf_tts_pipeline))
+    monkeypatch.setattr(ppgs, "from_audio", fake_from_audio)
+
+    with patch("senselab.utils.data_structures.model.check_hf_repo_exists", return_value=True):
+        model = HFModel(path_or_uri="test/fake-tts-model", revision="main")
+
+    synthesized_audio = synthesize_texts(
+        texts=["We test mean phoneme durations."],
+        model=model,
+        device=DeviceType.CPU,
+    )
+    summary = extract_mean_phoneme_durations_from_audios(synthesized_audio, device=DeviceType.CPU)[0]
+    phonemes = {item["phoneme"]: item for item in summary["phoneme_durations"]}
+
+    assert summary["frame_count"] == 8
+    assert summary["phoneme_count"] == 4
+    assert summary["analysis_duration_seconds"] == pytest.approx(1.0)
+    assert phonemes["w"]["mean_duration_seconds"] == pytest.approx(0.25)
+    assert phonemes["iy"]["mean_duration_seconds"] == pytest.approx(0.25)
+    assert phonemes["t"]["mean_duration_seconds"] == pytest.approx(0.25)
+    assert phonemes["<silent>"]["mean_duration_seconds"] == pytest.approx(0.25)
 
 
 @pytest.mark.skipif(SPARC_AVAILABLE, reason="sparc is installed.")


### PR DESCRIPTION
## Summary
- add PPG mean phoneme duration extraction utilities and optional start/end time slicing
- add a phoneme timeline plotting function that marks onset and offset for contiguous argmax segments
- add focused offline-friendly tests for sliced PPG extraction, duration summaries, synthesized phrase coverage, and plotting

## Testing
- uv run pytest src/tests/audio/tasks/features_extraction_test.py -k "plot_ppg_phoneme_timeline or mean_phoneme_durations or extract_ppgs_from_audios or synthesized_phrase"
- UV_CACHE_DIR=.uv-cache uv run ruff check src/senselab/audio/tasks/features_extraction/ppg.py src/senselab/audio/tasks/features_extraction/__init__.py src/tests/audio/tasks/features_extraction_test.py