### PR TITLE
Fix video I/O: context manager, no-audio guard, temp cleanup

### DIFF
--- a/src/senselab/video/tasks/input_output.py
+++ b/src/senselab/video/tasks/input_output.py
@@ -78,10 +78,11 @@ def extract_audios_from_local_videos(
     with tempfile.TemporaryDirectory(prefix="senselab-video-io-") as temp_dir:
         audio_files_paths = []
         for file in formatted_files:
-            base_file_name = os.path.splitext(str(file.filepath).replace(common_path, ""))[0]
+            rel_path = os.path.relpath(file.filepath, common_path)
+            base_file_name = os.path.splitext(rel_path)[0]
             output_audio_path = os.path.join(temp_dir, f"{base_file_name}.{audio_format}")
             os.makedirs(os.path.dirname(output_audio_path), exist_ok=True)
             if _extract_audio_from_local_video(file.filepath, output_audio_path, fmt=audio_format, codec=acodec):
                 audio_files_paths.append(output_audio_path)
 
-        return read_files_from_disk(audio_files_paths)
+        return read_files_from_disk(audio_files_paths) if audio_files_paths else {}

--- a/src/senselab/video/tasks/input_output.py
+++ b/src/senselab/video/tasks/input_output.py
@@ -1,6 +1,7 @@
 """This module implements the video IOTask."""
 
 import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Union
@@ -9,7 +10,7 @@ import av
 import numpy as np
 import soundfile as sf
 
-from senselab.utils.data_structures import from_strings_to_files, get_common_directory
+from senselab.utils.data_structures import from_strings_to_files, get_common_directory, logger
 from senselab.utils.tasks.input_output import read_files_from_disk
 
 
@@ -33,22 +34,29 @@ def extract_audios_from_local_videos(
         A dataset dict of the extracted audio files.
     """
 
-    def _extract_audio_from_local_video(video_path: Path, output_audio_path: str, fmt: str, codec: str) -> None:
-        """Extract audio from a video file using PyAV."""
-        container = av.open(str(video_path))
-        audio_stream = container.streams.audio[0]
-        sample_rate = audio_stream.rate or 16000
+    def _extract_audio_from_local_video(video_path: Path, output_audio_path: str, fmt: str, codec: str) -> bool:
+        """Extract audio from a video file using PyAV.
 
-        frames = []
-        for frame in container.decode(audio=0):
-            arr = frame.to_ndarray()
-            if arr.ndim > 1:
-                arr = arr.mean(axis=0)  # downmix to mono
-            frames.append(arr)
-        container.close()
+        Returns:
+            True if audio was extracted, False if the video has no audio track.
+        """
+        with av.open(str(video_path)) as container:
+            if not container.streams.audio:
+                logger.warning("No audio track found in %s, skipping.", video_path)
+                return False
+
+            audio_stream = container.streams.audio[0]
+            sample_rate = audio_stream.rate or 16000
+
+            frames = []
+            for frame in container.decode(audio=0):
+                arr = frame.to_ndarray()
+                if arr.ndim > 1:
+                    arr = arr.mean(axis=0)  # downmix to mono
+                frames.append(arr)
 
         if not frames:
-            return
+            return False
 
         audio_data = np.concatenate(frames)
 
@@ -61,6 +69,7 @@ def extract_audios_from_local_videos(
             )
 
         sf.write(output_audio_path, audio_data, sample_rate, format=fmt.upper())
+        return True
 
     if isinstance(files, str):
         files = [files]
@@ -69,12 +78,17 @@ def extract_audios_from_local_videos(
 
     temp_dir = tempfile.mkdtemp()
 
-    audio_files_paths = []
-    for file in formatted_files:
-        base_file_name = os.path.splitext(str(file.filepath).replace(common_path, ""))[0]
-        output_audio_path = os.path.join(temp_dir, f"{base_file_name}.{audio_format}")
-        os.makedirs(os.path.dirname(output_audio_path), exist_ok=True)
-        _extract_audio_from_local_video(file.filepath, output_audio_path, fmt=audio_format, codec=acodec)
-        audio_files_paths.append(output_audio_path)
+    try:
+        audio_files_paths = []
+        for file in formatted_files:
+            base_file_name = os.path.splitext(str(file.filepath).replace(common_path, ""))[0]
+            output_audio_path = os.path.join(temp_dir, f"{base_file_name}.{audio_format}")
+            os.makedirs(os.path.dirname(output_audio_path), exist_ok=True)
+            if _extract_audio_from_local_video(file.filepath, output_audio_path, fmt=audio_format, codec=acodec):
+                audio_files_paths.append(output_audio_path)
 
-    return read_files_from_disk(audio_files_paths)
+        result = read_files_from_disk(audio_files_paths)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    return result

--- a/src/senselab/video/tasks/input_output.py
+++ b/src/senselab/video/tasks/input_output.py
@@ -1,7 +1,6 @@
 """This module implements the video IOTask."""
 
 import os
-import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Union
@@ -76,9 +75,7 @@ def extract_audios_from_local_videos(
     formatted_files = from_strings_to_files(files)
     common_path = get_common_directory(files)
 
-    temp_dir = tempfile.mkdtemp()
-
-    try:
+    with tempfile.TemporaryDirectory(prefix="senselab-video-io-") as temp_dir:
         audio_files_paths = []
         for file in formatted_files:
             base_file_name = os.path.splitext(str(file.filepath).replace(common_path, ""))[0]
@@ -87,8 +84,4 @@ def extract_audios_from_local_videos(
             if _extract_audio_from_local_video(file.filepath, output_audio_path, fmt=audio_format, codec=acodec):
                 audio_files_paths.append(output_audio_path)
 
-        result = read_files_from_disk(audio_files_paths)
-    finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)
-
-    return result
+        return read_files_from_disk(audio_files_paths)


### PR DESCRIPTION
Addresses PR #482 review comments:
- `with av.open()` context manager for proper resource cleanup
- Guard against videos with no audio track (was IndexError on `streams.audio[0]`)
- Temp directory cleaned up with `shutil.rmtree` in `finally` block
- Videos without audio are skipped with a warning instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.3.1-alpha.19`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - Fix video I/O: context manager, no-audio guard, temp cleanup [#483](https://github.com/sensein/senselab/pull/483) ([@satra](https://github.com/satra))
  
  #### Authors: 1
  
  - Satrajit Ghosh ([@satra](https://github.com/satra))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
