### PR TITLE
Promote scalene profiling wrapper to main (alpha→main)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,10 @@ dev = [
 docs = [
   "pdoc~=16.0"
 ]
+profiling = [
+  "scalene>=2.2",
+  "nbconvert>=7"
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/senselab"]

--- a/scripts/profile_with_scalene.py
+++ b/scripts/profile_with_scalene.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Profile any Python script or Jupyter notebook with Scalene.
+
+A thin wrapper around Scalene 2.2's `run` and `view` subcommands that:
+- Accepts .py or .ipynb targets (notebooks are auto-converted via nbconvert)
+- Produces a standalone HTML report (default) or JSON profile
+- Supports path-substring scoping (--scope, --no-thirdparty, --exclude)
+- Writes reports to artifacts/scalene/ with a timestamp suffix
+
+Install:
+    uv sync --group profiling
+
+Examples:
+    uv run python scripts/profile_with_scalene.py path/to/script.py
+    uv run python scripts/profile_with_scalene.py tutorials/audio/speech_to_text.ipynb
+    uv run python scripts/profile_with_scalene.py --scope speech_to_text examples/run.py
+    uv run python scripts/profile_with_scalene.py examples/run.py --- --input my.wav
+
+See specs/20260503-235625-scalene-profiling/contracts/cli.md for the full CLI reference.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+# Exit codes (mirrors contracts/cli.md)
+EXIT_SUCCESS = 0
+EXIT_PROFILING_FAILED = 1
+EXIT_SCALENE_MISSING = 3
+EXIT_INVALID_ARGS = 4
+EXIT_NBCONVERT_MISSING = 5
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI arguments. Args after a literal `---` are forwarded to the target."""
+    if "---" in argv:
+        sep = argv.index("---")
+        own_argv = argv[:sep]
+        target_args = argv[sep + 1 :]
+    else:
+        own_argv = argv
+        target_args = []
+
+    parser = argparse.ArgumentParser(
+        description="Profile a Python script or Jupyter notebook with Scalene.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Use `---` (three dashes) to separate target script arguments:\n"
+            "  profile_with_scalene.py script.py --- --input my.wav --batch 4"
+        ),
+    )
+    parser.add_argument("target", help="Path to a .py script or .ipynb notebook")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifacts/scalene"),
+        help="Directory where the report is written (default: artifacts/scalene/)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("html", "json"),
+        default="html",
+        help="Report format. JSON is Scalene's native run output; HTML adds a view step.",
+    )
+    parser.add_argument(
+        "--cpu-only",
+        action="store_true",
+        help="Skip memory profiling for a faster run",
+    )
+    parser.add_argument(
+        "--gpu",
+        action="store_true",
+        help="Enable GPU profiling (no-op on macOS; requires CUDA)",
+    )
+    parser.add_argument(
+        "--exclude",
+        metavar="SUBSTR",
+        default=None,
+        help="Exclude files whose path contains SUBSTR (substring match against file paths)",
+    )
+    parser.add_argument(
+        "--keep-intermediate",
+        action="store_true",
+        help=(
+            "Retain the intermediate JSON profile (for --format html) and the converted "
+            ".py file (for notebook targets) next to the final report"
+        ),
+    )
+    scope_group = parser.add_mutually_exclusive_group()
+    scope_group.add_argument(
+        "--scope",
+        metavar="SUBSTR",
+        default=None,
+        help=(
+            "Profile only files whose path contains SUBSTR (substring match against file "
+            "paths, not function names). Mutually exclusive with --no-thirdparty."
+        ),
+    )
+    scope_group.add_argument(
+        "--no-thirdparty",
+        action="store_true",
+        help=("Restrict profiling to files with 'senselab' in their path. Mutually exclusive with --scope."),
+    )
+
+    ns = parser.parse_args(own_argv)
+    ns.target_args = target_args
+    return ns
+
+
+def check_scalene_available() -> None:
+    """Exit with code 3 and an install hint if Scalene is missing."""
+    if importlib.util.find_spec("scalene") is None:
+        print(
+            "ERROR: Scalene is not installed in this environment.\nTo install: uv sync --group profiling",
+            file=sys.stderr,
+        )
+        sys.exit(EXIT_SCALENE_MISSING)
+
+
+def check_nbconvert_available() -> None:
+    """Exit with code 5 and an install hint if nbconvert is missing."""
+    if importlib.util.find_spec("nbconvert") is None:
+        print(
+            "ERROR: nbconvert is not installed; required to profile notebooks.\nTo install: uv sync --group profiling",
+            file=sys.stderr,
+        )
+        sys.exit(EXIT_NBCONVERT_MISSING)
+
+
+def validate_target(target: Path) -> str:
+    """Return target kind ('python_script' or 'jupyter_notebook'); exit 4 if invalid."""
+    if not target.exists() or not target.is_file():
+        print(f"ERROR: target file does not exist or is not a file: {target}", file=sys.stderr)
+        sys.exit(EXIT_INVALID_ARGS)
+
+    suffix = target.suffix.lower()
+    if suffix == ".py":
+        return "python_script"
+    if suffix == ".ipynb":
+        return "jupyter_notebook"
+    print(
+        f"ERROR: unsupported target extension '{suffix}'. Expected .py or .ipynb.",
+        file=sys.stderr,
+    )
+    sys.exit(EXIT_INVALID_ARGS)
+
+
+_IPYTHON_STUB = """\
+# Auto-injected by profile_with_scalene.py — stub IPython helpers so
+# notebooks converted via nbconvert can run as plain Python under Scalene.
+# This is best-effort: cells whose semantics depend on real IPython behavior
+# (e.g., `%matplotlib inline` actually configuring backends, `!shell-cmd`
+# side effects, `display(obj)` returning a value, widget event loops) will
+# silently no-op. Profile the resulting script accordingly.
+import sys as _scalene_wrapper_sys
+import types as _scalene_wrapper_types
+
+class _NoOpIPython:
+    def __getattr__(self, name):
+        return self
+    def __call__(self, *args, **kwargs):
+        return None
+
+def get_ipython():  # noqa: N802
+    return _NoOpIPython()
+
+# Stub the IPython package + common submodules so `from IPython.display import display`
+# and similar import statements (preserved verbatim by nbconvert) do not raise.
+if "IPython" not in _scalene_wrapper_sys.modules:
+    _ipy = _scalene_wrapper_types.ModuleType("IPython")
+    _ipy.get_ipython = get_ipython
+    _scalene_wrapper_sys.modules["IPython"] = _ipy
+    for _sub in ("display", "core", "core.display", "core.magic"):
+        _mod = _scalene_wrapper_types.ModuleType(f"IPython.{_sub}")
+        # Any attribute access on these modules returns a no-op callable
+        _mod.__getattr__ = lambda name: (lambda *a, **k: None)
+        _scalene_wrapper_sys.modules[f"IPython.{_sub}"] = _mod
+    # Convenience: `display` is the most-imported name; expose it directly.
+    _scalene_wrapper_sys.modules["IPython.display"].display = lambda *a, **k: None
+del _scalene_wrapper_sys, _scalene_wrapper_types
+"""
+
+
+def convert_notebook(notebook: Path, tmpdir: Path) -> Path:
+    """Convert a notebook to .py via nbconvert; return the resulting .py path.
+
+    nbconvert translates IPython magics (e.g., `%matplotlib inline`) into
+    `get_ipython().run_line_magic(...)` calls. Those fail when the converted
+    file is run as plain Python. We prepend a no-op `get_ipython` stub so
+    magic calls become harmless no-ops during profiling.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "nbconvert",
+        "--to",
+        "script",
+        "--output-dir",
+        str(tmpdir),
+        str(notebook),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        print("ERROR: nbconvert failed:", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(EXIT_PROFILING_FAILED)
+    # nbconvert may emit warnings to stderr even when returncode == 0 (e.g., missing
+    # kernel spec, deprecation notices). Forward them so they do not silently disappear.
+    if result.stderr.strip():
+        print(result.stderr, end="", file=sys.stderr)
+    # nbconvert decides the output extension from kernel metadata: .py for Python
+    # notebooks, .txt as a fallback for non-Python kernels (or notebooks lacking
+    # language_info). We accept either and rename .txt -> .py before profiling.
+    candidates = [tmpdir / f"{notebook.stem}.py", tmpdir / f"{notebook.stem}.txt"]
+    converted = next((p for p in candidates if p.exists()), None)
+    if converted is None:
+        produced = list(tmpdir.iterdir())
+        print(
+            f"ERROR: nbconvert did not produce expected file. Looked for: "
+            f"{[str(c) for c in candidates]}; tmpdir contents: {[str(p) for p in produced]}",
+            file=sys.stderr,
+        )
+        sys.exit(EXIT_PROFILING_FAILED)
+    # Always run as a .py so Scalene's --program-path heuristics work consistently.
+    if converted.suffix != ".py":
+        py_path = converted.with_suffix(".py")
+        converted.rename(py_path)
+        converted = py_path
+    original = converted.read_text(encoding="utf-8")
+    converted.write_text(_inject_ipython_stub(original), encoding="utf-8")
+    return converted
+
+
+_FUTURE_IMPORT_RE = re.compile(r"^\s*from\s+__future__\s+import\b")
+
+
+def _inject_ipython_stub(source: str) -> str:
+    """Return ``source`` with ``_IPYTHON_STUB`` inserted at a syntactically valid spot.
+
+    ``from __future__`` imports must be the first non-docstring/comment statement
+    in a Python file, so the stub cannot be placed before them. Walk the source
+    line-by-line, find the index just after any ``from __future__`` block, and
+    insert the stub there. When no future imports are present, the stub goes at
+    the very top.
+    """
+    lines = source.splitlines(keepends=True)
+    insert_at = 0
+    for i, line in enumerate(lines):
+        if _FUTURE_IMPORT_RE.match(line):
+            insert_at = i + 1
+    return "".join(lines[:insert_at]) + _IPYTHON_STUB + "\n" + "".join(lines[insert_at:])
+
+
+def build_run_command(
+    target: Path,
+    target_args: list[str],
+    json_path: Path,
+    args: argparse.Namespace,
+) -> list[str]:
+    """Build the `scalene run` command list."""
+    cmd = [sys.executable, "-m", "scalene", "run", "-o", str(json_path)]
+
+    if args.cpu_only:
+        cmd.append("--cpu-only")
+    if args.gpu:
+        cmd.append("--gpu")
+    if args.scope is not None:
+        cmd.extend(["--profile-only", args.scope])
+    elif args.no_thirdparty:
+        cmd.extend(["--profile-only", "senselab"])
+    if args.exclude is not None:
+        cmd.extend(["--profile-exclude", args.exclude])
+
+    cmd.append(str(target))
+    if target_args:
+        cmd.append("---")
+        cmd.extend(target_args)
+    return cmd
+
+
+def run_view_step(json_path: Path, work_dir: Path) -> Path:
+    """Run `scalene view --standalone` to produce HTML; return the HTML path.
+
+    Scalene's `view --standalone` writes to `scalene-profile.html` in the current
+    working directory (not next to the input JSON). We run it inside `work_dir`
+    and rename the result to a deterministic per-target name.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "scalene",
+        "view",
+        "--standalone",
+        str(json_path),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=work_dir, check=False)
+    if result.returncode != 0:
+        print("ERROR: scalene view failed:", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(EXIT_PROFILING_FAILED)
+    produced = work_dir / "scalene-profile.html"
+    if not produced.exists():
+        print(
+            f"ERROR: scalene view did not produce expected file: {produced}",
+            file=sys.stderr,
+        )
+        sys.exit(EXIT_PROFILING_FAILED)
+    renamed = work_dir / json_path.with_suffix(".html").name
+    produced.rename(renamed)
+    return renamed
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the wrapper end-to-end and return the wrapper's exit code."""
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+
+    check_scalene_available()
+
+    target = Path(args.target).resolve()
+    kind = validate_target(target)
+    if kind == "jupyter_notebook":
+        check_nbconvert_available()
+
+    if sys.platform == "darwin" and args.gpu:
+        print(
+            "Note: GPU profiling is not available on macOS; GPU columns will be empty.",
+            file=sys.stderr,
+        )
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Timestamp + PID + short token: avoids collisions when two runs hit the
+    # same second (e.g., concurrent CI invocations or rapid local re-runs).
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    suffix = f"{timestamp}-{os.getpid()}-{secrets.token_hex(2)}"
+    json_filename = f"{target.stem}_{suffix}.json"
+    final_json_path = args.output_dir / json_filename
+    final_html_path = final_json_path.with_suffix(".html")
+
+    with tempfile.TemporaryDirectory(prefix="scalene_profile_") as tmpdir_str:
+        tmpdir = Path(tmpdir_str)
+
+        if kind == "jupyter_notebook":
+            run_target = convert_notebook(target, tmpdir)
+            if args.keep_intermediate:
+                kept_py = args.output_dir / f"{target.stem}_{timestamp}.py"
+                shutil.copy2(run_target, kept_py)
+                print(f"Kept converted notebook: {kept_py}")
+        else:
+            run_target = target
+
+        intermediate_json = tmpdir / json_filename
+        run_cmd = build_run_command(run_target, args.target_args, intermediate_json, args)
+        run_result = subprocess.run(run_cmd, text=True, check=False)
+        if run_result.returncode != 0 or not intermediate_json.exists():
+            print(
+                "ERROR: scalene run failed (target script may have raised, or Scalene errored).",
+                file=sys.stderr,
+            )
+            return EXIT_PROFILING_FAILED
+
+        if args.format == "json":
+            shutil.move(str(intermediate_json), str(final_json_path))
+            report_path = final_json_path
+        else:
+            html_in_tmp = run_view_step(intermediate_json, tmpdir)
+            shutil.move(str(html_in_tmp), str(final_html_path))
+            report_path = final_html_path
+            if args.keep_intermediate:
+                shutil.move(str(intermediate_json), str(final_json_path))
+
+    print(f"Scalene profile written to: {report_path}")
+    if sys.platform == "darwin":
+        print(f"Open with: open {report_path}")
+    elif sys.platform.startswith("linux"):
+        print(f"Open with: xdg-open {report_path}")
+    return EXIT_SUCCESS
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/profile_with_scalene.py
+++ b/scripts/profile_with_scalene.py
@@ -26,6 +26,7 @@ import importlib.util
 import os
 import re
 import secrets
+import shlex
 import shutil
 import subprocess
 import sys
@@ -379,11 +380,12 @@ def main(argv: list[str] | None = None) -> int:
             if args.keep_intermediate:
                 shutil.move(str(intermediate_json), str(final_json_path))
 
+    quoted_path = shlex.quote(str(report_path))
     print(f"Scalene profile written to: {report_path}")
     if sys.platform == "darwin":
-        print(f"Open with: open {report_path}")
+        print(f"Open with: open {quoted_path}")
     elif sys.platform.startswith("linux"):
-        print(f"Open with: xdg-open {report_path}")
+        print(f"Open with: xdg-open {quoted_path}")
     return EXIT_SUCCESS
 
 

--- a/src/tests/scripts/profile_with_scalene_test.py
+++ b/src/tests/scripts/profile_with_scalene_test.py
@@ -180,6 +180,37 @@ def test_wrapper_handles_notebook_with_future_imports(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not scalene_available, reason="scalene not installed")
+def test_wrapper_quotes_paths_with_spaces(tmp_path: Path) -> None:
+    """The 'Open with' hint shell-quotes paths so spaces are handled correctly."""
+    out_dir = tmp_path / "dir with space"
+    target = tmp_path / "tiny.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(WRAPPER),
+            "--output-dir",
+            str(out_dir),
+            str(target),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    # The "Open with" line must contain a shell-quoted path so a copy-paste
+    # of the printed command works in zsh/bash.
+    open_lines = [ln for ln in result.stdout.splitlines() if ln.startswith("Open with:")]
+    assert len(open_lines) == 1, f"expected one Open-with line, got: {open_lines}"
+    line = open_lines[0]
+    # shlex.quote wraps in single quotes when the string contains a space
+    assert "'" in line and "dir with space" in line, f"path with space was not shell-quoted in: {line}"
+
+
+@pytest.mark.skipif(not scalene_available, reason="scalene not installed")
 def test_wrapper_rejects_missing_target(tmp_path: Path) -> None:
     """The wrapper exits with code 4 when the target does not exist."""
     result = subprocess.run(

--- a/src/tests/scripts/profile_with_scalene_test.py
+++ b/src/tests/scripts/profile_with_scalene_test.py
@@ -1,0 +1,217 @@
+"""Smoke test for scripts/profile_with_scalene.py.
+
+Skipped automatically when Scalene is not installed (the default `uv sync` install
+path), so the existing CI test suite is unaffected by this addition.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WRAPPER = REPO_ROOT / "scripts" / "profile_with_scalene.py"
+
+scalene_available = importlib.util.find_spec("scalene") is not None
+
+
+@pytest.mark.skipif(not scalene_available, reason="scalene not installed")
+def test_wrapper_produces_html_report(tmp_path: Path) -> None:
+    """The wrapper produces a standalone HTML report for a trivial script."""
+    target = tmp_path / "tiny.py"
+    target.write_text(
+        "import time\ntime.sleep(0.05)\n_ = [i * i for i in range(2000)]\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "reports"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(WRAPPER),
+            "--output-dir",
+            str(out_dir),
+            str(target),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"wrapper exit={result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    htmls = list(out_dir.glob("tiny_*.html"))
+    assert len(htmls) == 1, f"expected one HTML report, found: {htmls}"
+    assert htmls[0].stat().st_size > 1000, "HTML report is suspiciously small"
+
+
+@pytest.mark.skipif(not scalene_available, reason="scalene not installed")
+def test_wrapper_json_format(tmp_path: Path) -> None:
+    """With --format json, the wrapper produces a JSON profile and skips the view step."""
+    target = tmp_path / "tiny.py"
+    target.write_text("x = sum(i * i for i in range(1000))\n", encoding="utf-8")
+    out_dir = tmp_path / "reports"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(WRAPPER),
+            "--format",
+            "json",
+            "--output-dir",
+            str(out_dir),
+            str(target),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    jsons = list(out_dir.glob("tiny_*.json"))
+    assert len(jsons) == 1, f"expected one JSON profile, found: {jsons}"
+
+
+@pytest.mark.skipif(not scalene_available, reason="scalene not installed")
+def test_wrapper_handles_notebook_with_ipython_imports(tmp_path: Path) -> None:
+    """The wrapper profiles a notebook whose cells use IPython imports + magics.
+
+    Verifies that the injected IPython stub covers `from IPython.display import display`
+    (a common nbconvert output pattern) and `get_ipython().run_line_magic(...)`
+    (how nbconvert translates `%matplotlib inline` and similar).
+    """
+    nb_path = tmp_path / "needs_ipython.ipynb"
+    nb_path.write_text(
+        "{\n"
+        ' "cells": [{\n'
+        '  "cell_type": "code",\n'
+        '  "metadata": {},\n'
+        '  "source": [\n'
+        '    "from IPython.display import display\\n",\n'
+        '    "get_ipython().run_line_magic(\\"matplotlib\\", \\"inline\\")\\n",\n'
+        '    "import time\\n",\n'
+        '    "time.sleep(0.05)\\n",\n'
+        '    "display(\\"hello\\")\\n",\n'
+        '    "_ = [i * i for i in range(1000)]\\n"\n'
+        "  ],\n"
+        '  "outputs": [],\n'
+        '  "execution_count": null\n'
+        " }],\n"
+        ' "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},\n'
+        '              "language_info": {"name": "python"}},\n'
+        ' "nbformat": 4, "nbformat_minor": 4\n'
+        "}\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "reports"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(WRAPPER),
+            "--output-dir",
+            str(out_dir),
+            str(nb_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"wrapper exit={result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    htmls = list(out_dir.glob("needs_ipython_*.html"))
+    assert len(htmls) == 1, f"expected one HTML report, found: {htmls}"
+
+
+@pytest.mark.skipif(not scalene_available, reason="scalene not installed")
+def test_wrapper_handles_notebook_with_future_imports(tmp_path: Path) -> None:
+    """Notebook starting with `from __future__ import annotations` profiles cleanly.
+
+    `from __future__` imports must be the first statement in a Python file,
+    so the IPython stub must be injected AFTER any such imports rather than
+    blindly prepended. Regression test for the SyntaxError that prepending
+    would otherwise produce.
+    """
+    nb_path = tmp_path / "with_future.ipynb"
+    nb_path.write_text(
+        "{\n"
+        ' "cells": [{\n'
+        '  "cell_type": "code",\n'
+        '  "metadata": {},\n'
+        '  "source": [\n'
+        '    "from __future__ import annotations\\n",\n'
+        '    "import time\\n",\n'
+        '    "time.sleep(0.05)\\n",\n'
+        '    "_ = [i * i for i in range(1000)]\\n"\n'
+        "  ],\n"
+        '  "outputs": [],\n'
+        '  "execution_count": null\n'
+        " }],\n"
+        ' "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},\n'
+        '              "language_info": {"name": "python"}},\n'
+        ' "nbformat": 4, "nbformat_minor": 4\n'
+        "}\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "reports"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(WRAPPER),
+            "--output-dir",
+            str(out_dir),
+            str(nb_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"wrapper exit={result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    htmls = list(out_dir.glob("with_future_*.html"))
+    assert len(htmls) == 1, f"expected one HTML report, found: {htmls}"
+
+
+@pytest.mark.skipif(not scalene_available, reason="scalene not installed")
+def test_wrapper_rejects_missing_target(tmp_path: Path) -> None:
+    """The wrapper exits with code 4 when the target does not exist."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(WRAPPER),
+            str(tmp_path / "does_not_exist.py"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 4, f"expected exit 4 for missing target, got {result.returncode}"
+    assert "does not exist" in result.stderr.lower()
+
+
+@pytest.mark.skipif(not scalene_available, reason="scalene not installed")
+def test_wrapper_rejects_conflicting_scope_flags(tmp_path: Path) -> None:
+    """The mutually-exclusive group rejects --scope + --no-thirdparty together."""
+    target = tmp_path / "tiny.py"
+    target.write_text("pass\n", encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(WRAPPER),
+            "--scope",
+            "foo",
+            "--no-thirdparty",
+            str(target),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, "expected non-zero exit for conflicting flags"

--- a/uv.lock
+++ b/uv.lock
@@ -828,6 +828,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "codespell"
 version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3810,6 +3819,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-ml-py"
+version = "13.595.45"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/49/c29f6e30d8662d2e94fef17739ea7309cc76aba269922ae999e4cc07f268/nvidia_ml_py-13.595.45.tar.gz", hash = "sha256:c9f34897fe0441ff35bc8f35baf80f830a20b0f4e6ce71e0a325bc0e66acf079", size = 50780, upload-time = "2026-03-19T16:59:44.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/24/fc256107d23597fa33d319505ce77160fa1a2349c096d01901ffc7cb7fc4/nvidia_ml_py-13.595.45-py3-none-any.whl", hash = "sha256:b65a7977f503d56154b14d683710125ef93594adb63fbf7e559336e3318f1376", size = 51776, upload-time = "2026-03-19T16:59:43.603Z" },
+]
+
+[[package]]
 name = "nvidia-nccl-cu13"
 version = "2.28.9"
 source = { registry = "https://pypi.org/simple" }
@@ -5879,6 +5897,35 @@ wheels = [
 ]
 
 [[package]]
+name = "scalene"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "jinja2" },
+    { name = "numpy" },
+    { name = "nvidia-ml-py", marker = "sys_platform != 'darwin'" },
+    { name = "psutil" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/fc/ed550649058e9ad4bc262039c2c146c92e4d5d0b9d305c7d33d709c151f5/scalene-2.2.1.tar.gz", hash = "sha256:642f809e34d84cae5712bbe8cca76450af81f2dc4c02762b714d1710160dd791", size = 9483401, upload-time = "2026-03-22T14:49:36.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/16/79de96af863a9df1ac9a3b30fc0c9bd51fe4754c137207b2ab3a1f7ebe2f/scalene-2.2.1-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:87be9856bd8b13d87e023ab5e96feae36fd6611912a5433e996e5c34288fe2a4", size = 1225210, upload-time = "2026-03-22T14:49:35.4Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fa/9118db832a7b8bf4eacf20273c5d9e4fe2554bda103712df35273ef193ad/scalene-2.2.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3ff0507f7f176703cf4d3f51b4778e9282910699d8de717040cd4ac070aff97b", size = 1526990, upload-time = "2026-03-22T14:42:40.539Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3a/10e260f5465d77191affc6ef27c04a59451a47ef7d947957c85dc12ca346/scalene-2.2.1-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:e9625d2bf3ab1fef827f836e38134d3f56fc319513ac7632e45c36fd6c00d872", size = 1224979, upload-time = "2026-03-22T14:44:08.652Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b4/6765587712d20353f0d96951bee397e3e6303bc00f376d2561982b081efc/scalene-2.2.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0eb22ef9c1bb8fb3df95365b6263a57e94eb81e777f550af1c513d7f32a50721", size = 1527444, upload-time = "2026-03-22T14:42:33.537Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/7c5b47a3ae695ab7110919b98d60f98c0ca1e6001f3a2e2a9c18bee5c711/scalene-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:de06f01ec97cae6939e5ff3a31e6ab0d96cfe3cf8a2146bea536a998ddac434c", size = 1158170, upload-time = "2026-03-22T14:44:52.863Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f0/5697e94cf16a82999e6c5d456b457fd037ce406399b75070dafbe10173ea/scalene-2.2.1-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:6f94c608d7186ce3d6311bf5b7270c2ba69350f96141c8e913e5fcd272d00ef2", size = 1229689, upload-time = "2026-03-22T14:49:47.403Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/43/8e9bb41288713df00a8b1d0c9eabe00272cf4a93370992cbbfb26ef660f7/scalene-2.2.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6a72a3a55c3672779bcbd0d8278d9557ff99ef23d8d1b99b9cdcef3138c25b9", size = 1537230, upload-time = "2026-03-22T14:42:36.301Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/86/08024979ec47aed7fa26c8c5c644539c84c935cf06657c34f745a31defb7/scalene-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:6adf5db81cc83b644fe0d60640b0b3097cfa4ff36911bc1e9f1833023930c99a", size = 1159794, upload-time = "2026-03-22T14:44:46.863Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/38/6ee3bbd6eb983bf6f25427b4110b2f2d34359e78fbb02b79b4e9c11ca565/scalene-2.2.1-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:7e13ceaaea670c385825b9b21b58596f86f4d0b6e2a0927eefa9dcbf1444380b", size = 1229918, upload-time = "2026-03-22T14:49:37.607Z" },
+    { url = "https://files.pythonhosted.org/packages/94/1a/0e7a49db2440c31e66479c93567cc4e4f0198dbe413699a2de9d2095a8e3/scalene-2.2.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:edb511df0097d3091b4967c70023698306e5fa2c75e9532216904b882e3bd02e", size = 1537041, upload-time = "2026-03-22T14:42:40.067Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/13/a11f6b081c7235a66da71c5230adf5a7a87ef92a6cd98c659494ec20d22e/scalene-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:8af3834504d3a4f4ebaa489bb9266563be818972c83a826337936b6809c145e7", size = 1165782, upload-time = "2026-03-22T14:45:13.804Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6093,6 +6140,10 @@ dev = [
 docs = [
     { name = "pdoc" },
 ]
+profiling = [
+    { name = "nbconvert" },
+    { name = "scalene" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -6152,6 +6203,10 @@ dev = [
     { name = "uvloop", specifier = "~=0.22" },
 ]
 docs = [{ name = "pdoc", specifier = "~=16.0" }]
+profiling = [
+    { name = "nbconvert", specifier = ">=7" },
+    { name = "scalene", specifier = ">=2.2" },
+]
 
 [[package]]
 name = "sentence-transformers"


### PR DESCRIPTION
Promotes the Scalene profiling wrapper from alpha to main. Already validated end-to-end on `alpha` via PR #507 (squash-merged after CI green and review).

## Summary

- Adds `scripts/profile_with_scalene.py`: a thin wrapper around Scalene 2.2 that profiles `.py` scripts and `.ipynb` notebooks and writes standalone HTML or JSON reports to `artifacts/scalene/`
- Adds `[dependency-groups.profiling]` (scalene + nbconvert) — opt-in only; default `uv sync` is unchanged
- Adds smoke tests under `src/tests/scripts/`, guarded by `@pytest.mark.skipif(not scalene_available)` so existing CI is unaffected when the profiling group is not installed

## Test plan

- [x] CI green on `alpha` (PR #507): pre-commit, build-and-deploy, cpu-tests (3.12) all passed
- [ ] CI green on alpha→main PR (this PR)
- [x] All 6 wrapper smoke tests pass (`uv run pytest src/tests/scripts/`)
- [x] Default `uv sync` does not pull scalene (verified)
- [x] `uv sync --group profiling` installs scalene 2.2.x and nbconvert ≥7

🤖 Generated with [Claude Code](https://claude.com/claude-code)