### PR TITLE
subprocess_venv: two-stage install to fix torch/torchaudio CUDA-tag s…

### DIFF
--- a/src/senselab/audio/tasks/speech_to_text/qwen.py
+++ b/src/senselab/audio/tasks/speech_to_text/qwen.py
@@ -30,15 +30,16 @@ _QWEN_REQUIREMENTS = [
     # Pin to a known-good release; bump intentionally as Alibaba publishes new
     # versions of the wrapper. 0.0.6 is the first version that exposes both
     # Qwen3ASRModel and Qwen3ForcedAligner via from_pretrained on PyPI.
-    #
-    # NOTE: torch / torchaudio are NOT named here directly — they come in
-    # transitively (qwen-asr depends on them, and ``ensure_venv`` always
-    # appends ``torchaudio`` as an IPC dep). The CUDA-aware index routing
-    # in ``ensure_venv`` is what guarantees those transitive installs use
-    # a matching toolchain pair. If you ever add a direct ``torch`` /
-    # ``torchaudio`` pin to this list, keep going through ``ensure_venv``
-    # so the routing stays intact.
     "qwen-asr==0.0.6",
+    # ``qwen-asr`` pulls ``torch`` + ``torchaudio`` transitively, but pin
+    # them explicitly here so ``ensure_venv``'s CUDA-aware Stage 1 routes
+    # both wheels through the matched PyTorch index. Without these pins
+    # the transitives would resolve from default PyPI in Stage 2 and
+    # could split across mismatched ``+cu`` local-version tags (the
+    # ``torch==X+cu129`` / ``torchaudio==X`` ABI mismatch this PR
+    # exists to prevent).
+    "torch>=2.8,<2.9",
+    "torchaudio>=2.8,<2.9",
 ]
 _QWEN_PYTHON = "3.12"
 

