### PR TITLE
Configure alpha prerelease branch

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,6 +1,7 @@
 {
-    "onlyPublishWithReleaseLabel": true,
+    "onlyPublishWithReleaseLabel": false,
     "baseBranch": "main",
+    "prereleaseBranches": ["alpha"],
     "author": "bot <fabiocat@mit.edu>",
     "noVersionPrefix": true,
     "plugins": ["git-tag"]

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build-docs:
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,21 +21,21 @@ jobs:
         github.event.pull_request.base.ref == 'alpha'
       )
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          fetch-tags: true
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+        fetch-tags: true
 
-      - name: Unset header
-        run: git config --local --unset http.https://github.com/.extraheader
+    - name: Unset header
+      run: git config --local --unset http.https://github.com/.extraheader
 
-      - name: Download auto
-        run: |
-          auto_download_url="$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/tags/$AUTO_VERSION | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')"
-          wget -O- "$auto_download_url" | gunzip > ~/auto
-          chmod a+x ~/auto
+    - name: Download auto
+      run: |
+        auto_download_url="$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/tags/$AUTO_VERSION | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')"
+        wget -O- "$auto_download_url" | gunzip > ~/auto
+        chmod a+x ~/auto
 
-      - name: Create release
-        run: ~/auto shipit -vv
-        env:
-          GH_TOKEN: ${{ secrets.AUTO_ORG_TOKEN }}
+    - name: Create release
+      run: ~/auto shipit -vv
+      env:
+        GH_TOKEN: ${{ secrets.AUTO_ORG_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,42 +1,41 @@
-name: Auto-release
+name: Auto-release on PR merge
 
 on:
-  push:
-    branches:
-    - main
+  pull_request:
+    branches: [main, alpha]
+    types: [closed]
 
 env:
-  AUTO_VERSION: v11.1.2
+  AUTO_VERSION: v11.2.1
 
 jobs:
   auto-release:
+    name: Create release
     runs-on: ubuntu-latest
-
+    # Stable release: merged PR to main with 'release' label
+    # Alpha pre-release: merged PR to alpha (no label needed)
+    if: >-
+      github.event.pull_request.merged == true &&
+      (
+        contains(github.event.pull_request.labels.*.name, 'release') ||
+        github.event.pull_request.base.ref == 'alpha'
+      )
     steps:
-    - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
-    - name: Prepare repository
-        # Fetch full git history and tags
-      run: git fetch --unshallow --tags
+      - name: Unset header
+        run: git config --local --unset http.https://github.com/.extraheader
 
-    - name: Unset header
-        # checkout@v2 adds a header that makes branch protection report errors
-        # because the Github action bot is not a collaborator on the repo
-      run: git config --local --unset http.https://github.com/.extraheader
+      - name: Download auto
+        run: |
+          auto_download_url="$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/tags/$AUTO_VERSION | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')"
+          wget -O- "$auto_download_url" | gunzip > ~/auto
+          chmod a+x ~/auto
 
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.11'
-
-    - name: Download auto
-      run: |
-        auto_download_url="$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/tags/$AUTO_VERSION | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')"
-        wget -O- "$auto_download_url" | gunzip > ~/auto
-        chmod a+x ~/auto
-
-    - name: Create release
-      run: |
-        ~/auto shipit -vv
-      env:
-        GH_TOKEN: ${{ secrets.AUTO_ORG_TOKEN }}
+      - name: Create release
+        run: ~/auto shipit -vv
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_ORG_TOKEN }}


### PR DESCRIPTION
## Summary
- Configure Auto and release workflow to support alpha pre-releases from a dedicated `alpha` branch
- PRs merged to `alpha` automatically create alpha version tags + GitHub pre-releases + PyPI publish
- Stable releases on `main` unchanged (still require `release` label)
- Skip doc builds on pre-releases

## Changes
- `.autorc`: add `prereleaseBranches: ["alpha"]`, set `onlyPublishWithReleaseLabel: false`
- `.github/workflows/release.yaml`: PR-closed trigger on `[main, alpha]` with label/branch condition
- `.github/workflows/docs.yaml`: skip on pre-releases

## Post-merge steps
After merging this PR to `main`:
1. Create `alpha` branch from `main`: `git checkout main && git pull && git checkout -b alpha && git push -u origin alpha`
2. Create a test PR against `alpha` to verify the pipeline
3. Verify alpha tag, GitHub pre-release, and PyPI publish

## Test plan
- [ ] Pre-commit passes
- [ ] macOS-tests pass
- [ ] After merge: create alpha branch and verify end-to-end release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)