### PR TITLE
PR #511 follow-up: AutoConfig memo + SpeechBrain CWD lock + _BASE_REGISTRY smoke test

### DIFF
--- a/src/senselab/audio/tasks/classification/speech_emotion_recognition/api.py
+++ b/src/senselab/audio/tasks/classification/speech_emotion_recognition/api.py
@@ -17,6 +17,7 @@ null) are run in an isolated subprocess venv with pinned huggingface-hub<1.0.
 import json
 import subprocess
 import tempfile
+import threading
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -72,34 +73,43 @@ except ImportError:  # pragma: no cover — older huggingface_hub
 #
 # The cache is unbounded but small (~1 KB / entry); long-running processes that
 # instantiate many distinct SER models may want to clear it via ``_config_memo.clear()``.
-_config_memo: dict[tuple[str, str], tuple[Optional[Any], Optional[dict]]] = {}
+_config_memo: dict[tuple[str, str], tuple[Optional[PretrainedConfig], Optional[dict]]] = {}
+_config_memo_lock = threading.Lock()
 
 
-def _load_config_cached(model: "HFModel") -> tuple[Optional[Any], Optional[dict]]:
+def _load_config_cached(model: "HFModel") -> tuple[Optional[PretrainedConfig], Optional[dict]]:
     """Return ``(typed_config_or_None, raw_dict_or_None)`` for ``model``, memoized.
 
     Tries ``AutoConfig.from_pretrained`` first; on ``_CONFIG_LOAD_RECOVERABLE`` falls
     back to a raw ``config.json`` read via ``hf_hub_download``. Both outcomes are
     cached so subsequent calls return locally without a hub round-trip.
+
+    Thread-safe via double-checked locking: concurrent callers for the same
+    ``(path, revision)`` deduplicate to a single network round-trip rather than
+    each missing the cache.
     """
     key = (str(model.path_or_uri), model.revision or "main")
     cached = _config_memo.get(key)
     if cached is not None:
         return cached
-    try:
-        from transformers import AutoConfig
+    with _config_memo_lock:
+        cached = _config_memo.get(key)
+        if cached is not None:
+            return cached
+        try:
+            from transformers import AutoConfig
 
-        config = AutoConfig.from_pretrained(model.path_or_uri, revision=model.revision)
-        result: tuple[Optional[Any], Optional[dict]] = (config, None)
-    except _CONFIG_LOAD_RECOVERABLE:
-        from huggingface_hub import hf_hub_download
+            config = AutoConfig.from_pretrained(model.path_or_uri, revision=model.revision)
+            result: tuple[Optional[PretrainedConfig], Optional[dict]] = (config, None)
+        except _CONFIG_LOAD_RECOVERABLE:
+            from huggingface_hub import hf_hub_download
 
-        config_path = hf_hub_download(str(model.path_or_uri), "config.json", revision=model.revision)
-        with open(config_path) as f:
-            raw = json.load(f)
-        result = (None, raw)
-    _config_memo[key] = result
-    return result
+            config_path = hf_hub_download(str(model.path_or_uri), "config.json", revision=model.revision)
+            with open(config_path) as f:
+                raw = json.load(f)
+            result = (None, raw)
+        _config_memo[key] = result
+        return result
 
 
 class SERType(Enum):

--- a/src/senselab/audio/tasks/classification/speech_emotion_recognition/api.py
+++ b/src/senselab/audio/tasks/classification/speech_emotion_recognition/api.py
@@ -20,7 +20,6 @@ import tempfile
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any, Callable, List, Optional, cast
 
 import torch
@@ -59,6 +58,48 @@ try:
     )
 except ImportError:  # pragma: no cover — older huggingface_hub
     _CONFIG_LOAD_RECOVERABLE = (ValueError, TypeError, KeyError)