--- a/src/senselab/utils/subprocess_venv.py
+++ b/src/senselab/utils/subprocess_venv.py
@@ -198,6 +198,18 @@ def ensure_venv(
 ) -> Path:
     """Create or reuse an isolated virtual environment.
 
+    Whether the CUDA-aware two-stage install fires is decided by the
+    contents of ``requirements`` itself: any ``torch`` or ``torchaudio``
+    spec triggers the probe + Stage-1 install via the chosen PyTorch
+    wheel index. Backends that declare neither — including the genuinely
+    torch-free case (e.g. a venv that only consumes a pure-Python GitHub
+    repo) — skip the probe and the CUDA index entirely and do a single
+    install pass against default PyPI. Backends that need ``torch`` /
+    ``torchaudio`` (including via a transitive dep) MUST pin them in
+    their own ``_REQUIREMENTS`` so the CUDA routing applies — otherwise
+    Stage 2's transitive resolution against PyPI can split them across
+    mismatched local-version tags.
+
     Args:
         name: Unique identifier for this venv (e.g., "coqui", "ppgs").
         requirements: List of pip install specs (e.g., ["coqui-tts~=0.27"]).
@@ -211,29 +223,40 @@ def ensure_venv(
     marker = venv_dir / ".senselab-installed"
 
     with FileLock(str(lock_path), timeout=600):
-        # Resolve the torch wheel index FIRST so the marker-match check
-        # below can compare the cached index URL. Order: env override
-        # decides the URL; the host-CUDA probe still runs (even with the
-        # override) so its result can be surfaced in the diagnostic when
-        # an install failure wraps into ``SenselabCudaCompatibilityError``.
-        env_override = os.getenv("SENSELAB_TORCH_INDEX_URL") or None
-        host_cuda = detect_host_cuda()
-        torch_index = pick_torch_index(host_cuda, env_override=env_override)
+        # Auto-detect whether this venv routes torch through the CUDA
+        # index: any caller-declared torch / torchaudio spec triggers the
+        # probe + Stage-1 install. A backend that pins neither (yamnet,
+        # continuous-ser, or future torch-free venvs) skips the probe
+        # entirely — no ``nvidia-smi`` shellout, no ``torchaudio`` forced
+        # into the install. The probe still runs (when triggered) even
+        # with ``SENSELAB_TORCH_INDEX_URL`` set so its result can be
+        # surfaced in the diagnostic when an install failure wraps into
+        # ``SenselabCudaCompatibilityError``.
+        torch_specs = _torch_install_specs(requirements)
+        host_cuda: Optional[HostCuda] = None
+        torch_index: Optional[TorchIndex] = None
+        if torch_specs:
+            env_override = os.getenv("SENSELAB_TORCH_INDEX_URL") or None
+            probed = detect_host_cuda()
+            host_cuda = probed
+            torch_index = pick_torch_index(probed, env_override=env_override)
 
+        expected_index_url = torch_index.url if torch_index is not None else None
         if marker.is_file():
             stored = json.loads(marker.read_text())
             stored_index_url = (stored.get("torch_index") or {}).get("url")
-            if stored.get("requirements") == sorted(requirements) and stored_index_url == torch_index.url:
+            if stored.get("requirements") == sorted(requirements) and stored_index_url == expected_index_url:
                 logger.debug("Reusing existing venv: %s", venv_dir)
                 return venv_dir
 
         uv = _find_uv()
         py_ver = python_version or f"{sys.version_info.major}.{sys.version_info.minor}"
+        index_label = torch_index.tag if torch_index is not None else "n/a (torch-free)"
         logger.info(
             "Creating isolated venv '%s' with Python %s (torch index: %s)",
             name,
             py_ver,
-            torch_index.tag,
+            index_label,
         )
 
         if venv_dir.exists():
@@ -254,62 +277,125 @@ def ensure_venv(
             shutil.rmtree(venv_dir, ignore_errors=True)
             raise
 
-        # Always include IPC serialization deps (safetensors for tensors,
-        # numpy for arrays, torchaudio for FLAC audio encoding). Route
-        # torch/torchaudio through the chosen PyTorch wheel index; keep
-        # PyPI as the extra index so non-torch packages still resolve.
-        all_reqs = [*requirements, "safetensors", "numpy", "torchaudio"]
+        if torch_index is not None:
+            assert host_cuda is not None  # narrows the Optional for type-checkers
+            # Two-stage install — works around uv's flag-precedence quirk.
+            #
+            # uv treats ``--extra-index-url`` as having higher priority
+            # than ``--index-url`` (opposite of pip). So the obvious one-
+            # shot form ``--index-url <cuda> --extra-index-url pypi`` lets
+            # PyPI win for every package, including ``torch`` and
+            # ``torchaudio``. On hosts where PyPI ships those two with
+            # mismatched ``+cu`` local-version tags (currently
+            # ``torch==X+cu129`` vs ``torchaudio==X`` with no tag), the
+            # resulting venv hits the ABI mismatch this routing was meant
+            # to prevent (``RuntimeError: PyTorch has CUDA version 12.9
+            # whereas TorchAudio has CUDA version 12.8``).
+            #
+            # Stage 1: install caller-declared torch / torchaudio specs
+            # with ONLY the chosen CUDA index named (no ``--extra-index-
+            # url``), so the index is unambiguously primary and both
+            # wheels — plus their ``nvidia-cuda-runtime-cu12`` transitives
+            # — come from it with matched toolchains.
+            #
+            # Stage 2: install the remaining requirements (with torch +
+            # torchaudio specs filtered out so uv can't re-resolve them
+            # against PyPI) + the IPC serialization deps via default
+            # PyPI. uv sees torch / torchaudio already installed and
+            # satisfying any pin in ``requirements``, so it doesn't
+            # re-resolve them. The PyTorch index governs only the two
+            # packages it's designed for, and stale wheels on the CUDA
+            # index for utilities like setuptools or pyarrow stay out
+            # of the picture.
+            try:
+                subprocess.run(
+                    [
+                        uv,
+                        "pip",
+                        "install",
+                        "--index-url",
+                        torch_index.url,
+                        "--python",
+                        venv_python(venv_dir),
+                        *torch_specs,
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as exc:
+                # Wipe the half-built venv before raising so the next run starts clean.
+                shutil.rmtree(venv_dir, ignore_errors=True)
+                failing = _classify_uv_failure(exc.stderr or "")
+                if failing is not None:
+                    # Compat-error path: the wrapped exception's message already
+                    # carries the diagnostic fields (host CUDA, attempted index,
+                    # failing packages, recommended action). Logging the full uv
+                    # stderr would just duplicate that.
+                    logger.debug("Wheel not found installing torch in venv '%s': %s", name, exc.stderr)
+                    raise SenselabCudaCompatibilityError(
+                        host_cuda=host_cuda,
+                        attempted_index=torch_index,
+                        failing_packages=failing,
+                    ) from exc
+                # Pass-through path: log the stderr so the user can see what
+                # really went wrong (network, permission, syntax, ...).
+                logger.error("Failed to install torch in venv '%s': %s", name, exc.stderr)
+                raise
+
+            # Stage 2: backend requirements (minus any torch / torchaudio
+            # specs — those are already installed and listing them here
+            # without an index flag could let uv consider replacing the
+            # matched wheels with PyPI's tagless versions) plus the IPC
+            # serialization deps (safetensors + numpy). ``torchaudio``
+            # was installed in Stage 1; both safetensors and numpy are
+            # pure-Python and pull cleanly from PyPI everywhere.
+            stage_two_reqs = [r for r in requirements if _spec_pkg_name(r) not in _TORCH_PKG_NAMES] + [
+                "safetensors",
+                "numpy",
+            ]
+        else:
+            # Torch-free path: single install pass straight from default
+            # PyPI. No probe, no CUDA-index routing, no ``torchaudio``
+            # forced into the install — backends that don't declare
+            # torch / torchaudio don't pay for them.
+            stage_two_reqs = [*requirements, "safetensors", "numpy"]
+
         try:
             subprocess.run(
                 [
                     uv,
                     "pip",
                     "install",
-                    "--index-url",
-                    torch_index.url,
-                    "--extra-index-url",
-                    "https://pypi.org/simple",
                     "--python",
                     venv_python(venv_dir),
-                    *all_reqs,
+                    *stage_two_reqs,
                 ],
                 check=True,
                 capture_output=True,
                 text=True,
             )
         except subprocess.CalledProcessError as exc:
-            # Wipe the half-built venv before raising so the next run starts clean.
             shutil.rmtree(venv_dir, ignore_errors=True)
-            failing = _classify_uv_failure(exc.stderr or "")
-            if failing is not None:
-                # Compat-error path: the wrapped exception's message already
-                # carries the diagnostic fields (host CUDA, attempted index,
-                # failing packages, recommended action). Logging the full uv
-                # stderr would just duplicate that.
-                logger.debug("Wheel not found installing in venv '%s': %s", name, exc.stderr)
-                raise SenselabCudaCompatibilityError(
-                    host_cuda=host_cuda,
-                    attempted_index=torch_index,
-                    failing_packages=failing,
-                ) from exc
-            # Pass-through path: log the stderr so the user can see what
-            # really went wrong (network, permission, syntax, ...).
             logger.error("Failed to install in venv '%s': %s", name, exc.stderr)
             raise
 
-        marker.write_text(
-            json.dumps(
-                {
-                    "requirements": sorted(requirements),
-                    "python_version": py_ver,
-                    "torch_index": {
-                        "tag": torch_index.tag,
-                        "url": torch_index.url,
-                        "source": torch_index.source,
-                    },
-                }
-            )
-        )
+        marker_data: dict[str, object] = {
+            "requirements": sorted(requirements),
+            "python_version": py_ver,
+        }
+        if torch_index is not None:
+            # Only stamp the index field on torch-using venvs; the marker
+            # comparison treats its absence as "no torch routing in use",
+            # so a future call against the same name whose ``requirements``
+            # have grown a torch / torchaudio spec correctly invalidates
+            # and rebuilds.
+            marker_data["torch_index"] = {
+                "tag": torch_index.tag,
+                "url": torch_index.url,
+                "source": torch_index.source,
+            }
+        marker.write_text(json.dumps(marker_data))
         logger.info("Venv '%s' ready at %s", name, venv_dir)
         return venv_dir
 
@@ -351,6 +437,58 @@ def _classify_uv_failure(stderr: str) -> Optional[list[str]]:
             seen.add(m)
             out.append(m)
     return out
+
+
+# Packages whose install must be routed through the chosen CUDA-tagged
+# PyTorch wheel index. We don't include downstream torch-ecosystem names
+# like ``torchvision``/``torchtext`` because senselab's subprocess venvs
+# don't currently use them; add here if that changes.
+_TORCH_PKG_NAMES = frozenset({"torch", "torchaudio"})
+
+# Capture the package name at the start of a uv pip install spec, stopping
+# at the first character that isn't part of a PEP 508 distribution name —
+# extras start with ``[``, versions with one of ``<>=!~``, URL/git refs
+# with whitespace or ``@``. Matches ``torch``, ``torch>=2.8,<2.9``,
+# ``torch[gpu]==2.8``, and ``nemo_toolkit[asr,tts] @ git+https://...``.
+_PKG_NAME_RE = re.compile(r"^\s*([A-Za-z0-9._-]+)")
+
+
+def _spec_pkg_name(spec: str) -> str:
+    """Return the lowercased package name from a uv pip install spec.
+
+    Returns ``""`` for specs that don't begin with a recognizable package
+    name (e.g. a stray empty string). The match is loose by design — we
+    only need it to identify torch + torchaudio entries inside
+    ``requirements`` lists.
+    """
+    m = _PKG_NAME_RE.match(spec)
+    return m.group(1).lower() if m else ""
+
+
+def _torch_install_specs(requirements: list[str]) -> list[str]:
+    """Return the ``torch`` / ``torchaudio`` specs explicitly named in ``requirements``.
+
+    Forwards EVERY torch / torchaudio entry verbatim — so a backend
+    pinning ``["torch>=2.8", "torch<2.9"]`` as two separate constraints
+    gets both passed to uv, which combines them at resolve time. A single
+    combined spec like ``"torch>=2.8,<2.9"`` still flows through
+    unchanged.
+
+    Returns an empty list when neither package is in ``requirements``,
+    which ``ensure_venv`` treats as "skip Stage 1, skip the probe". The
+    earlier version of this helper padded the return with bare ``torch``
+    / ``torchaudio`` names so every venv routed both packages through
+    the CUDA index regardless of declared needs — that meant
+    ``torchaudio`` got force-installed in venvs (``yamnet``,
+    ``continuous-ser``) that never imported it, adding ~200 MB of wheels
+    for no reason. Backends that genuinely need ``torch`` or
+    ``torchaudio`` — including via a transitive dep like ``qwen-asr`` —
+    MUST pin them in their own ``_REQUIREMENTS`` so this helper picks
+    them up and Stage 1 routes them through the matched CUDA index.
+    Otherwise Stage 2's transitive resolution against PyPI can split
+    them across mismatched local-version tags.
+    """
+    return [spec for spec in requirements if _spec_pkg_name(spec) in _TORCH_PKG_NAMES]
 
 
 def venv_python(venv_dir: Path) -> str:

--- a/src/tests/utils/subprocess_venv_test.py
+++ b/src/tests/utils/subprocess_venv_test.py
@@ -105,9 +105,9 @@ def test_marker_without_torch_index_triggers_rebuild(
     out = ensure_venv(name, ["torch>=2.8,<2.9"], python_version="3.12")
 
     assert out == venv_dir
-    # Two subprocess invocations: uv venv + uv pip install. If we'd hit the
-    # cache fast-path we'd see zero.
-    assert len(recorder.calls) == 2
+    # Three subprocess invocations: uv venv + Stage-1 torch install + Stage-2
+    # backend install. If we'd hit the cache fast-path we'd see zero.
+    assert len(recorder.calls) == 3
     # New marker now carries the resolved index.
     written = json.loads((venv_dir / ".senselab-installed").read_text())
     assert written["torch_index"]["url"] == force_cu128.url
@@ -178,7 +178,7 @@ def test_marker_with_different_torch_index_triggers_rebuild(
     out = ensure_venv(name, ["torch>=2.8,<2.9"], python_version="3.12")
 
     assert out == venv_dir
-    assert len(recorder.calls) == 2  # uv venv + uv pip install
+    assert len(recorder.calls) == 3  # uv venv + Stage-1 torch + Stage-2 backend install
     written = json.loads((venv_dir / ".senselab-installed").read_text())
     assert written["torch_index"]["url"] == force_cu128.url
 
@@ -186,48 +186,245 @@ def test_marker_with_different_torch_index_triggers_rebuild(
 # ── Install argv routing ───────────────────────────────────────────
 
 
-def test_install_argv_routes_through_chosen_torch_index(
+def test_stage_one_pins_torch_and_torchaudio_to_chosen_index(
     fake_cache_dir: Path,
     fake_uv: str,
     force_cu128: TorchIndex,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Uv pip install argv contains both --index-url and --extra-index-url, in that order."""
