### PR TITLE
Remove sentence2 from lab: single audio throughout

### DIFF
--- a/tutorials/audio/speech_representations_lab.ipynb
+++ b/tutorials/audio/speech_representations_lab.ipynb
@@ -78,8 +78,7 @@
                 "## Part 1: Recording and Preparation\n",
                 "\n",
                 "For a speech/hearing course, everyone should record the same **standard sentence**\n",
-                "so that results can be compared across students. We also load a second recording\n",
-                "from a different speaker for voice conversion later.\n",
+                "so that results can be compared across students.\n",
                 "\n",
                 "The standard sentence below is designed to exercise a wide variety of English\n",
                 "phonemes and articulatory gestures:\n",
@@ -87,7 +86,7 @@
                 "> *\"The beige ant carried a muffin over the head of Liberty!\"*\n",
                 "\n",
                 "If you are running in Google Colab with a microphone, you can record your own\n",
-                "voice. Otherwise, sample files are downloaded automatically."
+                "voice. Otherwise, a sample file is downloaded automatically.\n"
             ]
         },
         {
@@ -158,35 +157,27 @@
             "source": [
                 "from pathlib import Path\n",
                 "\n",
-                "# Load recorded audio if available, otherwise download sample files\n",
+                "# Load recorded audio if available, otherwise download a sample file\n",
                 "import urllib.request\n",
                 "\n",
                 "base_url = \"https://github.com/sensein/senselab/raw/main/src/tests/data_for_testing\"\n",
+                "dest = Path(\"tutorial_audio_files/audio_48khz_mono_16bits.wav\")\n",
+                "if not dest.exists():\n",
+                "    Path(\"tutorial_audio_files\").mkdir(exist_ok=True)\n",
+                "    urllib.request.urlretrieve(f\"{base_url}/audio_48khz_mono_16bits.wav\", str(dest))\n",
                 "\n",
-                "# Download sample files as fallback\n",
-                "for fname in [\"audio_48khz_mono_16bits.wav\", \"audio_48khz_stereo_16bits.wav\"]:\n",
-                "    dest = Path(\"tutorial_audio_files\") / fname\n",
-                "    if not dest.exists():\n",
-                "        urllib.request.urlretrieve(f\"{base_url}/{fname}\", str(dest))\n",
-                "\n",
-                "# Use recording if available, otherwise use sample\n",
+                "# Use recording if available\n",
                 "rec_path = Path(\"tutorial_audio_files/my_recording.wav\")\n",
                 "if rec_path.exists() and rec_path.stat().st_size > 1000:\n",
-                "    sentence1 = Audio(filepath=str(rec_path.resolve()))\n",
-                "    print(\"Sentence 1: using your recording\")\n",
+                "    audio = Audio(filepath=str(rec_path.resolve()))\n",
+                "    print(\"Using your recording\")\n",
                 "else:\n",
-                "    sentence1 = Audio(filepath=os.path.abspath(\"tutorial_audio_files/audio_48khz_mono_16bits.wav\"))\n",
-                "    print(\"Sentence 1: using sample audio\")\n",
-                "\n",
-                "# Second audio for speaker comparison (always sample)\n",
-                "sentence2_raw = Audio(filepath=os.path.abspath(\"tutorial_audio_files/audio_48khz_stereo_16bits.wav\"))\n",
+                "    audio = Audio(filepath=os.path.abspath(\"tutorial_audio_files/audio_48khz_mono_16bits.wav\"))\n",
+                "    print(\"Using sample audio\")\n",
                 "\n",
                 "# Preprocess: mono + 16kHz\n",
-                "sentence1_16k = resample_audios(downmix_audios_to_mono([sentence1]), resample_rate=16000)[0]\n",
-                "sentence2_16k = resample_audios(downmix_audios_to_mono([sentence2_raw]), resample_rate=16000)[0]\n",
-                "\n",
-                "print(f\"Sentence 1: {sentence1_16k.waveform.shape[1] / 16000:.2f}s at 16kHz\")\n",
-                "print(f\"Sentence 2: {sentence2_16k.waveform.shape[1] / 16000:.2f}s at 16kHz (sample, for comparison)\")"
+                "audio_16k = resample_audios(downmix_audios_to_mono([audio]), resample_rate=16000)[0]\n",
+                "print(f\"Audio: {audio_16k.waveform.shape[1] / 16000:.2f}s at 16kHz\")"
             ]
         },
         {
@@ -195,8 +186,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "print(\"Sentence 1:\")\n",
-                "play_audio(sentence1_16k)"
+                "play_audio(audio_16k)"
             ]
         },
         {
@@ -205,35 +195,17 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "print(\"Sentence 2:\")\n",
-                "play_audio(sentence2_16k)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Waveforms side by side\n",
-                "fig, axes = plt.subplots(2, 1, figsize=(12, 4), sharex=False)\n",
+                "# Waveform visualization\n",
+                "wf = audio_16k.waveform.squeeze().cpu().numpy()\n",
+                "duration = len(wf) / audio_16k.sampling_rate\n",
+                "time_axis = np.linspace(0, duration, len(wf), endpoint=False)\n",
                 "\n",
-                "wf1 = sentence1_16k.waveform.squeeze().numpy()\n",
-                "wf2 = sentence2_16k.waveform.squeeze().numpy()\n",
-                "t1 = np.linspace(0, len(wf1) / 16000, len(wf1))\n",
-                "t2 = np.linspace(0, len(wf2) / 16000, len(wf2))\n",
-                "\n",
-                "axes[0].plot(t1, wf1, linewidth=0.3, color=\"steelblue\")\n",
-                "axes[0].set_ylabel(\"Amplitude\")\n",
-                "axes[0].set_title(\"Sentence 1\")\n",
-                "axes[0].grid(True, alpha=0.2)\n",
-                "\n",
-                "axes[1].plot(t2, wf2, linewidth=0.3, color=\"coral\")\n",
-                "axes[1].set_ylabel(\"Amplitude\")\n",
-                "axes[1].set_title(\"Sentence 2\")\n",
-                "axes[1].set_xlabel(\"Time (seconds)\")\n",
-                "axes[1].grid(True, alpha=0.2)\n",
-                "\n",
+                "fig, ax = plt.subplots(figsize=(12, 3))\n",
+                "ax.plot(time_axis, wf, linewidth=0.3, color=\"steelblue\")\n",
+                "ax.set_xlabel(\"Time (seconds)\")\n",
+                "ax.set_ylabel(\"Amplitude\")\n",
+                "ax.set_title(\"Audio Waveform\")\n",
+                "ax.grid(True, alpha=0.2)\n",
                 "plt.tight_layout()\n",
                 "plt.show()"
             ]