+
+
+# Per-process memo for AutoConfig + raw config.json. Each ``classify_emotions_from_speech``
+# call previously triggered up to four ``AutoConfig.from_pretrained`` round-trips
+# (``_get_ser_type``, ``_emotion_head_kind``, ``_resolve_apply_softmax``, and the
+# loader in ``_classify_wav2vec2_speech_cls_ser``) — all hitting the same
+# (path, revision). The memo collapses that to one. Cached entries are::
+#
+#     (config, None)        — typed AutoConfig loaded successfully
+#     (None, raw_dict)      — typed load raised one of ``_CONFIG_LOAD_RECOVERABLE``;
+#                             raw ``config.json`` cached so the fallback paths share it.
+#
+# The cache is unbounded but small (~1 KB / entry); long-running processes that
+# instantiate many distinct SER models may want to clear it via ``_config_memo.clear()``.
+_config_memo: dict[tuple[str, str], tuple[Optional[Any], Optional[dict]]] = {}
+
+
+def _load_config_cached(model: "HFModel") -> tuple[Optional[Any], Optional[dict]]:
+    """Return ``(typed_config_or_None, raw_dict_or_None)`` for ``model``, memoized.
+
+    Tries ``AutoConfig.from_pretrained`` first; on ``_CONFIG_LOAD_RECOVERABLE`` falls
+    back to a raw ``config.json`` read via ``hf_hub_download``. Both outcomes are
+    cached so subsequent calls return locally without a hub round-trip.
+    """
+    key = (str(model.path_or_uri), model.revision or "main")
+    cached = _config_memo.get(key)
+    if cached is not None:
+        return cached
+    try:
+        from transformers import AutoConfig
+
+        config = AutoConfig.from_pretrained(model.path_or_uri, revision=model.revision)
+        result: tuple[Optional[Any], Optional[dict]] = (config, None)
+    except _CONFIG_LOAD_RECOVERABLE:
+        from huggingface_hub import hf_hub_download
+
+        config_path = hf_hub_download(str(model.path_or_uri), "config.json", revision=model.revision)
+        with open(config_path) as f:
+            raw = json.load(f)
+        result = (None, raw)
+    _config_memo[key] = result
+    return result
 
 
 class SERType(Enum):
@@ -373,22 +414,16 @@ def _emotion_head_kind(model: HFModel) -> Optional[tuple[str, _HeadEntry]]:
         found, use the matching head.
       - Repo registered in ``_KNOWN_HEAD_LAYOUTS``: use the registered entry.
     """
-    try:
-        from transformers import AutoConfig
-
-        config = AutoConfig.from_pretrained(model.path_or_uri, revision=model.revision)
+    config, raw = _load_config_cached(model)
+    if config is not None:
         auto_map = getattr(config, "auto_map", None)
         architectures = getattr(config, "architectures", None) or []
         model_type = getattr(config, "model_type", None)
-    except _CONFIG_LOAD_RECOVERABLE:
-        from huggingface_hub import hf_hub_download
-
-        config_path = hf_hub_download(str(model.path_or_uri), "config.json", revision=model.revision)
-        with open(config_path) as f:
-            config_dict = json.load(f)
-        auto_map = config_dict.get("auto_map")
-        architectures = config_dict.get("architectures") or []
-        model_type = config_dict.get("model_type")
+    else:
+        assert raw is not None
+        auto_map = raw.get("auto_map")
+        architectures = raw.get("architectures") or []
+        model_type = raw.get("model_type")
 
     if auto_map:
         return None
@@ -436,20 +471,14 @@ def _resolve_apply_softmax(model: HFModel, ser_type: "SERType") -> bool:
     checkpoints declare ``Wav2Vec2ForSequenceClassification`` so the legacy
     keyword-based heuristic remains correct for them.
     """
-    try:
-        from transformers import AutoConfig
-
-        config = AutoConfig.from_pretrained(model.path_or_uri, revision=model.revision)
+    config, raw = _load_config_cached(model)
+    if config is not None:
         problem_type = getattr(config, "problem_type", None)
         architectures = getattr(config, "architectures", None) or []
-    except _CONFIG_LOAD_RECOVERABLE:
-        from huggingface_hub import hf_hub_download
-
-        config_path = hf_hub_download(str(model.path_or_uri), "config.json", revision=model.revision)
-        with open(config_path) as f:
-            config_dict = json.load(f)
-        problem_type = config_dict.get("problem_type")
-        architectures = config_dict.get("architectures") or []
+    else:
+        assert raw is not None
+        problem_type = raw.get("problem_type")
+        architectures = raw.get("architectures") or []
 
     if problem_type == "regression":
         return False
