### PR TITLE
Fix isolated backend compat check + wire coqui to subprocess venv

### DIFF
--- a/src/senselab/audio/tasks/quality_control/review.py
+++ b/src/senselab/audio/tasks/quality_control/review.py
@@ -19,9 +19,12 @@ except ImportError:
 
     def labeling_function(**kwargs: object) -> Callable:  # type: ignore[misc]
         """No-op decorator when snorkel is not installed."""
+
         def decorator(fn: Callable) -> Callable:
             return fn
+
         return decorator
+
 
 from senselab.audio.tasks.quality_control.taxonomies import (
     BIOACOUSTIC_ACTIVITY_TAXONOMY,

--- a/src/senselab/audio/tasks/voice_cloning/_coqui_worker.py
+++ b/src/senselab/audio/tasks/voice_cloning/_coqui_worker.py
@@ -4,9 +4,12 @@ This module is called by call_in_venv() and should NOT be imported
 directly by senselab. It has access to coqui-tts and its own torch.
 """
 
-import json
 from pathlib import Path
 from typing import Dict, List
+
+import torch
+import torchaudio
+from TTS.api import TTS
 
 
 def run_voice_cloning(
@@ -28,16 +31,19 @@ def run_voice_cloning(
     Returns:
         Dict with "output_paths" list of cloned audio file paths.
     """
-    import torchaudio
-    from TTS.api import TTS
-
     tts = TTS(model_id).to(device=device)
     audio_config = tts.voice_converter.vc_config.audio
+
+    expected_sample_rate = (
+        audio_config.input_sample_rate
+        if hasattr(audio_config, "input_sample_rate")
+        else getattr(audio_config, "sample_rate", None)
+    )
 
     output_sample_rate = (
         audio_config.output_sample_rate
         if hasattr(audio_config, "output_sample_rate")
-        else getattr(audio_config, "sample_rate", None)
+        else getattr(audio_config, "sample_rate", expected_sample_rate)
     )
 
     output_paths = []
@@ -45,20 +51,27 @@ def run_voice_cloning(
         src_wav, src_sr = torchaudio.load(src_path)
         tgt_wav, tgt_sr = torchaudio.load(tgt_path)
 
+        # Validate sampling rates match model expectation
+        if expected_sample_rate is not None:
+            if src_sr != expected_sample_rate:
+                raise ValueError(f"[Pair {i}] Source sample rate {src_sr} != model expected {expected_sample_rate}")
+            if tgt_sr != expected_sample_rate:
+                raise ValueError(f"[Pair {i}] Target sample rate {tgt_sr} != model expected {expected_sample_rate}")
+
         converted = tts.voice_conversion(
             source_wav=src_wav.squeeze(),
             target_wav=tgt_wav.squeeze(),
         )
-
-        import torch
 
         if not isinstance(converted, torch.Tensor):
             converted = torch.tensor(converted)
         if converted.dim() == 1:
             converted = converted.unsqueeze(0)
 
+        # Fall back to source sample rate if output_sample_rate is None
+        sr = output_sample_rate or src_sr
         out_path = str(Path(output_dir) / f"cloned_{i}.flac")
-        torchaudio.save(out_path, converted, output_sample_rate, format="flac")
+        torchaudio.save(out_path, converted, sr, format="flac")
         output_paths.append(out_path)
 
     return {"output_paths": output_paths}

--- a/src/senselab/audio/tasks/voice_cloning/_coqui_worker.py
+++ b/src/senselab/audio/tasks/voice_cloning/_coqui_worker.py
@@ -1,0 +1,64 @@
+"""Coqui TTS worker — runs inside the isolated subprocess venv.
+
+This module is called by call_in_venv() and should NOT be imported
+directly by senselab. It has access to coqui-tts and its own torch.
+"""
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+def run_voice_cloning(
+    source_paths: List[str],
+    target_paths: List[str],
+    model_id: str,
+    device: str,
+    output_dir: str,
+) -> Dict[str, List[str]]:
+    """Run voice cloning in the isolated coqui venv.
+
+    Args:
+        source_paths: Paths to source FLAC files.
+        target_paths: Paths to target FLAC files.
+        model_id: Coqui TTS model identifier.
+        device: "cpu" or "cuda".
+        output_dir: Directory for output FLAC files.
+
+    Returns:
+        Dict with "output_paths" list of cloned audio file paths.
+    """
+    import torchaudio
+    from TTS.api import TTS
+
+    tts = TTS(model_id).to(device=device)
+    audio_config = tts.voice_converter.vc_config.audio
+
+    output_sample_rate = (
+        audio_config.output_sample_rate
+        if hasattr(audio_config, "output_sample_rate")
+        else getattr(audio_config, "sample_rate", None)
+    )
+
+    output_paths = []
+    for i, (src_path, tgt_path) in enumerate(zip(source_paths, target_paths)):
+        src_wav, src_sr = torchaudio.load(src_path)
+        tgt_wav, tgt_sr = torchaudio.load(tgt_path)
+
+        converted = tts.voice_conversion(
+            source_wav=src_wav.squeeze(),
+            target_wav=tgt_wav.squeeze(),
+        )
+
+        import torch
+
+        if not isinstance(converted, torch.Tensor):
+            converted = torch.tensor(converted)
+        if converted.dim() == 1:
+            converted = converted.unsqueeze(0)
+
+        out_path = str(Path(output_dir) / f"cloned_{i}.flac")
+        torchaudio.save(out_path, converted, output_sample_rate, format="flac")
+        output_paths.append(out_path)
+
+    return {"output_paths": output_paths}

--- a/src/senselab/audio/tasks/voice_cloning/coqui.py
+++ b/src/senselab/audio/tasks/voice_cloning/coqui.py
@@ -7,9 +7,7 @@ Audio data is serialized as FLAC for efficient lossless transfer.
 
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional, Union
-
-import torch
+from typing import List, Optional
 
 from senselab.audio.data_structures import Audio
 from senselab.utils.data_structures import CoquiTTSModel, DeviceType
@@ -50,22 +48,20 @@ class CoquiVoiceCloner:
         if len(source_audios) != len(target_audios):
             raise ValueError("Number of source and target audios must be the same.")
 
-        for i, (src, tgt) in enumerate(zip(source_audios, target_audios)):
-            if src.waveform.squeeze().dim() != 1 or tgt.waveform.squeeze().dim() != 1:
-                raise ValueError(f"[Pair {i}] Only mono audio is supported.")
-
-        # Serialize audio to temp FLAC files
         with tempfile.TemporaryDirectory(prefix="senselab-coqui-") as tmpdir:
             tmp = Path(tmpdir)
 
-            # Write source/target audio files
+            # Validate and serialize in a single pass
             source_paths = []
             target_paths = []
             for i, (src, tgt) in enumerate(zip(source_audios, target_audios)):
+                if src.waveform.squeeze().dim() != 1 or tgt.waveform.squeeze().dim() != 1:
+                    raise ValueError(f"[Pair {i}] Only mono audio is supported.")
+
                 src_path = str(tmp / f"source_{i}.flac")
                 tgt_path = str(tmp / f"target_{i}.flac")
-                _save_audio_flac(src, src_path)
-                _save_audio_flac(tgt, tgt_path)
+                src.save_to_file(src_path, format="flac")
+                tgt.save_to_file(tgt_path, format="flac")
                 source_paths.append(src_path)
                 target_paths.append(tgt_path)
 
@@ -90,35 +86,6 @@ class CoquiVoiceCloner:
             cloned_audios = []
             output_paths = result.get("output_paths", []) if isinstance(result, dict) else []
             for out_path in output_paths:
-                audio = _load_audio_flac(out_path)
-                cloned_audios.append(audio)
+                cloned_audios.append(Audio(filepath=out_path))
 
             return cloned_audios
-
-
-def _save_audio_flac(audio: Audio, path: str) -> None:
-    """Save Audio to FLAC (lossless, compressed)."""
-    try:
-        from torchcodec.encoders import AudioEncoder
-
-        encoder = AudioEncoder(samples=audio.waveform, sample_rate=audio.sampling_rate)
-        encoder.to_file(path)
-    except (ImportError, RuntimeError):
-        import torchaudio
-
-        torchaudio.save(path, audio.waveform, audio.sampling_rate, format="flac")
-
-
-def _load_audio_flac(path: str) -> Audio:
-    """Load Audio from FLAC."""
-    try:
-        from torchcodec.decoders import AudioDecoder
-
-        decoder = AudioDecoder(path)
-        samples = decoder.get_all_samples()
-        return Audio(waveform=samples.data, sampling_rate=samples.sample_rate)
-    except (ImportError, RuntimeError):
-        import torchaudio
-
-        waveform, sr = torchaudio.load(path)
-        return Audio(waveform=waveform, sampling_rate=sr)

--- a/src/senselab/audio/tasks/voice_cloning/coqui.py
+++ b/src/senselab/audio/tasks/voice_cloning/coqui.py
@@ -1,41 +1,28 @@
-"""This module contains functions for voice cloning using Coqui TTS."""
+"""Voice cloning using Coqui TTS via isolated subprocess venv.
 
-from typing import Any, Dict, List, Optional, Union
+Coqui TTS has conflicting dependencies (pins old torch versions, requires
+Python <=3.11). It runs in an isolated subprocess venv managed by uv.
+Audio data is serialized as FLAC for efficient lossless transfer.
+"""
 
-try:
-    from TTS.api import TTS
-
-    TTS_AVAILABLE = True
-except ModuleNotFoundError:
-    TTS_AVAILABLE = False
-
+import tempfile
 from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import torch
 
 from senselab.audio.data_structures import Audio
-from senselab.utils.data_structures import CoquiTTSModel, DeviceType, _select_device_and_dtype
-from senselab.utils.dependencies import retry_on_transient_error
+from senselab.utils.data_structures import CoquiTTSModel, DeviceType
+from senselab.utils.subprocess_venv import call_in_venv
+
+# Coqui venv specification
+_COQUI_VENV = "coqui"
+_COQUI_REQUIREMENTS = ["coqui-tts~=0.27", "torch~=2.8", "torchaudio~=2.8"]
+_COQUI_PYTHON = "3.11"
 
 
 class CoquiVoiceCloner:
-    """A factory for managing voice cloning pipelines using Coqui TTS."""
-
-    _models: Dict[str, "TTS"] = {}
-
-    @classmethod
-    def _get_tts_model(cls, model_id: Union[str, Path], user_preference: Optional[DeviceType] = None) -> "TTS":
-        """Get or create a TTS voice conversion pipeline."""
-        if not TTS_AVAILABLE:
-            raise ModuleNotFoundError(
-                "`coqui-tts` is not available. Please install senselab audio dependencies using `pip install senselab`."
-            )
-        device, _ = _select_device_and_dtype(
-            user_preference=user_preference, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]
-        )
-        key = f"{model_id}-{device.value}"
-        if key not in cls._models:
-            tts = retry_on_transient_error(TTS, model_id).to(device=device.value)
-            cls._models[key] = tts
-        return cls._models[key]
+    """Voice cloning via Coqui TTS in an isolated subprocess venv."""
 
     @classmethod
     def clone_voices(
@@ -47,86 +34,91 @@ class CoquiVoiceCloner:
     ) -> List[Audio]:
         """Clone voices from source audios to target audios using Coqui TTS.
 
+        The actual Coqui TTS operations run in an isolated subprocess venv
+        with its own Python and torch version. Audio is transferred via
+        lossless FLAC files.
+
         Args:
-            source_audios (List[Audio]): List of source audio objects.
-            target_audios (List[Audio]): List of target audio objects.
-            model (CoquiTTSModel, optional): The Coqui TTS model to use for voice conversion.
-                All Coqui TTS models are supported, including
-                "voice_conversion_models/multilingual/multi-dataset/knnvc",
-                "voice_conversion_models/multilingual/vctk/freevc24",
-                "voice_conversion_models/multilingual/multi-dataset/openvoice_v1",
-                "voice_conversion_models/multilingual/multi-dataset/openvoice_v2".
-                If None, the default model "voice_conversion_models/multilingual/multi-dataset/knnvc" is used.
-            device (Optional[DeviceType], optional): The device to run the model on.
-                Defaults to None.
+            source_audios: List of source audio objects.
+            target_audios: List of target audio objects.
+            model: Coqui TTS model. Default: knnvc voice conversion.
+            device: Device preference (CUDA or CPU).
         """
-        # Validate model
         if model is None:
             model = CoquiTTSModel(path_or_uri="voice_conversion_models/multilingual/multi-dataset/knnvc")
-        if model._scope != "voice_conversion_models":
-            all_models = TTS.list_models()
-            voice_conversion_models = [m for m in all_models if m.startswith("voice_conversion_models")]
-            raise ValueError(
-                f"Model {model.path_or_uri} is not a voice conversion model. "
-                f"Available voice conversion models: {voice_conversion_models}"
-            )
-
-        # Get TTS pipeline
-        tts = cls._get_tts_model(model_id=model.path_or_uri, user_preference=device)
-
-        # Validate sampling rates
-        audio_config = tts.voice_converter.vc_config.audio
-
-        expected_sample_rate = (
-            audio_config.input_sample_rate
-            if hasattr(audio_config, "input_sample_rate")
-            else getattr(audio_config, "sample_rate", None)
-        )
-
-        output_sample_rate = (
-            audio_config.output_sample_rate
-            if hasattr(audio_config, "output_sample_rate")
-            else getattr(audio_config, "sample_rate", None)
-        )
 
         if len(source_audios) != len(target_audios):
             raise ValueError("Number of source and target audios must be the same.")
 
-        for i, (source_audio, target_audio) in enumerate(zip(source_audios, target_audios)):
-            source_path = (
-                source_audio.filepath() if hasattr(source_audio, "filepath") and source_audio.filepath() else ""
+        for i, (src, tgt) in enumerate(zip(source_audios, target_audios)):
+            if src.waveform.squeeze().dim() != 1 or tgt.waveform.squeeze().dim() != 1:
+                raise ValueError(f"[Pair {i}] Only mono audio is supported.")
+
+        # Serialize audio to temp FLAC files
+        with tempfile.TemporaryDirectory(prefix="senselab-coqui-") as tmpdir:
+            tmp = Path(tmpdir)
+
+            # Write source/target audio files
+            source_paths = []
+            target_paths = []
+            for i, (src, tgt) in enumerate(zip(source_audios, target_audios)):
+                src_path = str(tmp / f"source_{i}.flac")
+                tgt_path = str(tmp / f"target_{i}.flac")
+                _save_audio_flac(src, src_path)
+                _save_audio_flac(tgt, tgt_path)
+                source_paths.append(src_path)
+                target_paths.append(tgt_path)
+
+            # Call coqui in isolated venv
+            result = call_in_venv(
+                name=_COQUI_VENV,
+                requirements=_COQUI_REQUIREMENTS,
+                module="senselab.audio.tasks.voice_cloning._coqui_worker",
+                function="run_voice_cloning",
+                args={
+                    "source_paths": source_paths,
+                    "target_paths": target_paths,
+                    "model_id": str(model.path_or_uri),
+                    "device": device.value if device else "cpu",
+                    "output_dir": str(tmp),
+                },
+                python_version=_COQUI_PYTHON,
+                timeout=600,
             )
-            target_path = (
-                target_audio.filepath() if hasattr(target_audio, "filepath") and target_audio.filepath() else ""
-            )
 
-            source_desc = f"{source_audio.generate_id()}{f' ({source_path})' if source_path else ''}"
-            target_desc = f"{target_audio.generate_id()}{f' ({target_path})' if target_path else ''}"
+            # Load results
+            cloned_audios = []
+            output_paths = result.get("output_paths", []) if isinstance(result, dict) else []
+            for out_path in output_paths:
+                audio = _load_audio_flac(out_path)
+                cloned_audios.append(audio)
 
-            if source_audio.waveform.squeeze().dim() != 1 or target_audio.waveform.squeeze().dim() != 1:
-                raise ValueError(
-                    f"[Pair index {i}] Only mono audio files are supported. "
-                    f"Source: {source_desc}, Target: {target_desc}."
-                )
+            return cloned_audios
 
-            if source_audio.sampling_rate != expected_sample_rate or target_audio.sampling_rate != expected_sample_rate:
-                raise ValueError(
-                    f"[Pair index {i}] Expected sample rate {expected_sample_rate}, but got "
-                    f"{source_audio.sampling_rate} (source) and {target_audio.sampling_rate} (target). "
-                    f"Source: {source_desc}, Target: {target_desc}."
-                )
 
-            # Ensure mono audio
-            source_waveform = source_audio.waveform.squeeze()
-            target_waveform = target_audio.waveform.squeeze()
-            if source_waveform.dim() > 1 or target_waveform.dim() > 1:
-                raise ValueError("Both source and target audios must be mono.")
+def _save_audio_flac(audio: Audio, path: str) -> None:
+    """Save Audio to FLAC (lossless, compressed)."""
+    try:
+        from torchcodec.encoders import AudioEncoder
 
-        cloned_audios = []
-        for source_audio, target_audio in zip(source_audios, target_audios):
-            # Perform voice conversion
-            converted_waveform = tts.voice_conversion(source_wav=source_waveform, target_wav=target_waveform)
+        encoder = AudioEncoder(samples=audio.waveform, sample_rate=audio.sampling_rate)
+        encoder.to_file(path)
+    except (ImportError, RuntimeError):
+        import torchaudio
 
-            cloned_audios.append(Audio(waveform=converted_waveform, sampling_rate=output_sample_rate))
+        torchaudio.save(path, audio.waveform, audio.sampling_rate, format="flac")
 
-        return cloned_audios
+
+def _load_audio_flac(path: str) -> Audio:
+    """Load Audio from FLAC."""
+    try:
+        from torchcodec.decoders import AudioDecoder
+
+        decoder = AudioDecoder(path)
+        samples = decoder.get_all_samples()
+        return Audio(waveform=samples.data, sampling_rate=samples.sample_rate)
+    except (ImportError, RuntimeError):
+        import torchaudio
+
+        waveform, sr = torchaudio.load(path)
+        return Audio(waveform=waveform, sampling_rate=sr)

--- a/src/senselab/utils/compatibility.py
+++ b/src/senselab/utils/compatibility.py
@@ -233,16 +233,17 @@ def check_compatibility(function_key: str) -> bool:
     if entry is None:
         return True
 
-    # Check Python version range
+    # Isolated backends run in their own subprocess venv with their own
+    # Python version — don't check host Python or host deps
+    if entry.isolated:
+        return True
+
+    # Check Python version range (host Python, for non-isolated functions)
     py_ver = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     if not entry.python_versions.contains(py_ver):
         raise RuntimeError(
             f"Function '{function_key}' requires Python {entry.python_versions}, but you are running Python {py_ver}."
         )
-
-    # Isolated backends don't need deps in the host environment
-    if entry.isolated:
-        return True
 
     # Check each required dependency — presence AND version
     for dep in entry.required_deps:


### PR DESCRIPTION
## Changes
- Fix: skip host Python version check for isolated backends (they use their own venv Python)
- Wire coqui voice cloning to subprocess venv (Python 3.11, coqui-tts ~=0.27)
- Audio transferred via FLAC (torchcodec preferred, torchaudio fallback)
- Worker script `_coqui_worker.py` runs inside the isolated venv

## Fixes EC2 3.12 error
`clone_voices` on Python 3.12 was raising RuntimeError because the compat check applied the Python <3.12 constraint to the host. Now it skips the host check for isolated backends.

## Test results
- 434 passed, 0 failed locally
- All 17 pre-commit hooks pass

Generated with Claude Code
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.3.1-alpha.4`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - Fix isolated backend compat check + wire coqui to subprocess venv [#449](https://github.com/sensein/senselab/pull/449) ([@satra](https://github.com/satra))
  
  #### ⚠️ Pushed to `alpha`
  
  - Fix ruff format on audio.py ([@satra](https://github.com/satra))
  - Migrate audio.py to torchcodec with torchaudio fallback ([@satra](https://github.com/satra))
  - Wire compatibility checks into all 13 API entry points ([@satra](https://github.com/satra))
  
  #### Authors: 1
  
  - Satrajit Ghosh ([@satra](https://github.com/satra))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