@@ -271,7 +243,7 @@
             "outputs": [],
             "source": [
                 "# Extract SPARC articulatory features\n",
-                "sparc_features = SparcFeatureExtractor.extract_sparc_features(audios=[sentence1_16k], device=device, resample=True)\n",
+                "sparc_features = SparcFeatureExtractor.extract_sparc_features(audios=[audio_16k], device=device, resample=True)\n",
                 "features1 = sparc_features[0]\n",
                 "print(f\"EMA shape: {features1['ema'].shape}  (channels x frames)\")\n",
                 "print(f\"Pitch shape: {features1['pitch'].shape}\")\n",
@@ -414,7 +386,7 @@
                 "print(f\"Resynthesized: {resynthesized.waveform.shape[1] / resynthesized.sampling_rate:.2f}s\")\n",
                 "\n",
                 "print(\"\\nOriginal:\")\n",
-                "play_audio(sentence1_16k)"
+                "play_audio(audio_16k)"
             ]
         },
         {
@@ -445,7 +417,7 @@
             "outputs": [],
             "source": [
                 "# Extract acoustic pitch contour\n",
-                "pitch_result = extract_pitch_from_audios([sentence1_16k], freq_low=80, freq_high=500)\n",
+                "pitch_result = extract_pitch_from_audios([audio_16k], freq_low=80, freq_high=500)\n",
                 "pitch_contour = pitch_result[0][\"pitch\"].squeeze()\n",
                 "\n",
                 "# Build time axis (default hop length for torchaudio pitch detection)\n",
@@ -488,7 +460,7 @@
             "outputs": [],
             "source": [
                 "# Extract phonetic posteriorgrams\n",
-                "ppgs = extract_ppgs_from_audios([sentence1_16k], device=device)\n",
+                "ppgs = extract_ppgs_from_audios([audio_16k], device=device)\n",
                 "ppg1 = ppgs[0]\n",
                 "print(f\"PPG shape: {ppg1.shape}\")\n",
                 "print(\"Each column is a time frame; each row is a phoneme probability.\")"
@@ -501,7 +473,7 @@
             "outputs": [],
             "source": [
                 "# Phoneme duration analysis from PPG\n",
-                "durations = extract_mean_phoneme_durations(sentence1_16k, ppg1)\n",
+                "durations = extract_mean_phoneme_durations(audio_16k, ppg1)\n",
                 "print(f\"Analysis: {durations['frame_count']} frames over {durations['analysis_duration_seconds']:.2f}s\")\n",
                 "print(\"\\n=== Top 10 Phonemes by Total Duration ===\")\n",
                 "for p in sorted(durations[\"phoneme_durations\"], key=lambda x: x[\"total_duration_seconds\"], reverse=True)[:10]:\n",
@@ -531,7 +503,7 @@
                 "\n",
                 "# Get PPG segments for plotting\n",
                 "frame_major = to_frame_major_posteriorgram(ppg1)\n",
-                "segments = extract_ppg_segments(sentence1_16k, frame_major)\n",
+                "segments = extract_ppg_segments(audio_16k, frame_major)\n",
                 "\n",
                 "# Convert PPG segments to plot_aligned_panels format\n",
                 "ppg_segments = [\n",
@@ -544,7 +516,7 @@
                 "pitch_data = [(time_pitch[voiced_mask], pitch_contour[voiced_mask], \"F0\", \"steelblue\")]\n",
                 "\n",
                 "plot_aligned_panels(\n",
-                "    sentence1_16k,\n",
+                "    audio_16k,\n",
                 "    [\n",
                 "        {\"type\": \"waveform\"},\n",
                 "        {\"type\": \"spectrogram\", \"mel\": False},\n",
@@ -588,7 +560,7 @@
             "source": [
                 "# Get PPG segments for the comparison\n",
                 "frame_major = to_frame_major_posteriorgram(ppg1)\n",
-                "segments = extract_ppg_segments(sentence1_16k, frame_major)\n",
+                "segments = extract_ppg_segments(audio_16k, frame_major)\n",
                 "ppg_segments = [\n",
                 "    {\"label\": seg[\"phoneme\"], \"start\": seg[\"start_seconds\"], \"end\": seg[\"start_seconds\"] + seg[\"duration_seconds\"]}\n",
                 "    for seg in segments\n",
@@ -620,7 +592,7 @@
                 "    ema_data.append((time_ema, signal, name, color_map.get(artic, \"gray\")))\n",
                 "\n",
                 "plot_aligned_panels(\n",
-                "    sentence1_16k,\n",
+                "    audio_16k,\n",
                 "    [\n",
                 "        {\"type\": \"waveform\"},\n",
                 "        {\"type\": \"features\", \"data\": pitch_comparison_data, \"style\": \"line\"},\n",


### PR DESCRIPTION
Removes all sentence2 references from the speech representations lab.
Voice conversion was removed earlier but sentence2 loading, playback,
and waveform plotting remained.

Now uses single `audio_16k` throughout. 32 cells, all pass papermill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.3.1-alpha.22`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - Remove sentence2 from lab: single audio throughout [#489](https://github.com/sensein/senselab/pull/489) ([@satra](https://github.com/satra))
  
  #### Authors: 1
  
  - Satrajit Ghosh ([@satra](https://github.com/satra))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
