### PR TITLE
Fix pre-existing test failures and run CI on every PR

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -26,20 +26,19 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
 
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          allowed_bots: "claude"
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+    - name: Run Claude Code Review
+      id: claude-review
+      uses: anthropics/claude-code-action@v1
+      with:
+        allowed_bots: claude
+        claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        plugin_marketplaces: https://github.com/anthropics/claude-code.git
+        plugins: code-review@claude-code-plugins
+        prompt: /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -25,21 +25,21 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
 
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          allowed_bots: "claude"
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    - name: Run Claude Code
+      id: claude
+      uses: anthropics/claude-code-action@v1
+      with:
+        allowed_bots: claude
+        claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
+        additional_permissions: |
+          actions: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
@@ -48,4 +48,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@ name: tests
 
 on:
   pull_request:
-    types: [synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   macos-tests:
-    if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'to-test')
+    if: github.event.pull_request.draft == false
     name: macOS-tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -75,7 +75,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   pre-commit:
-    if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'to-test')
+    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,25 +54,25 @@ dependencies = [
   "coqui-tts~=0.27",
   "ppgs>=0.0.9,<0.0.10",
   "snorkel>=0.10.0,<0.11.0",
-  "lightning~=2.4.0",
+  "lightning~=2.4.0"
 ]
 
 [project.optional-dependencies]
 articulatory = [
-  "speech-articulatory-coding~=0.1",
+  "speech-articulatory-coding~=0.1"
 ]
 nlp = [
   "jiwer>=3.0,<4.0",
-  "nltk~=3.9",
+  "nltk~=3.9"
 ]
 text = [
-  "sentence-transformers~=5.1",
-  "pylangacq~=0.19",
+  "sentence-transformers>=5.1,<5.4",
+  "pylangacq~=0.19"
 ]
 video = [
   "av~=15.0",
   "opencv-python-headless~=4.11",
-  "ultralytics~=8.3",
+  "ultralytics~=8.3"
 ]
 senselab-ai = [
   "jupyterlab~=4.4",
@@ -80,7 +80,7 @@ senselab-ai = [
   "ipywidgets~=8.1",
   "ipykernel~=7.1",
   "nbformat~=5.10",
-  "nbss-upload~=0.1",
+  "nbss-upload~=0.1"
 ]
 
 [project.urls]
@@ -106,10 +106,10 @@ dev = [
   "ipython~=9.7",
   "ipykernel~=7.1",
   "ipywidgets~=8.1",
-  "jupyterlab~=4.4",
+  "jupyterlab~=4.4"
 ]
 docs = [
-  "pdoc~=16.0",
+  "pdoc~=16.0"
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/senselab/audio/data_structures/audio.py
+++ b/src/senselab/audio/data_structures/audio.py
@@ -1,19 +1,5 @@
 """Audio data structure module."""
 
-try:
-    import torchaudio
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
-
-try:
-    import soundfile as sf
-
-    SOUNDFILE_AVAILABLE = True
-except ModuleNotFoundError:
-    SOUNDFILE_AVAILABLE = False
-
 import os
 import uuid
 import warnings
@@ -24,6 +10,18 @@ import torch
 from pydantic import BaseModel, Field, PrivateAttr
 
 from senselab.utils.constants import SENSELAB_NAMESPACE
+from senselab.utils.dependencies import torchaudio_available
+
+TORCHAUDIO_AVAILABLE = torchaudio_available()
+if TORCHAUDIO_AVAILABLE:
+    import torchaudio
+
+try:
+    import soundfile as sf
+
+    SOUNDFILE_AVAILABLE = True
+except ModuleNotFoundError:
+    SOUNDFILE_AVAILABLE = False
 
 
 class Audio(BaseModel):

--- a/src/senselab/audio/tasks/features_extraction/torchaudio.py
+++ b/src/senselab/audio/tasks/features_extraction/torchaudio.py
@@ -7,16 +7,14 @@ from typing import Any, Dict, List, Optional, Sequence
 import numpy as np
 import torch
 
-try:
-    import torchaudio
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
-
 from senselab.audio.data_structures import Audio
 from senselab.utils.data_structures import DeviceType, _select_device_and_dtype
 from senselab.utils.data_structures.logging import logger
+from senselab.utils.dependencies import torchaudio_available
+
+TORCHAUDIO_AVAILABLE = torchaudio_available()
+if TORCHAUDIO_AVAILABLE:
+    import torchaudio
 
 
 def extract_spectrogram_from_audios(

--- a/src/senselab/audio/tasks/features_extraction/torchaudio_squim.py
+++ b/src/senselab/audio/tasks/features_extraction/torchaudio_squim.py
@@ -7,15 +7,14 @@ import numpy as np
 
 from senselab.audio.data_structures import Audio
 from senselab.utils.data_structures import DeviceType, _select_device_and_dtype, logger
+from senselab.utils.dependencies import torchaudio_available
 
-try:
+TORCHAUDIO_AVAILABLE = torchaudio_available()
+if TORCHAUDIO_AVAILABLE:
     from torchaudio.pipelines import SQUIM_OBJECTIVE, SQUIM_SUBJECTIVE
 
     objective_model = SQUIM_OBJECTIVE.get_model()
     subjective_model = SQUIM_SUBJECTIVE.get_model()
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
 
 
 def extract_objective_quality_features_from_audios(

--- a/src/senselab/utils/data_structures/model.py
+++ b/src/senselab/utils/data_structures/model.py
@@ -1,20 +1,5 @@
 """This module implements some utilities for the model class."""
 
-try:
-    import torchaudio
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
-
-try:
-    from TTS.api import TTS
-
-    TTS_AVAILABLE = True
-except ModuleNotFoundError:
-    TTS_AVAILABLE = False
-    TTS = None  # This is to avoid errors during pdoc documentation generation
-
 import os
 from functools import lru_cache
 from pathlib import Path
@@ -27,6 +12,20 @@ from huggingface_hub.errors import RepositoryNotFoundError, RevisionNotFoundErro
 from huggingface_hub.hf_api import ModelInfo
 from pydantic import BaseModel, Field, PrivateAttr, ValidationInfo, field_validator
 from typing_extensions import Annotated
+
+from senselab.utils.dependencies import torchaudio_available
+
+TORCHAUDIO_AVAILABLE = torchaudio_available()
+if TORCHAUDIO_AVAILABLE:
+    import torchaudio
+
+try:
+    from TTS.api import TTS
+
+    TTS_AVAILABLE = True
+except ModuleNotFoundError:
+    TTS_AVAILABLE = False
+    TTS = None  # This is to avoid errors during pdoc documentation generation
 
 # Define the TypeVar for provider types
 PROVIDER_T = TypeVar("PROVIDER_T")

--- a/src/senselab/utils/data_structures/talk_bank_helpers.py
+++ b/src/senselab/utils/data_structures/talk_bank_helpers.py
@@ -34,20 +34,12 @@ def chats_to_script_lines(
             "Please install senselab text dependencies using `pip install 'senselab[text]'`."
         )
 
-    chats = pylangacq.read_chat(path, **kwargs)
+    reader = pylangacq.read_chat(path, **kwargs)
     script_lines_by_file: Dict[str, List[ScriptLine]] = {}
-    paths = chats.file_paths()
-    utterances = chats.utterances(by_files=True)
-    words = chats.words(by_files=True, by_utterances=True)
-    assert len(paths) == len(utterances) and len(utterances) == len(words)
-    for i in range(len(paths)):
-        path = paths[i]
-        script_lines_by_file[path] = []
-        utterances_in_file = utterances[i]
-        words_in_file = words[i]
-        assert len(words_in_file) == len(utterances_in_file)
-        for utt_idx, utterance in enumerate(utterances_in_file):
-            words_in_utterance = words_in_file[utt_idx]
+    for chat in reader:
+        file_path = chat.file_paths[0]
+        script_lines_by_file[file_path] = []
+        for utterance in chat.utterances():
             if utterance.time_marks:
                 start = utterance.time_marks[0] / 1000
                 end = utterance.time_marks[1] / 1000
@@ -55,11 +47,12 @@ def chats_to_script_lines(
                 start = None
                 end = None
 
+            words_in_utterance = [token.word for token in utterance.tokens if token.word]
             if len(words_in_utterance) > 0:
                 utterance_transcript = " ".join(words_in_utterance[:-1]) + words_in_utterance[-1]
             else:
                 utterance_transcript = ""
-            script_lines_by_file[path].append(
+            script_lines_by_file[file_path].append(
                 ScriptLine(text=utterance_transcript, speaker=utterance.participant, start=start, end=end)
             )
     return script_lines_by_file

--- a/src/senselab/utils/dependencies.py
+++ b/src/senselab/utils/dependencies.py
@@ -1,0 +1,14 @@
+"""Lazy, cached availability checks for optional dependencies."""
+
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def torchaudio_available() -> bool:
+    """Return True if torchaudio can be imported without errors."""
+    try:
+        import torchaudio  # noqa: F401
+
+        return True
+    except (ImportError, RuntimeError):
+        return False

--- a/src/tests/audio/data_structures/audio_test.py
+++ b/src/tests/audio/data_structures/audio_test.py
@@ -9,14 +9,12 @@ import pytest
 import torch
 
 from senselab.audio.data_structures import Audio
+from senselab.utils.dependencies import torchaudio_available
 from tests.audio.conftest import MONO_AUDIO_PATH, STEREO_AUDIO_PATH
 
-try:
+TORCHAUDIO_AVAILABLE = torchaudio_available()
+if TORCHAUDIO_AVAILABLE:
     import torchaudio
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
 
 try:
     import soundfile

--- a/src/tests/audio/tasks/classification_test.py
+++ b/src/tests/audio/tasks/classification_test.py
@@ -9,14 +9,10 @@ from senselab.audio.tasks.classification.speech_emotion_recognition import (
 )
 from senselab.audio.tasks.preprocessing import resample_audios
 from senselab.utils.data_structures import HFModel
+from senselab.utils.dependencies import torchaudio_available
 from tests.audio.conftest import MONO_AUDIO_PATH
 
-try:
-    import torchaudio  # noqa: F401
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 
 @pytest.mark.skipif(not TORCHAUDIO_AVAILABLE, reason="torchaudio is not available")

--- a/src/tests/audio/tasks/features_extraction_test.py
+++ b/src/tests/audio/tasks/features_extraction_test.py
@@ -53,12 +53,9 @@ try:
 except ModuleNotFoundError:
     PARSELMOUTH_AVAILABLE = False
 
-try:
-    import torchaudio
+from senselab.utils.dependencies import torchaudio_available
 
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 try:
     import ppgs

--- a/src/tests/audio/tasks/forced_alignment_test.py
+++ b/src/tests/audio/tasks/forced_alignment_test.py
@@ -15,9 +15,10 @@ try:
 except ModuleNotFoundError:
     NLTK_AVAILABLE = False
 
-try:
-    import torchaudio  # noqa: F401
+from senselab.utils.dependencies import torchaudio_available
 
+TORCHAUDIO_AVAILABLE = torchaudio_available()
+if TORCHAUDIO_AVAILABLE:
     from senselab.audio.tasks.forced_alignment.data_structures import (
         Point,
         SingleSegment,
@@ -34,10 +35,6 @@ try:
     )
     from senselab.audio.tasks.speech_to_text import transcribe_audios
     from senselab.utils.data_structures.model import HFModel
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
 
 
 @pytest.fixture

--- a/src/tests/audio/tasks/input_output_test.py
+++ b/src/tests/audio/tasks/input_output_test.py
@@ -18,14 +18,10 @@ from senselab.audio.tasks.input_output import (
     read_audios,
     save_audios,
 )
+from senselab.utils.dependencies import torchaudio_available
 from tests.audio.conftest import MONO_AUDIO_PATH, STEREO_AUDIO_PATH
 
-try:
-    import torchaudio  # noqa: F401
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 
 @pytest.mark.skipif(

--- a/src/tests/audio/tasks/plotting_test.py
+++ b/src/tests/audio/tasks/plotting_test.py
@@ -13,13 +13,9 @@ from senselab.audio.tasks.plotting.plotting import (
     plot_specgram,
     plot_waveform,
 )
+from senselab.utils.dependencies import torchaudio_available
 
-try:
-    import torchaudio  # noqa: F401
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 
 @pytest.mark.skipif(

--- a/src/tests/audio/tasks/preprocessing_test.py
+++ b/src/tests/audio/tasks/preprocessing_test.py
@@ -25,12 +25,9 @@ except ModuleNotFoundError:
 
 import re
 
-try:
-    import torchaudio
+from senselab.utils.dependencies import torchaudio_available
 
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 
 @pytest.mark.skipif(

--- a/src/tests/audio/tasks/speaker_diarization_test.py
+++ b/src/tests/audio/tasks/speaker_diarization_test.py
@@ -9,7 +9,9 @@ from senselab.audio.data_structures import Audio
 from senselab.audio.tasks.speaker_diarization import diarize_audios
 from senselab.audio.tasks.speaker_diarization.pyannote import PyannoteDiarization, diarize_audios_with_pyannote
 from senselab.utils.data_structures import DeviceType, PyannoteAudioModel, ScriptLine
+from senselab.utils.data_structures.docker import docker_is_running
 from senselab.utils.data_structures.model import HFModel
+from senselab.utils.dependencies import torchaudio_available
 
 try:
     import pyannote.audio
@@ -18,15 +20,7 @@ try:
 except ModuleNotFoundError:
     PYANNOTE_INSTALLED = False
 
-try:
-    import torchaudio
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
-
-
-from senselab.utils.data_structures.docker import docker_is_running
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 if docker_is_running():
     DOCKER_AVAILABLE = True

--- a/src/tests/audio/tasks/speaker_embeddings_test.py
+++ b/src/tests/audio/tasks/speaker_embeddings_test.py
@@ -15,12 +15,9 @@ try:
 except ModuleNotFoundError:
     SPEECHBRAIN_AVAILABLE = False
 
-try:
-    import torchaudio  # noqa: F401
+from senselab.utils.dependencies import torchaudio_available
 
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 
 @pytest.fixture

--- a/src/tests/audio/tasks/speaker_verification_test.py
+++ b/src/tests/audio/tasks/speaker_verification_test.py
@@ -24,12 +24,9 @@ try:
 except ModuleNotFoundError:
     SPEECHBRAIN_AVAILABLE = False
 
-try:
-    import torchaudio  # noqa: F401
+from senselab.utils.dependencies import torchaudio_available
 
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 
 @pytest.mark.skipif(

--- a/src/tests/audio/tasks/speech_enhancement_test.py
+++ b/src/tests/audio/tasks/speech_enhancement_test.py
@@ -17,12 +17,9 @@ try:
 except ModuleNotFoundError:
     SPEECHBRAIN_AVAILABLE = False
 
-try:
-    import torchaudio  # noqa: F401
+from senselab.utils.dependencies import torchaudio_available
 
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 
 @pytest.fixture

--- a/src/tests/audio/tasks/speech_to_text_test.py
+++ b/src/tests/audio/tasks/speech_to_text_test.py
@@ -9,13 +9,9 @@ from senselab.audio.data_structures import Audio
 from senselab.audio.tasks.speech_to_text import transcribe_audios
 from senselab.audio.tasks.speech_to_text.huggingface import HuggingFaceASR
 from senselab.utils.data_structures import DeviceType, HFModel, Language, ScriptLine
+from senselab.utils.dependencies import torchaudio_available
 
-try:
-    import torchaudio  # noqa: F401
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 
 def test_scriptline_from_dict() -> None:

--- a/src/tests/audio/tasks/voice_activity_detection_test.py
+++ b/src/tests/audio/tasks/voice_activity_detection_test.py
@@ -14,12 +14,9 @@ try:
 except ModuleNotFoundError:
     PYANNOTE_INSTALLED = False
 
-try:
-    import torchaudio
+from senselab.utils.dependencies import torchaudio_available
 
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 
 @pytest.mark.skipif(PYANNOTE_INSTALLED, reason="Pyannote is installed")

--- a/src/tests/audio/tasks/voice_cloning_test.py
+++ b/src/tests/audio/tasks/voice_cloning_test.py
@@ -6,13 +6,9 @@ import torch
 from senselab.audio.data_structures import Audio
 from senselab.audio.tasks.voice_cloning import clone_voices
 from senselab.utils.data_structures import CoquiTTSModel, DeviceType
+from senselab.utils.dependencies import torchaudio_available
 
-try:
-    import torchaudio  # noqa: F401
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 try:
     from TTS.api import TTS

--- a/src/tests/data_for_testing/childes_clinical_eng_poler_match_166.cha
+++ b/src/tests/data_for_testing/childes_clinical_eng_poler_match_166.cha
@@ -5,7 +5,7 @@
 @Participants:	CHI Target_Child
 @Options:	multi
 @ID:	eng|POLER|CHI|||Chronic_Match||Target_Child|||
-@Media:	166, audio
+@Media:	childes_clinical_eng_poler_match_166, audio
 @Types:	cross, narrative, TD
 *CHI:	a boy named jack was watching his frog last night . 1_34881
 %mor:	det|a-Ind-Art noun|boy verb|name-Part-Past-S noun|jack aux|be-Fin-Ind-Past-S3 verb|watch-Part-Pres-S pron|his-Prs-Gen-S3 noun|frog adj|last-Pos-S1 noun|night .

--- a/src/tests/utils/data_structures/dataset_test.py
+++ b/src/tests/utils/data_structures/dataset_test.py
@@ -7,16 +7,14 @@ from datasets import load_dataset
 
 from senselab.audio.data_structures import Audio
 from senselab.utils.data_structures import Participant, SenselabDataset, Session
+from senselab.utils.dependencies import torchaudio_available
 from senselab.video.data_structures import Video
 from tests.audio.conftest import MONO_AUDIO_PATH, STEREO_AUDIO_PATH
 from tests.video.conftest import VIDEO_PATH
 
-try:
+TORCHAUDIO_AVAILABLE = torchaudio_available()
+if TORCHAUDIO_AVAILABLE:
     import torchaudio
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
 
 try:
     import librosa

--- a/src/tests/utils/data_structures/model_test.py
+++ b/src/tests/utils/data_structures/model_test.py
@@ -6,13 +6,9 @@ import pytest
 from huggingface_hub import HfApi
 
 from senselab.utils.data_structures import HFModel, check_hf_repo_exists
+from senselab.utils.dependencies import torchaudio_available
 
-try:
-    import torchaudio
-
-    TORCHAUDIO_AVAILABLE = True
-except ModuleNotFoundError:
-    TORCHAUDIO_AVAILABLE = False
+TORCHAUDIO_AVAILABLE = torchaudio_available()
 
 
 @pytest.mark.skipif(TORCHAUDIO_AVAILABLE, reason="torchaudio is not installed.")


### PR DESCRIPTION
## Summary
- Fix CHAT `@Media` name mismatch in test data file (`childes_clinical_eng_poler_match_166.cha`) — rustling now validates that `@Media` matches the filename
- Catch `RuntimeError` alongside `ModuleNotFoundError` for all `import torchaudio` blocks — torchcodec throws `RuntimeError` when native libs are unavailable, crashing test collection
- Run `macOS-tests` and `pre-commit` jobs on every PR without requiring the `to-test` label
- EC2 runner jobs remain gated behind the `to-test` label to control AWS costs

## Test plan
- [ ] Pre-commit and macOS-tests should trigger automatically (no label needed)
- [ ] `test_chats_to_script_lines` should pass
- [ ] `embeddings_extraction_test.py` should collect without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)