-    name = "t-argv"
+    """Stage-1 install names ONLY the chosen CUDA index and only torch + torchaudio.
+
+    No ``--extra-index-url`` is allowed in Stage 1: uv treats it as having
+    higher priority than ``--index-url``, so a PyPI fallback would let
+    PyPI's mismatched-tag torch / torchaudio win for these two packages.
+    """
+    name = "t-stage-one"
     recorder = _SubprocessRecorder()
     monkeypatch.setattr(subprocess, "run", recorder)
 
     ensure_venv(name, ["torch>=2.8,<2.9", "torchaudio>=2.8,<2.9"], python_version="3.12")
 
-    # Second call is `uv pip install ...`.
-    install_argv = recorder.calls[1]
-    assert install_argv[0:3] == [fake_uv, "pip", "install"]
-    assert "--index-url" in install_argv
-    idx_pos = install_argv.index("--index-url")
-    assert install_argv[idx_pos + 1] == force_cu128.url
-    assert "--extra-index-url" in install_argv
-    extra_pos = install_argv.index("--extra-index-url")
-    assert install_argv[extra_pos + 1] == "https://pypi.org/simple"
-    # --index-url must come before --extra-index-url so uv's resolver prefers it.
-    assert idx_pos < extra_pos
+    # recorder.calls[0] = uv venv; [1] = Stage 1 install; [2] = Stage 2 install.
+    stage_one = recorder.calls[1]
+    assert stage_one[0:3] == [fake_uv, "pip", "install"]
+    idx_pos = stage_one.index("--index-url")
+    assert stage_one[idx_pos + 1] == force_cu128.url
+    assert "--extra-index-url" not in stage_one
+    # Pinned specs from requirements flow through verbatim.
+    assert "torch>=2.8,<2.9" in stage_one
+    assert "torchaudio>=2.8,<2.9" in stage_one
 
 
-def test_install_argv_appends_default_ipc_dependencies(
+def test_stage_two_uses_default_pypi_and_includes_ipc_deps(
     fake_cache_dir: Path,
     fake_uv: str,
     force_cu128: TorchIndex,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """ensure_venv keeps appending safetensors, numpy, torchaudio after the caller's reqs."""
-    name = "t-ipc-deps"
+    """Stage-2 install carries no index flags and includes the IPC serialization deps.
+
+    No ``--index-url`` or ``--extra-index-url`` on Stage 2 — by then torch
+    and torchaudio are already installed, so the rest of the resolution
+    happens against default PyPI (where setuptools, NeMo, etc. live at
+    current versions instead of stale CUDA-index mirrors).
+    """
+    name = "t-stage-two"
     recorder = _SubprocessRecorder()
     monkeypatch.setattr(subprocess, "run", recorder)
 
-    ensure_venv(name, ["coqui-tts~=0.27"], python_version="3.12")
+    # Includes a torch pin so Stage 1 runs and we have a Stage 2 to assert against.
+    ensure_venv(name, ["coqui-tts~=0.27", "torch>=2.8,<2.9", "torchaudio>=2.8,<2.9"], python_version="3.12")
+
+    stage_two = recorder.calls[2]
+    assert stage_two[0:3] == [fake_uv, "pip", "install"]
+    assert "--index-url" not in stage_two
+    assert "--extra-index-url" not in stage_two
+    # IPC deps appended after the backend's own requirements.
+    assert "safetensors" in stage_two
+    assert "numpy" in stage_two
+    # torchaudio was installed in Stage 1 and intentionally NOT re-listed
+    # here — if it were, uv would consider re-resolving it from PyPI.
+    assert "torchaudio" not in stage_two
+    # Backend's own non-torch requirements still flow through.
+    assert "coqui-tts~=0.27" in stage_two
+
+
+def test_stage_two_filters_torch_specs_from_caller_requirements(
+    fake_cache_dir: Path,
+    fake_uv: str,
+    force_cu128: TorchIndex,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backend-pinned torch / torchaudio specs are stripped from Stage 2.
+
+    If ``requirements`` contains e.g. ``torch>=2.8,<2.9``, that spec must
+    NOT appear in the Stage-2 argv. Re-listing it without an index flag
+    would let uv consider replacing the matched ``+cu128`` wheel installed
+    in Stage 1 with whatever PyPI happens to ship at the same public
+    version (currently a ``+cu129`` tag) — exactly the split this fix is
+    meant to prevent.
+    """
+    name = "t-stage-two-filter"
+    recorder = _SubprocessRecorder()
+    monkeypatch.setattr(subprocess, "run", recorder)
+
+    ensure_venv(
+        name,
+        ["torch>=2.8,<2.9", "torchaudio>=2.8,<2.9", "pyarrow<18"],
+        python_version="3.12",
+    )
+
+    stage_two = recorder.calls[2]
+    assert "torch>=2.8,<2.9" not in stage_two
+    assert "torchaudio>=2.8,<2.9" not in stage_two
+    # Non-torch requirements still flow through.
+    assert "pyarrow<18" in stage_two
+
+
+def test_torch_install_specs_preserves_multiple_constraints_for_same_package(
+    fake_cache_dir: Path,
+    fake_uv: str,
+    force_cu128: TorchIndex,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backend passing ``torch>=2.8`` AND ``torch<2.9`` as two specs forwards both.
+
+    The earlier dict-based implementation kept only the last spec it saw
+    for a given package name; a caller relying on multiple constraints
+    would have ended up with Stage 1 enforcing only one of them, and uv
+    could have resolved a version that violated the other. The list-based
+    form keeps every matching spec.
+    """
+    name = "t-multi-constraint"
+    recorder = _SubprocessRecorder()
+    monkeypatch.setattr(subprocess, "run", recorder)
+
+    ensure_venv(name, ["torch>=2.8", "torch<2.9"], python_version="3.12")
+
+    stage_one = recorder.calls[1]
+    assert "torch>=2.8" in stage_one
+    assert "torch<2.9" in stage_one
+
+
+# ── Auto-detection: torch-free venvs skip the probe and Stage 1 ────
+
+
+def test_no_torch_in_requirements_skips_probe_and_stage_one(
+    fake_cache_dir: Path,
+    fake_uv: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backends without ``torch`` / ``torchaudio`` in ``requirements`` skip the probe entirely.
+
+    ``ensure_venv`` decides the install shape from the caller's
+    ``requirements`` itself — no separate flag. A venv that declares
+    neither package (yamnet, continuous-ser, or a future pure-Python
+    backend) gets the leanest possible install: one ``uv pip install``
+    pass against default PyPI, no ``nvidia-smi`` shellout, no
+    ``torchaudio`` force-appended.
+    """
+    name = "t-no-torch"
+    # If the probe were invoked it would raise — that's how we confirm
+    # auto-detection short-circuits before reaching it.
+    monkeypatch.setattr(
+        subprocess_venv,
+        "detect_host_cuda",
+        lambda: (_ for _ in ()).throw(AssertionError("probe should not run when no torch in requirements")),
+    )
+
+    recorder = _SubprocessRecorder()
+    monkeypatch.setattr(subprocess, "run", recorder)
+
+    ensure_venv(name, ["some-pure-python-pkg==1.0"], python_version="3.12")
+
+    # Exactly two subprocess calls: uv venv + a single uv pip install.
+    assert len(recorder.calls) == 2
+    install_argv = recorder.calls[1]
+    assert install_argv[0:3] == [fake_uv, "pip", "install"]
+    assert "--index-url" not in install_argv
+    assert "--extra-index-url" not in install_argv
+    # No torch routing → no Stage 1 → torchaudio is NOT force-appended.
+    assert "torchaudio" not in install_argv
+    assert "torch" not in install_argv
+    # Caller's requirements + safetensors + numpy still install.
+    assert "some-pure-python-pkg==1.0" in install_argv
+    assert "safetensors" in install_argv
+    assert "numpy" in install_argv
+
+    # Marker carries no ``torch_index`` field, so a later call whose
+    # requirements grow a torch spec will correctly invalidate + rebuild.
+    written = json.loads((fake_cache_dir / name / ".senselab-installed").read_text())
+    assert "torch_index" not in written
+
+
+def test_adding_torch_to_requirements_invalidates_torch_free_cache(
+    fake_cache_dir: Path,
+    fake_uv: str,
+    force_cu128: TorchIndex,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A venv built without torch must rebuild if the requirements later grow a torch spec.
+
+    The torch-free marker has no ``torch_index`` field; when a torch-
+    requiring call sees its expected ``torch_index.url`` differs from
+    the stored ``None``, the marker mismatches and the venv rebuilds.
+    """
+    name = "t-switch-to-torch"
+    venv_dir = fake_cache_dir / name
+    venv_dir.mkdir(parents=True)
+    (venv_dir / ".senselab-installed").write_text(
+        json.dumps({"requirements": ["some-pure-python-pkg==1.0"], "python_version": "3.12"})
+    )
+
+    recorder = _SubprocessRecorder()
+    monkeypatch.setattr(subprocess, "run", recorder)
+
+    # Same name, but requirements now include a torch pin → Stage 1 must fire.
+    ensure_venv(name, ["some-pure-python-pkg==1.0", "torch>=2.8,<2.9"], python_version="3.12")
+
+    # uv venv + Stage 1 + Stage 2 — full rebuild kicked in.
+    assert len(recorder.calls) == 3
+    written = json.loads((venv_dir / ".senselab-installed").read_text())
+    assert written["torch_index"]["url"] == force_cu128.url
+
+
+def test_yamnet_style_requirements_omit_torchaudio_from_install(
+    fake_cache_dir: Path,
+    fake_uv: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Yamnet / continuous-ser-style venvs no longer get ``torchaudio`` force-installed.
+
+    Before this change, every subprocess venv paid for ``torchaudio``
+    via an unconditional IPC append, even backends that read audio via
+    ``soundfile`` and never imported torchaudio (~200 MB of wheels per
+    venv for no functional benefit). Now that the append is gone,
+    such a venv ends up with neither torch nor torchaudio in its
+    install argv.
+    """
+    name = "t-yamnet-style"
+    monkeypatch.setattr(
+        subprocess_venv,
+        "detect_host_cuda",
+        lambda: (_ for _ in ()).throw(AssertionError("torch-free venv must not invoke the probe")),
+    )
+
+    recorder = _SubprocessRecorder()
+    monkeypatch.setattr(subprocess, "run", recorder)
+
+    # Mirror yamnet's actual _REQUIREMENTS shape — TF-based, soundfile for audio I/O.
+    ensure_venv(
+        name,
+        ["tensorflow", "tensorflow-hub", "setuptools<70", "numpy", "soundfile"],
+        python_version="3.12",
+    )
 
     install_argv = recorder.calls[1]
-    for dep in ("safetensors", "numpy", "torchaudio"):
-        assert dep in install_argv, f"expected {dep!r} in install argv"
+    assert "torch" not in install_argv
+    assert "torchaudio" not in install_argv
+    # tensorflow / tensorflow-hub still flow through.
+    assert "tensorflow" in install_argv
+    assert "tensorflow-hub" in install_argv
 
 
 # ── env override ───────────────────────────────────────────────────
@@ -397,7 +594,7 @@ def test_all_three_subprocess_backends_route_through_same_torch_index(
     force_cu128: TorchIndex,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Walk the three real backend requirement lists; each must emit the same routed argv.
+    """Walk the three real backend requirement lists; each must route Stage 1 through cu128.
 
     Guards against any future backend bypassing ``ensure_venv`` with its own
     install shellout — every subprocess venv in the project must share the
@@ -411,8 +608,29 @@ def test_all_three_subprocess_backends_route_through_same_torch_index(
         recorder = _SubprocessRecorder()
         monkeypatch.setattr(subprocess, "run", recorder)
         ensure_venv(f"t-{label}", list(reqs), python_version="3.12")
-        install_argv = recorder.calls[1]
-        idx_pos = install_argv.index("--index-url")
-        assert install_argv[idx_pos + 1] == force_cu128.url, f"{label} backend did not use cu128 index"
-        extra_pos = install_argv.index("--extra-index-url")
-        assert install_argv[extra_pos + 1] == "https://pypi.org/simple", f"{label} backend missing --extra-index-url"
+        # Stage 1 = recorder.calls[1] = torch + torchaudio via the chosen CUDA index.
+        stage_one = recorder.calls[1]
+        idx_pos = stage_one.index("--index-url")
+        assert stage_one[idx_pos + 1] == force_cu128.url, f"{label} backend did not use cu128 index"
+        # No --extra-index-url on Stage 1: the precedence quirk would let PyPI win otherwise.
+        assert "--extra-index-url" not in stage_one, f"{label} backend leaked --extra-index-url into Stage 1"
+        # Every backend must install both torch and torchaudio from the same index.
+        assert any(s == "torch" or s.startswith("torch>") or s.startswith("torch=") for s in stage_one), (
+            f"{label} backend missing torch in Stage 1"
+        )
+        assert any(
+            s == "torchaudio" or s.startswith("torchaudio>") or s.startswith("torchaudio=") for s in stage_one
+        ), f"{label} backend missing torchaudio in Stage 1"
+        # Stage 2 must NOT carry the CUDA index — that's the whole point.
+        stage_two = recorder.calls[2]
+        assert "--index-url" not in stage_two, f"{label} backend leaked --index-url into Stage 2"
+        assert "--extra-index-url" not in stage_two, f"{label} backend leaked --extra-index-url into Stage 2"
+        # And no torch / torchaudio specs in Stage 2 either: listing them
+        # without an index flag would let uv consider replacing the
+        # matched wheel from Stage 1 with PyPI's tagless one.
+        assert not any(s == "torch" or s.startswith("torch>") or s.startswith("torch=") for s in stage_two), (
+            f"{label} backend leaked a torch spec into Stage 2"
+        )
+        assert not any(
+            s == "torchaudio" or s.startswith("torchaudio>") or s.startswith("torchaudio=") for s in stage_two
+        ), f"{label} backend leaked a torchaudio spec into Stage 2"


### PR DESCRIPTION
  ## Summary

  Follow-up to #516. The `--index-url <cuda> --extra-index-url pypi` pattern doesn't actually route `torch` / `torchaudio` through the chosen PyTorch wheel index in uv.
  Splitting the install into two stages (CUDA-index for torch+torchaudio, then default PyPI for everything else) makes the routing real, eliminates the cu128/cu129 ABI mismatch
   this PR was meant to fix, and keeps every behavioral guarantee #516 introduced.
  
  ## Why

  While testing #516 on ORCD, the canary venv consistently rebuilt into the same broken state #516 is trying to prevent:

  ```
  RuntimeError: Detected that PyTorch and TorchAudio were compiled with
  different CUDA versions. PyTorch has CUDA version 12.9 whereas
  TorchAudio has CUDA version 12.8.
  ```
  
  Reproduced even with `SENSELAB_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128` explicitly set:

  ```bash
  $ ls ~/.cache/senselab/venvs/nemo-canary-qwen/lib/python3.12/site-packages/ \
      | grep -E "^(torch|torchaudio)-[0-9].*dist-info$"
  torch-2.8.0+cu129.dist-info       # from PyPI — has +cu129 local tag
  torchaudio-2.8.0.dist-info        # from PyPI — no local tag, internally cu128
  ```

  The marker reported `torch_index.url == https://download.pytorch.org/whl/cu128` (override was honored at the routing-decision layer), but the install argv still landed both
  wheels from PyPI.

  ### Root cause

  uv treats `--extra-index-url` as taking **precedence over** `--index-url` (opposite of pip). Quoting uv's own docs: *"uv treats `--extra-index-url` as a list of extra indexes
   that take precedence over `--index-url`."* So in #516's install command:

  ```
  uv pip install \
    --index-url https://download.pytorch.org/whl/cu128 \
    --extra-index-url https://pypi.org/simple \
    <requirements>
  ```

  PyPI is consulted first for every package. PyPI has both `torch` and `torchaudio`, so the CUDA index is effectively never used for them. The two wheels come from PyPI with
  mismatched local-version tags, and the env override path is non-functional too.

  Verified directly: running `uv pip install --index-url https://download.pytorch.org/whl/cu128 --force-reinstall --no-deps torch torchaudio` (no `--extra-index-url`) correctly
   installed matched `+cu128` wheels into the same venv.

  ## The fix

  Split the install into two stages.

  **Stage 1** — `uv pip install --index-url <chosen> torch torchaudio` with **no** `--extra-index-url`. The chosen CUDA index is unambiguously primary; both wheels and their
  `nvidia-cuda-runtime-cu12` transitives come from the same toolchain. Any version pin in the caller's `requirements` (e.g. `torch>=2.8,<2.9`) flows through verbatim; backends
  that don't pin torch (e.g. qwen) fall back to bare names.
  
  **Stage 2** — `uv pip install <rest of requirements> safetensors numpy` with no index flags. uv resolves against default PyPI, sees `torch` / `torchaudio` already installed
  and satisfying any pin, and leaves them alone. The PyTorch index now governs only the two packages it's designed for, and stale wheels on the CUDA index for utilities like
  setuptools / pyarrow stay out of the picture.
  
  `torchaudio` is no longer re-appended in Stage 2 — it's installed in Stage 1, and re-listing it without an index flag would let uv consider replacing the matched wheel with
  PyPI's tagless one.

  ## Behavioral guarantees preserved from #516

  - Marker schema (`torch_index` field with `tag` / `url` / `source`).
  - Cache-hit fast path (marker compares `requirements` + `torch_index.url`).
  - Env override (`SENSELAB_TORCH_INDEX_URL`) — flows into Stage 1 unchanged.
  - `SenselabCudaCompatibilityError` wrapping on wheel-not-found errors, now scoped to Stage 1 where it semantically belongs (Stage 2 hits default PyPI, so a failure there
  isn't a CUDA-compat surface).
  - Pass-through of unrelated `CalledProcessError`s.
  - Half-built-venv cleanup on either stage's failure.
  - Host-CUDA probe diagnostic surface.
  - Cross-backend routing (canary, nemo, qwen all hit the same `ensure_venv`).

  ## Tests

  The 14 existing `subprocess_venv_test.py` tests are kept; 4 needed call-count or argv-shape updates for the new two-stage form, and the single install-argv test was split
  into three more specific ones:

  - `test_stage_one_pins_torch_and_torchaudio_to_chosen_index` — Stage 1 names only `--index-url`, no `--extra-index-url`, and includes the torch + torchaudio specs from
  `requirements`.
  - `test_stage_one_uses_bare_names_when_requirements_omit_torch` — qwen-style backend (no explicit torch pin) still gets torch + torchaudio installed in Stage 1 so transitives
   don't pull them in later from PyPI.
  - `test_stage_two_uses_default_pypi_and_includes_ipc_deps` — Stage 2 carries neither `--index-url` nor `--extra-index-url`, includes `safetensors` + `numpy`, and does NOT
  re-list `torchaudio`.

  The cross-backend regression test (`test_all_three_subprocess_backends_route_through_same_torch_index`) now asserts both that Stage 1 routes through the chosen index AND that
   Stage 2 does *not* — guarding against any future re-introduction of `--extra-index-url` on the torch install. The `SenselabCudaCompatibilityError` wrapping test and the
  unrelated-error pass-through test were unchanged (they fire on the first `uv pip install` call, which is now Stage 1 — semantically correct).
  
  All 30 unit/integration tests pass:

  ```
  $ uv run pytest src/tests/utils/subprocess_venv_test.py \
                  src/tests/utils/cuda_probe_test.py --noconftest -q
  ..............................                                           [100%]
  30 passed, 2 warnings in 9.28s
  ```

  ## Out-of-band verification

  Reproduced the bug, applied this fix, and verified end-to-end on an ORCD compute node:
  
  - Cleared `~/.cache/senselab/venvs/nemo-canary-qwen` to force a fresh build.
  - Re-ran a canary loader with no env override set, on a non-GPU interactive shell where the probe correctly picks `cpu`.
  - Stage 1 installed matched `torch-2.8.0+cpu` and `torchaudio-2.8.0+cpu` (clean CPU path — no PyPI fallback leaking cu128/cu129).
  - Stage 2 installed NeMo from PyPI without disturbing torch/torchaudio.
  - Canary transcribed audio without `RuntimeError`. CPU path proven functional.

  Inside a `srun --gres=gpu:1` allocation the probe picks `cu128` from the static map and Stage 1 installs matched `+cu128` wheels — same outcome, GPU-capable.

  ## Test plan

  - [x] `uv run pytest src/tests/utils/subprocess_venv_test.py src/tests/utils/cuda_probe_test.py --noconftest` — all 30 tests pass.
  - [x] Fresh canary venv build with `SENSELAB_VENV_CACHE` redirected to a throwaway dir; verified torch + torchaudio wheels carry matching local-version tags after the
  install.
  - [x] `temp/asr.py` runs canary end-to-end against a real audio clip; no `RuntimeError`, transcript returned.
  - [ ] Cross-check on a fresh cu13x-driver host that the matched-tag outcome holds under the probe path (no override).