@@ -619,14 +648,13 @@ def _classify_wav2vec2_speech_cls_ser(
     key = f"{model.path_or_uri}-{model.revision or 'main'}-{device_type.value}-{model_type}-{head.final_layer}"
     if key not in _wav2vec2_emotion_models:
         EmotionModel = _make_emotion_model_class(model_type, head)
-        try:
-            config = AutoConfig.from_pretrained(model.path_or_uri, revision=model.revision)
-        except _CONFIG_LOAD_RECOVERABLE:
-            from huggingface_hub import hf_hub_download
-
-            config_path = hf_hub_download(str(model.path_or_uri), "config.json", revision=model.revision)
-            with open(config_path) as f:
-                config_dict = json.load(f)
+        typed, raw = _load_config_cached(model)
+        if typed is not None:
+            config = typed
+        else:
+            assert raw is not None
+            # Copy so we don't mutate the cached raw dict.
+            config_dict = dict(raw)
             # config.json carries its own "model_type" key, which would collide with the positional
             # arg to AutoConfig.for_model(...). Drop it.
             config_dict.pop("model_type", None)
@@ -745,19 +773,12 @@ def _classify_wav2vec2_speech_cls_ser(
 
 def _get_ser_type(model: HFModel) -> SERType:
     """Get the type of SER the model is likely used for based on the labels it is set to predict."""
-    try:
-        from transformers import AutoConfig
-
-        config = AutoConfig.from_pretrained(model.path_or_uri, revision=model.revision)
-    except _CONFIG_LOAD_RECOVERABLE:
-        # Fall back to raw config dict for models with invalid fields
-        from huggingface_hub import hf_hub_download
-
-        config_path = hf_hub_download(str(model.path_or_uri), "config.json", revision=model.revision)
-        with open(config_path) as f:
-            config_dict = json.load(f)
-        config = SimpleNamespace(id2label=config_dict.get("id2label", {}))
-    id2label = config.id2label
+    typed, raw = _load_config_cached(model)
+    if typed is not None:
+        id2label = getattr(typed, "id2label", None) or {}
+    else:
+        assert raw is not None
+        id2label = raw.get("id2label", {})
     if id2label:
         labels = list(id2label.values())
         if "positive" in labels and "negative" in labels and "neutral" in labels:

--- a/src/senselab/audio/tasks/classification/speech_emotion_recognition/api.py
+++ b/src/senselab/audio/tasks/classification/speech_emotion_recognition/api.py
@@ -71,10 +71,18 @@ except ImportError:  # pragma: no cover — older huggingface_hub
 #     (None, raw_dict)      — typed load raised one of ``_CONFIG_LOAD_RECOVERABLE``;
 #                             raw ``config.json`` cached so the fallback paths share it.
 #
+# Concurrency: per-(path, revision) locks rather than a single global lock, so
+# concurrent loads of *different* models don't serialize on the network. Mirrors
+# the per-key strategy ``dependencies.ensure_hf_model`` uses for artifact downloads
+# (file-based ``_HeartbeatLock`` there; in-memory ``threading.Lock`` here, since
+# this memo is single-process). The ``_config_memo_locks_guard`` only protects
+# inserts into the per-key lock map itself — held for microseconds, never across I/O.
+#
 # The cache is unbounded but small (~1 KB / entry); long-running processes that
 # instantiate many distinct SER models may want to clear it via ``_config_memo.clear()``.
 _config_memo: dict[tuple[str, str], tuple[Optional[PretrainedConfig], Optional[dict]]] = {}
-_config_memo_lock = threading.Lock()
+_config_memo_locks: dict[tuple[str, str], threading.Lock] = {}
+_config_memo_locks_guard = threading.Lock()
 
 
 def _load_config_cached(model: "HFModel") -> tuple[Optional[PretrainedConfig], Optional[dict]]:
@@ -84,15 +92,18 @@ def _load_config_cached(model: "HFModel") -> tuple[Optional[PretrainedConfig], O
     back to a raw ``config.json`` read via ``hf_hub_download``. Both outcomes are
     cached so subsequent calls return locally without a hub round-trip.
 
-    Thread-safe via double-checked locking: concurrent callers for the same
-    ``(path, revision)`` deduplicate to a single network round-trip rather than
-    each missing the cache.
+    Thread-safety: per-key double-checked locking. Concurrent callers for the same
+    ``(path, revision)`` deduplicate to a single network round-trip; concurrent
+    callers for *different* models proceed in parallel rather than serializing on
+    a shared lock.
     """
     key = (str(model.path_or_uri), model.revision or "main")
     cached = _config_memo.get(key)
     if cached is not None:
         return cached
-    with _config_memo_lock:
+    with _config_memo_locks_guard:
+        per_key_lock = _config_memo_locks.setdefault(key, threading.Lock())
+    with per_key_lock:
         cached = _config_memo.get(key)
         if cached is not None:
             return cached

--- a/src/senselab/utils/dependencies.py
+++ b/src/senselab/utils/dependencies.py
@@ -136,6 +136,17 @@ def speechbrain_savedir(repo_id: str, revision: Optional[str] = None) -> Path:
     return _senselab_cache_dir() / "speechbrain" / _safe_key(repo_id, rev)
 
 
+# ``os.chdir`` is process-global: while this context manager holds the lock and
+# CWD is pinned to ``savedir``, any *other* thread doing CWD-relative I/O sees
+# the same redirect. To prevent concurrent SpeechBrain loaders from racing on
+# the working directory (e.g. loading two models from different threads), the
+# context serializes via this module-level lock. Code that needs the original
+# CWD inside the body must not run concurrently from another thread — that's
+# the documented trade-off. Non-SpeechBrain code paths are unaffected because
+# the lock is private to this function.
+_speechbrain_cwd_lock = threading.Lock()
+
+
 @contextlib.contextmanager
 def speechbrain_loading_cwd(savedir: Path) -> Iterator[Path]:
     """Run a SpeechBrain ``from_hparams`` call with CWD pinned to ``savedir``.
@@ -146,15 +157,24 @@ def speechbrain_loading_cwd(savedir: Path) -> Iterator[Path]:
     ``savedir=`` argument does not redirect. Wrapping the loader in this context
     causes those relative paths to resolve under ``savedir`` instead of the
     process CWD, keeping the artifacts inside the senselab cache.
+
+    **Threading caveat.** ``os.chdir`` is process-global. To prevent two threads
+    concurrently entering this context from racing on the working directory,
+    the implementation serializes via a module-level lock — concurrent
+    SpeechBrain loads will block, not interleave. This is correct but means
+    parallel-model-init use cases will load sequentially. If you need
+    concurrent SpeechBrain model construction, use multiple processes (each
+    has its own CWD) rather than threads.
     """
     savedir = Path(savedir).resolve()
     savedir.mkdir(parents=True, exist_ok=True)
-    prev = Path.cwd()
-    os.chdir(savedir)
-    try:
-        yield savedir
-    finally:
-        os.chdir(prev)
+    with _speechbrain_cwd_lock:
+        prev = Path.cwd()
+        os.chdir(savedir)
+        try:
+            yield savedir
+        finally:
+            os.chdir(prev)
 
 
 def _safe_key(repo_id: str, revision: str) -> str:

--- a/src/tests/audio/tasks/classification_test.py
+++ b/src/tests/audio/tasks/classification_test.py
@@ -31,6 +31,7 @@ def _reset_ser_module_caches() -> None:
     from senselab.audio.tasks.classification.speech_emotion_recognition import api as ser_api
 
     ser_api._config_memo.clear()
+    ser_api._config_memo_locks.clear()
     ser_api._wav2vec2_emotion_models.clear()
 
 

--- a/src/tests/audio/tasks/classification_test.py
+++ b/src/tests/audio/tasks/classification_test.py
@@ -16,6 +16,24 @@ from senselab.utils.data_structures import DeviceType, HFModel
 from tests.audio.conftest import MONO_AUDIO_PATH
 
 
+@pytest.fixture(autouse=True)
+def _reset_ser_module_caches() -> None:
+    """Reset per-process SER caches between tests.
+
+    Several tests monkeypatch ``transformers.AutoConfig.from_pretrained`` to return
+    a fake config for ``audeering/wav2vec2-large-robust-12-ft-emotion-msp-dim``. The
+    module-level ``_config_memo`` introduced in PR #515 would otherwise hand back the
+    cached fake from a prior test, silently bypassing the monkeypatch in the next
+    one. Same risk for ``_wav2vec2_emotion_models`` (the constructed model cache),
+    which existing tests already reset by hand — centralising that here keeps the
+    invariant in one place.
+    """
+    from senselab.audio.tasks.classification.speech_emotion_recognition import api as ser_api
+
+    ser_api._config_memo.clear()
+    ser_api._wav2vec2_emotion_models.clear()
+
+
 def test_speech_emotion_recognition_continuous(cpu_cuda_device: DeviceType) -> None:
     """Tests continuous speech emotion recognition (Tier 2: ~661MB model)."""
     audio_dataset = [Audio(filepath=MONO_AUDIO_PATH)]
@@ -84,9 +102,6 @@ def test_wav2vec2_speech_cls_ser_raises_on_random_head(
 
     from senselab.audio.tasks.classification.speech_emotion_recognition import api as ser_api
 
-    # Reset the per-(model, revision, device, final_layer) cache so the mock fires.
-    ser_api._wav2vec2_emotion_models.clear()
-
     fake_model = MagicMock()
     # The shape sanity-check expects out_features matching config.num_labels.
     fake_model.classifier.out_proj.out_features = 3
@@ -121,8 +136,6 @@ def test_wav2vec2_speech_cls_ser_raises_on_shape_mismatch(monkeypatch: pytest.Mo
     from unittest.mock import MagicMock
 
     from senselab.audio.tasks.classification.speech_emotion_recognition import api as ser_api
-
-    ser_api._wav2vec2_emotion_models.clear()
 
     fake_model = MagicMock()
     fake_model.classifier.out_proj.out_features = 5  # config says 3
@@ -342,7 +355,8 @@ def test_load_config_cached_round_trips_once(monkeypatch: pytest.MonkeyPatch) ->
 
     from senselab.audio.tasks.classification.speech_emotion_recognition import api as ser_api
 
-    ser_api._config_memo.clear()
+    # Autouse fixture should have cleared the memo before us — sanity check.
+    assert ser_api._config_memo == {}, "_config_memo leaked from a prior test"
     fake_config = MagicMock(model_type="wav2vec2", architectures=["X"], id2label={0: "a"})
     call_counter = MagicMock(return_value=fake_config)
     monkeypatch.setattr("transformers.AutoConfig.from_pretrained", call_counter)

--- a/src/tests/audio/tasks/classification_test.py
+++ b/src/tests/audio/tasks/classification_test.py
@@ -297,6 +297,64 @@ def test_check_head_loaded_cleanly_silent_on_clean_load() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("model_type", "expected_base_name", "expected_encoder_name", "expected_attr"),
+    [
+        ("wav2vec2", "Wav2Vec2PreTrainedModel", "Wav2Vec2Model", "wav2vec2"),
+        ("hubert", "HubertPreTrainedModel", "HubertModel", "hubert"),
+        ("wavlm", "WavLMPreTrainedModel", "WavLMModel", "wavlm"),
+    ],
+)
+def test_resolve_base_returns_real_transformers_classes(
+    model_type: str, expected_base_name: str, expected_encoder_name: str, expected_attr: str
+) -> None:
+    """Smoke test: every ``_BASE_REGISTRY`` entry must resolve to real transformers classes.
+
+    A typo in the registry (e.g. ``"Wav2Vec2BasePreTrainedModel"`` instead of
+    ``"Wav2Vec2PreTrainedModel"``) would silently route through the standard pipeline
+    fallback and silently random-initialize heads. This test catches such typos at
+    test-collection time without downloading any model.
+    """
+    from senselab.audio.tasks.classification.speech_emotion_recognition.api import _resolve_base
+
+    resolved = _resolve_base(model_type)
+    assert resolved is not None, f"_BASE_REGISTRY['{model_type}'] failed to resolve"
+    base_cls, encoder_cls, attr_name = resolved
+    assert base_cls.__name__ == expected_base_name
+    assert encoder_cls.__name__ == expected_encoder_name
+    assert attr_name == expected_attr
+
+
+def test_resolve_base_unknown_model_type_returns_none() -> None:
+    """Unknown ``model_type`` → ``None`` so callers can dispatch to the standard pipeline."""
+    from senselab.audio.tasks.classification.speech_emotion_recognition.api import _resolve_base
+
+    assert _resolve_base("not-a-real-family") is None
+
+
+def test_load_config_cached_round_trips_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_load_config_cached`` must hit ``AutoConfig.from_pretrained`` at most once per (path, revision).
+
+    Mocks ``AutoConfig.from_pretrained`` with a call counter, invokes the cache four
+    times with the same model handle, and asserts the underlying call happened once.
+    """
+    from unittest.mock import MagicMock
+
+    from senselab.audio.tasks.classification.speech_emotion_recognition import api as ser_api
+
+    ser_api._config_memo.clear()
+    fake_config = MagicMock(model_type="wav2vec2", architectures=["X"], id2label={0: "a"})
+    call_counter = MagicMock(return_value=fake_config)
+    monkeypatch.setattr("transformers.AutoConfig.from_pretrained", call_counter)
+
+    model: HFModel = HFModel(path_or_uri="audeering/wav2vec2-large-robust-12-ft-emotion-msp-dim", revision="main")
+    for _ in range(4):
+        typed, raw = ser_api._load_config_cached(model)
+        assert typed is fake_config
+        assert raw is None
+    assert call_counter.call_count == 1, f"Expected 1 AutoConfig call, got {call_counter.call_count}"
+
+
 def test_scene_results_to_segments() -> None:
     """Test conversion of windowed results to segment format."""
     window_results = [


### PR DESCRIPTION
## Summary

Follow-up addressing [@wilke0818's review on PR #511](https://github.com/sensein/senselab/pull/511). Stacks on top of the existing PR #511 branch.

| # | wilke0818's point | Action |
|---|---|---|
| 1 | `os.chdir` in `speechbrain_loading_cwd` is process-global → concurrent threads can race | **Fixed**: module-level `threading.Lock` serializes the context; docstring documents the trade-off |
| 2 | `_emotion_head_kind` calls `AutoConfig.from_pretrained` once per inference even though `_get_ser_type` already did | **Fixed**: shared memo (#3) |
| 3 | `_resolve_apply_softmax` calls `AutoConfig.from_pretrained` a third time | **Fixed**: `_load_config_cached(model)` returns `(typed_config_or_None, raw_dict_or_None)` and is cached per `(path, revision)` for the process. All 4 call sites (`_get_ser_type`, `_emotion_head_kind`, `_resolve_apply_softmax`, `_classify_wav2vec2_speech_cls_ser`) share one round-trip |
| 4 | HuBERT/WavLM registry entries never exercised | **Partial**: added 3 parametrised unit tests for `_resolve_base("wav2vec2" / "hubert" / "wavlm")` that verify each entry resolves to real `transformers` classes — catches typos at test-collection time without downloading model weights. Integration tests against real HuBERT/WavLM checkpoints are still future work |
| 5 | Plan doc lives in `specs/` (will bit-rot) | **Skipped**: follows the convention from PR #513 (`specs/20260506-…/tasks.md`). Open to changing if maintainers prefer issue-based docs |

## Verification

- `ruff check` and `ruff format --check` clean across the touched files.
- `mypy --ignore-missing-imports --extra-checks` clean for the touched files. (Two pre-existing errors in `_cached_error` constructor calls at `dependencies.py:352-353` appear to be a local hf_hub-version drift; PR #514 CI passed with the same flags so they shouldn't appear in CI.)
- `pytest -k "not test_speech_emotion_recognition_continuous and not test_speech_emotion_recognition_discrete"`: 18 passed, including the 4 new tests:
  - `test_resolve_base_returns_real_transformers_classes[wav2vec2|hubert|wavlm]`
  - `test_resolve_base_unknown_model_type_returns_none`
  - `test_load_config_cached_round_trips_once`
- Audeering happy-path (slow) test still passes locally.

## Notes for reviewers

- The lock in #1 means parallel SpeechBrain model construction across threads now serializes. If anyone has a use case that needs concurrent SpeechBrain init, the docstring tells them to use multiple processes instead.
- The memo in #2/#3 is unbounded but tiny (~1 KB per entry). Long-running processes that instantiate many distinct SER models can call `_config_memo.clear()` if they need to bound it.

https://claude.ai/code/session_01DyXMQNsF7F5Ze8j3GGVw66

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyXMQNsF7F5Ze8j3GGVw66)_