### PR TITLE
Feat/pii subprocess venv

### DIFF
--- a/src/senselab/audio/workflows/audio_analysis/global_summary.py
+++ b/src/senselab/audio/workflows/audio_analysis/global_summary.py
@@ -280,14 +280,34 @@ def compute_pass_global_summary(
 
     # ─── no_pii ───
     # Surface the actual detected PII spans (text + category + detector + ASR
-    # source + confidence) so the consumer can audit. The boolean ``contains_pii``
-    # flag drives the bottom-line uncertainty; the span list lets a reviewer
-    # decide whether each detection is a true positive worth redacting.
+    # source + confidence) so the consumer can audit. The continuous
+    # ``detection_confidence`` (per-span score × cross-detector agreement ×
+    # cross-ASR agreement) drives the bottom-line uncertainty; the boolean
+    # ``contains_pii`` and the span list let a reviewer decide whether each
+    # detection is a true positive worth redacting. ``None`` propagation:
+    # ``pii_report is None`` (PII stage skipped upstream) or
+    # ``pii_report.detector_used is None`` (subprocess crashed / both
+    # detectors failed to load / caller passed ``detectors=[]``) both
+    # surface as ``no_pii_uncertainty = None`` — distinct from ``0.0``
+    # ("ran, found nothing") so a downstream auditor can tell "didn't
+    # check" from "checked clean".
     if pii_report is None:
         no_pii_uncertainty: float | None = None
         pii_block: dict[str, Any] | None = None
+    elif pii_report.detector_used is None:
+        no_pii_uncertainty = None
+        pii_block = {
+            "contains_pii": pii_report.contains_pii,
+            "n_spans": pii_report.n_spans,
+            "categories": pii_report.categories,
+            "detector_used": None,
+            "detection_confidence": None,
+            "spans_by_category": {},
+            "spans": [],
+            "failures": pii_report.failures,
+        }
     else:
-        no_pii_uncertainty = 1.0 if pii_report.contains_pii else 0.0
+        no_pii_uncertainty = pii_report.detection_confidence
         # Group spans by category for a quick at-a-glance view; full per-span
         # detail lives alongside.
         from collections import defaultdict
@@ -307,6 +327,7 @@ def compute_pass_global_summary(
             "n_spans": pii_report.n_spans,
             "categories": pii_report.categories,
             "detector_used": pii_report.detector_used,
+            "detection_confidence": pii_report.detection_confidence,
             "spans_by_category": dict(spans_by_category),
             "spans": [
                 {

--- a/src/senselab/audio/workflows/audio_analysis/pii.py
+++ b/src/senselab/audio/workflows/audio_analysis/pii.py
@@ -79,6 +79,84 @@ class PiiPassReport:
     # both loaded cleanly, ``"presidio"`` when GLiNER failed but
     # Presidio worked, or ``None`` when neither detector ran.
     detector_used: str | None = None
+    # Continuous detection confidence in ``[0, 1]`` computed from per-
+    # detector raw scores plus cross-detector and cross-ASR-model
+    # agreement. ``None`` ⇔ detectors did not actually run (subprocess
+    # failure, ``detectors=[]`` short-circuit, all detectors failed to
+    # load) — distinct from ``0.0`` which means "ran, found nothing".
+    # No category-severity weighting: in pediatric / clinical voice
+    # data the most-"severe" Presidio categories (US_SSN, CREDIT_CARD)
+    # have near-zero true-positive rate and are dominated by ASR
+    # digit-hallucinations, so weighting them up would inflate exactly
+    # the hits a reviewer should de-prioritize.
+    detection_confidence: float | None = None
+
+
+def _compute_detection_confidence(spans: list[PiiSpan], n_asr_models: int) -> float:
+    """Aggregate per-span detector scores into a single ``[0, 1]`` confidence.
+
+    Combines three signals per unique ``(category, normalized_text)`` finding:
+
+    - **max raw detector confidence** on that finding (Presidio's analyzer
+      score or GLiNER's prediction probability)
+    - **cross-detector agreement** — both Presidio and GLiNER independently
+      flagged the same (category, normalized_text) (factor of 1.0) vs only
+      one detector (0.5). Two-detector agreement is the strongest "is this
+      a real entity or hallucinated?" signal we have at this layer.
+    - **cross-ASR-model agreement** — fraction of available ASR transcripts
+      that contain the finding. A span only one ASR transcribed (and that
+      neither sibling ASR confirms) is the prototypical hallucination case.
+
+    Then ``max()`` across findings — any single high-confidence corroborated
+    finding raises the alarm, matching how the transcript / single-speaker
+    axes combine their internal signals.
+
+    Deliberately NO category-severity weighting (no SSN > date scaling) —
+    in pediatric voice data the categories nominally most "severe" have
+    near-zero true-positive rate and are dominated by ASR digit
+    hallucinations; weighting them up would inflate the wrong cases.
+
+    Args:
+        spans: All PII spans collected for this pass.
+        n_asr_models: Total number of ASR backends whose transcripts were
+            scanned. Used as the denominator for cross-ASR agreement so
+            single-ASR setups don't get penalised relative to multi-ASR.
+
+    Returns:
+        Confidence in ``[0, 1]``. ``0.0`` when ``spans`` is empty (the
+        "detectors ran, nothing found" case). The "detectors did not run
+        at all" case is communicated separately via ``detector_used=None``
+        on the enclosing report; callers should branch on that, not on
+        this number.
+    """
+    if not spans:
+        return 0.0
+    groups: dict[tuple[str, str], dict[str, Any]] = {}
+    for s in spans:
+        normalized = s.text.strip().lower()
+        if not normalized:
+            continue
+        key = (s.category, normalized)
+        g = groups.setdefault(
+            key,
+            {"detectors": set(), "asrs": set(), "max_score": 0.0},
+        )
+        # ``source`` shape is "presidio" or "gliner/<original_label>" —
+        # take the part before the first ``/`` so both produce one bucket.
+        detector_root = s.source.split("/", 1)[0] if s.source else "unknown"
+        g["detectors"].add(detector_root)
+        g["asrs"].add(s.asr_model)
+        if s.score is not None:
+            g["max_score"] = max(g["max_score"], float(s.score))
+    if not groups:
+        return 0.0
+    denom_asrs = max(1, n_asr_models)
+    risks: list[float] = []
+    for g in groups.values():
+        detector_agreement = len(g["detectors"]) / 2  # 0.5 single, 1.0 both
+        asr_agreement = min(1.0, len(g["asrs"]) / denom_asrs)
+        risks.append(g["max_score"] * detector_agreement * asr_agreement)
+    return max(risks) if risks else 0.0
 
 
 def _build_full_text(resolved: Any) -> str:  # noqa: ANN401 — accepts list / dict / ScriptLine
@@ -301,6 +379,12 @@ def detect_pii_in_pass(
             contains_pii = True
 
     categories = sorted({s.category for s in spans})
+    # detection_confidence is computed only on the happy path where at
+    # least one detector ran. The early-return branches above already
+    # leave it as ``None`` (the dataclass default), so a caller can
+    # distinguish "detectors ran, found nothing" (0.0) from "detectors
+    # did not actually run" (None).
+    detection_confidence = _compute_detection_confidence(spans, n_asr_models=len(spans_by_asr))
     return PiiPassReport(
         pass_label=pass_label,
         contains_pii=contains_pii,
@@ -309,6 +393,7 @@ def detect_pii_in_pass(
         spans=spans,
         failures=failures,
         detector_used=",".join(detectors_used) if detectors_used else None,
+        detection_confidence=detection_confidence,
     )
 
 
@@ -320,6 +405,7 @@ def report_to_dict(report: PiiPassReport) -> dict[str, Any]:
         "n_spans": report.n_spans,
         "categories": report.categories,
         "detector_used": report.detector_used,
+        "detection_confidence": report.detection_confidence,
         "spans": [asdict(s) for s in report.spans],
         "failures": report.failures,
     }

--- a/src/senselab/audio/workflows/audio_analysis/pii.py
+++ b/src/senselab/audio/workflows/audio_analysis/pii.py
@@ -36,6 +36,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from senselab.audio.workflows.audio_analysis.pii_subprocess import (
+    _KNOWN_DETECTORS,
     DETECTOR_GLINER,
     DETECTOR_PRESIDIO,
     detect_pii_via_subprocess,
@@ -156,7 +157,7 @@ def _compute_detection_confidence(spans: list[PiiSpan], n_asr_models: int) -> fl
     denom_asrs = max(1, n_asr_models)
     risks: list[float] = []
     for g in groups.values():
-        detector_agreement = len(g["detectors"]) / 2  # 0.5 single, 1.0 both
+        detector_agreement = len(g["detectors"]) / len(_KNOWN_DETECTORS)  # 0.5 single, 1.0 both
         asr_agreement = min(1.0, len(g["asrs"]) / denom_asrs)
         risks.append(g["max_score"] * detector_agreement * asr_agreement)
     return max(risks) if risks else 0.0

--- a/src/senselab/audio/workflows/audio_analysis/pii.py
+++ b/src/senselab/audio/workflows/audio_analysis/pii.py
@@ -1,32 +1,55 @@
 """PII detection over ASR transcripts.
 
-Two ML-based detectors, layered with graceful degradation:
+Detection runs in an isolated subprocess venv (Presidio + GLiNER on
+Python 3.13) so the host process doesn't need ``presidio-analyzer`` /
+``spacy`` / ``gliner`` installed — see ``pii_subprocess.py`` for the
+venv contents and worker. Two detectors run in parallel inside the venv:
 
-1. **Microsoft Presidio Analyzer** (preferred) — industry-standard PII detection
-   library combining spaCy NER with purpose-built recognizers for emails, phone
-   numbers, SSNs, credit cards, IP addresses, dates, and locations. Each span
-   carries a confidence score and an entity type.
-2. **spaCy NER** (fallback) — bare ``en_core_web_sm`` / ``en_core_web_trf`` for
-   PERSON / GPE / LOC / ORG entities. Less coverage than Presidio (no email /
-   phone / SSN-specific recognizers) but available wherever spaCy is installed.
+1. **Microsoft Presidio Analyzer** — regex + spaCy-NER orchestrator with
+   purpose-built recognizers for emails, phone numbers, SSNs, credit
+   cards, IP addresses, dates, and locations.
+2. **GLiNER PII** (``nvidia/gliner-pii`` by default) — a transformer-
+   based zero-shot NER model fine-tuned on ~100k synthetic PII / PHI
+   records. Catches the long tail Presidio misses (especially medical /
+   health entities).
 
-Regex-only detection is intentionally NOT supported here: ASR transcripts
-routinely contain digit-heavy hallucinations and ambiguous date strings that
-flip a regex-only ``contains_pii`` flag from a single false positive. ML
-detectors with confidence scores let the workflow gate on a meaningful
-threshold.
+GLiNER's lowercase labels are normalized to Presidio's uppercase scheme
+inside the worker so the cross-model corroboration logic below — which
+keys on ``(category, text.lower())`` — sees the two detectors' hits on
+the same entity as the same finding.
 
-When neither detector is available, the report records an explicit failure
-reason (``failures["no_pii_detector"]``) and ``contains_pii`` defaults to
-``False`` — the user knows the check didn't run rather than getting a silent
-all-clear.
+When the subprocess fails to start or both detectors fail to load, the
+report records an explicit failure reason
+(``failures["pii_subprocess"]``) and ``contains_pii`` defaults to
+``False`` — the caller learns the check didn't actually run rather
+than getting a silent all-clear.
 """
 
 from __future__ import annotations
 
 import sys
+from collections import Counter
 from dataclasses import asdict, dataclass, field
 from typing import Any
+
+from senselab.audio.workflows.audio_analysis.pii_subprocess import (
+    DETECTOR_GLINER,
+    DETECTOR_PRESIDIO,
+    detect_pii_via_subprocess,
+)
+
+# Re-export the canonical detector names so ``analyze_audio.py`` (and
+# any other caller wiring up a ``--pii-detectors`` flag) can reference
+# them as ``pii.DETECTOR_PRESIDIO`` / ``pii.DETECTOR_GLINER`` rather
+# than reaching into the subprocess-specific module.
+__all__ = [
+    "DETECTOR_GLINER",
+    "DETECTOR_PRESIDIO",
+    "PiiPassReport",
+    "PiiSpan",
+    "detect_pii_in_pass",
+    "report_to_dict",
+]
 
 
 @dataclass
@@ -35,7 +58,7 @@ class PiiSpan:
 
     text: str
     category: str  # presidio entity_type, e.g. "PERSON", "EMAIL_ADDRESS", "PHONE_NUMBER"
-    source: str  # "presidio" or "spacy/<label>"
+    source: str  # "presidio" or "gliner/<original_label>"
     asr_model: str
     pass_label: str | None = None
     score: float | None = None  # detector confidence in [0, 1]
@@ -51,215 +74,163 @@ class PiiPassReport:
     categories: list[str]
     spans: list[PiiSpan] = field(default_factory=list)
     failures: dict[str, str] = field(default_factory=dict)
-    detector_used: str | None = None  # "presidio" or "spacy" or None
+    # Comma-joined list of detectors that successfully ran inside the
+    # subprocess venv for this report — e.g. ``"presidio,gliner"`` when
+    # both loaded cleanly, ``"presidio"`` when GLiNER failed but
+    # Presidio worked, or ``None`` when neither detector ran.
+    detector_used: str | None = None
 
 
-# Default Presidio entity types we treat as PII. Excludes things Presidio
-# detects but that aren't PII per se (e.g. URL alone without a personal site).
-_PRESIDIO_PII_ENTITIES = {
-    "PERSON",
-    "EMAIL_ADDRESS",
-    "PHONE_NUMBER",
-    "US_SSN",
-    "CREDIT_CARD",
-    "IP_ADDRESS",
-    "LOCATION",
-    "DATE_TIME",
-    "NRP",  # nationality / religion / political affiliation
-    "MEDICAL_LICENSE",
-    "US_DRIVER_LICENSE",
-    "US_BANK_NUMBER",
-    "US_PASSPORT",
-    "IBAN_CODE",
-    "CRYPTO",
-}
+def _build_full_text(resolved: Any) -> str:  # noqa: ANN401 — accepts list / dict / ScriptLine
+    """Concatenate the ``text`` fields of an ASR resolution into one string.
 
-# spaCy NER entity types we treat as PII when Presidio is unavailable.
-_SPACY_PII_ENTITIES = {"PERSON", "GPE", "LOC", "ORG", "FAC", "NORP"}
-
-
-def _load_presidio_analyzer() -> tuple[Any, str | None]:  # noqa: ANN401
-    """Try to load a Presidio AnalyzerEngine. Returns (analyzer_or_None, failure_msg)."""
-    try:
-        from presidio_analyzer import AnalyzerEngine
-    except ImportError as exc:
-        return None, (
-            f"Presidio not installed ({exc!r}); install via "
-            "'uv sync --extra pii' or 'pip install presidio-analyzer presidio-anonymizer'."
-        )
-    try:
-        # ``AnalyzerEngine()`` constructs a default NLP pipeline + recognizer
-        # registry. The first construction downloads / loads the spaCy model
-        # Presidio depends on (en_core_web_lg by default).
-        return AnalyzerEngine(), None
-    except Exception as exc:  # noqa: BLE001 — surface the cause to the caller
-        return None, f"Presidio AnalyzerEngine construction failed: {exc!r}"
-
-
-def _load_spacy_nlp() -> tuple[Any, str | None]:  # noqa: ANN401
-    """Try to load a spaCy English NER model. Returns (nlp_or_None, failure_msg)."""
-    try:
-        import spacy
-    except ImportError as exc:
-        return None, f"spaCy unavailable: {exc!r}"
-    for model_name in ("en_core_web_trf", "en_core_web_md", "en_core_web_sm"):
-        try:
-            return spacy.load(model_name), None
-        except (OSError, IOError):
-            continue
-    return None, (
-        "no spaCy English model installed (tried en_core_web_trf/md/sm); "
-        "install via 'uv run python -m spacy download en_core_web_sm'."
-    )
-
-
-def _scan_with_presidio(
-    text: str,
-    asr_model: str,
-    pass_label: str,
-    *,
-    analyzer: Any,  # noqa: ANN401
-    score_threshold: float,
-) -> list[PiiSpan]:
-    """Run Presidio over a transcript. Returns spans for entities in the PII allowlist."""
-    if not text.strip():
-        return []
-    try:
-        results = analyzer.analyze(text=text, language="en", score_threshold=score_threshold)
-    except Exception as exc:  # noqa: BLE001
-        print(
-            f"warn: Presidio analyzer failed on transcript from {asr_model!r}: {exc!r}",
-            file=sys.stderr,
-        )
-        return []
-    seen: set[tuple[str, str]] = set()
-    spans: list[PiiSpan] = []
-    for r in results:
-        entity_type = getattr(r, "entity_type", None) or ""
-        if entity_type not in _PRESIDIO_PII_ENTITIES:
-            continue
-        try:
-            start = int(r.start)
-            end = int(r.end)
-            score = float(r.score)
-        except (AttributeError, TypeError, ValueError):
-            continue
-        span_text = text[start:end]
-        normalized = span_text.strip().lower()
-        key = (entity_type, normalized)
-        if key in seen:
-            continue
-        seen.add(key)
-        spans.append(
-            PiiSpan(
-                text=span_text,
-                category=entity_type,
-                source="presidio",
-                asr_model=asr_model,
-                pass_label=pass_label,
-                score=score,
-            )
-        )
-    return spans
-
-
-def _scan_with_spacy(
-    text: str,
-    asr_model: str,
-    pass_label: str,
-    *,
-    nlp: Any,  # noqa: ANN401
-) -> list[PiiSpan]:
-    """Run spaCy NER over a transcript when Presidio isn't available."""
-    if not text.strip():
-        return []
-    try:
-        doc = nlp(text)
-    except Exception as exc:  # noqa: BLE001
-        print(
-            f"warn: spaCy NER failed on transcript from {asr_model!r}: {exc!r}",
-            file=sys.stderr,
-        )
-        return []
-    seen: set[tuple[str, str]] = set()
-    spans: list[PiiSpan] = []
-    for ent in doc.ents:
-        if ent.label_ not in _SPACY_PII_ENTITIES:
-            continue
-        normalized = ent.text.strip().lower()
-        key = (ent.label_, normalized)
-        if key in seen:
-            continue
-        seen.add(key)
-        spans.append(
-            PiiSpan(
-                text=ent.text,
-                category=ent.label_,
-                source=f"spacy/{ent.label_}",
-                asr_model=asr_model,
-                pass_label=pass_label,
-                score=None,  # spaCy NER doesn't expose per-span confidence
-            )
-        )
-    return spans
+    Accepts either a list of ``ScriptLine``-shaped dicts / objects, or a
+    single dict / object. Whitespace-only entries are dropped so they
+    don't waste the detectors' compute budget.
+    """
+    items = resolved if isinstance(resolved, list) else [resolved]
+    parts: list[str] = []
+    for line in items:
+        if isinstance(line, dict):
+            t = line.get("text") or ""
+        else:
+            t = getattr(line, "text", "") or ""
+        if t and t.strip():
+            parts.append(t)
+    return " ".join(parts)
 
 
 def detect_pii_in_pass(
     *,
     pass_label: str,
     asr_resolved: dict[str, Any],
+    detectors: list[str] | None = None,
     presidio_score_threshold: float = 0.4,
+    gliner_model: str | None = None,
+    gliner_labels: list[str] | None = None,
+    gliner_threshold: float = 0.5,
     require_cross_model_corroboration: bool = True,
 ) -> PiiPassReport:
     """Scan all ASR transcripts for one pass and return a unified PII report.
 
-    Detector preference order:
-    1. Microsoft Presidio (uses internal NLP + dedicated PII recognizers)
-    2. spaCy NER (lower coverage, no per-span confidence)
-    3. None — both unavailable; report records the failure and ``contains_pii``
-       defaults to ``False`` so the workflow can continue.
+    Detection runs in the ``pii-detection`` subprocess venv via
+    ``detect_pii_via_subprocess``. By default both Presidio and GLiNER
+    run on every transcript and their findings are merged before this
+    function applies cross-ASR-model corroboration. Callers that only
+    want one detector — e.g. Presidio's deterministic regex without
+    paying GLiNER's model-load cost, or GLiNER's model-based extraction
+    without Presidio's structured-data recognizers — can narrow the set
+    via ``detectors``.
 
     Args:
         pass_label: e.g. ``"raw_16k"``.
         asr_resolved: ``{asr_model_id → resolved_asr_result}``.
+        detectors: Subset of detector names to run inside the subprocess
+            venv. ``None`` (default) runs both ``"presidio"`` and
+            ``"gliner"``. Pass ``["presidio"]`` to skip the GLiNER model
+            load entirely; ``["gliner"]`` to skip Presidio. An empty list
+            short-circuits — no subprocess spawned, report has
+            ``detector_used=None`` and ``contains_pii=False`` with an
+            explicit ``"pii_disabled"`` failure note so the workflow
+            can tell "we deliberately didn't check" apart from
+            "the check failed".
         presidio_score_threshold: Presidio entities below this score are
             dropped at extraction time. 0.4 is permissive enough to catch
-            standard phone-number formats (Presidio assigns ~0.4 to phones
-            without surrounding "tel:" / "phone:" context); cross-model
-            corroboration still gates the boolean flag for borderline scores.
-        require_cross_model_corroboration: When ``True`` (default), only flip
-            ``contains_pii`` to ``True`` when a (category, normalized_text)
-            pair is detected by ≥2 ASR models. Filters out hallucinated
-            entities present in only one ASR's transcript.
+            standard phone-number formats; cross-model corroboration
+            still gates the boolean flag for borderline scores.
+        gliner_model: HuggingFace model id for GLiNER. ``None`` uses the
+            subprocess module's default (``nvidia/gliner-pii``). Ignored
+            when ``"gliner"`` is excluded from ``detectors``.
+        gliner_labels: Labels passed to GLiNER's ``predict_entities``.
+            ``None`` uses the subprocess module's curated default set.
+            Ignored when ``"gliner"`` is excluded from ``detectors``.
+        gliner_threshold: Drop GLiNER predictions below this score.
+        require_cross_model_corroboration: When ``True`` (default), only
+            flip ``contains_pii`` to ``True`` when a ``(category,
+            normalized_text)`` pair is detected by ≥2 ASR models. Filters
+            out hallucinated entities present in only one ASR's
+            transcript. When fewer than 2 ASR models are available, any
+            single detection counts.
 
     Returns:
-        ``PiiPassReport`` with per-span detail, the detector used, and any
-        failure reasons.
+        ``PiiPassReport`` with per-span detail, the detector(s) used, and
+        any failure reasons.
     """
     failures: dict[str, str] = {}
 
-    analyzer, presidio_msg = _load_presidio_analyzer()
-    nlp = None
-    spacy_msg: str | None = None
-    if analyzer is None:
-        if presidio_msg is not None:
-            failures["presidio"] = presidio_msg
-            print(f"warn: PII / Presidio: {presidio_msg}", file=sys.stderr)
-        nlp, spacy_msg = _load_spacy_nlp()
-        if nlp is None and spacy_msg is not None:
-            failures["spacy_ner"] = spacy_msg
-            print(f"warn: PII / spaCy NER: {spacy_msg}", file=sys.stderr)
+    # Build per-ASR concatenated transcripts up front so we send the
+    # subprocess one request covering every ASR backend for this pass.
+    transcripts_by_asr: dict[str, str] = {}
+    for asr_model, resolved in asr_resolved.items():
+        full_text = _build_full_text(resolved)
+        if not full_text.strip():
+            continue
+        transcripts_by_asr[asr_model] = full_text
 
-    detector_used: str | None = None
-    if analyzer is not None:
-        detector_used = "presidio"
-    elif nlp is not None:
-        detector_used = "spacy"
-    else:
-        failures["no_pii_detector"] = (
-            "Neither Presidio nor spaCy is available — PII check did not run. "
-            "contains_pii=False reported by default; install presidio-analyzer "
-            "or spaCy + en_core_web_sm to enable detection."
+    if not transcripts_by_asr:
+        # Nothing to scan — every ASR result was empty / whitespace.
+        return PiiPassReport(
+            pass_label=pass_label,
+            contains_pii=False,
+            n_spans=0,
+            categories=[],
+            spans=[],
+            failures=failures,
+            detector_used=None,
+        )
+
+    # Explicit ``detectors=[]`` means the caller has chosen to disable
+    # PII detection for this pass. Surface that as a distinct failure
+    # reason so a downstream auditor can tell "didn't run on purpose"
+    # apart from "ran but found nothing" and "subprocess crashed".
+    if detectors is not None and len(detectors) == 0:
+        failures["pii_disabled"] = "PII detection disabled by caller (detectors=[])."
+        return PiiPassReport(
+            pass_label=pass_label,
+            contains_pii=False,
+            n_spans=0,
+            categories=[],
+            spans=[],
+            failures=failures,
+            detector_used=None,
+        )
+
+    try:
+        subprocess_kwargs: dict[str, Any] = {
+            "presidio_score_threshold": presidio_score_threshold,
+            "gliner_threshold": gliner_threshold,
+        }
+        if detectors is not None:
+            subprocess_kwargs["detectors"] = detectors
+        if gliner_model is not None:
+            subprocess_kwargs["gliner_model"] = gliner_model
+        if gliner_labels is not None:
+            subprocess_kwargs["gliner_labels"] = gliner_labels
+        result = detect_pii_via_subprocess(transcripts_by_asr, **subprocess_kwargs)
+    except Exception as exc:  # noqa: BLE001 — caller needs the report to continue
+        msg = f"PII subprocess failed: {type(exc).__name__}: {exc}"
+        failures["pii_subprocess"] = msg
+        print(f"warn: {msg}", file=sys.stderr)
+        return PiiPassReport(
+            pass_label=pass_label,
+            contains_pii=False,
+            n_spans=0,
+            categories=[],
+            spans=[],
+            failures=failures,
+            detector_used=None,
+        )
+
+    spans_by_asr_raw = result.get("spans_by_asr", {})
+    failures.update(result.get("failures", {}))
+    detectors_used = list(result.get("detectors_used", []))
+    for name, msg in failures.items():
+        print(f"warn: PII / {name}: {msg}", file=sys.stderr)
+
+    if not detectors_used:
+        failures.setdefault(
+            "no_pii_detector",
+            "Neither Presidio nor GLiNER loaded inside the subprocess venv; contains_pii=False reported by default.",
         )
         print(f"warn: {failures['no_pii_detector']}", file=sys.stderr)
         return PiiPassReport(
@@ -272,54 +243,60 @@ def detect_pii_in_pass(
             detector_used=None,
         )
 
+    # Materialize PiiSpan objects with the asr_model + pass_label fields
+    # the subprocess can't fill in (it doesn't know which pass it's running
+    # against), and dedupe ``(category, normalized_text, source)`` per ASR
+    # model so a single entity detected by both Presidio and GLiNER counts
+    # once per detector rather than once per phrasing.
     spans_by_asr: dict[str, list[PiiSpan]] = {}
     spans: list[PiiSpan] = []
-    for asr_model, resolved in asr_resolved.items():
-        items = resolved if isinstance(resolved, list) else [resolved]
-        text_parts: list[str] = []
-        for line in items:
-            if isinstance(line, dict):
-                t = line.get("text") or ""
-            else:
-                t = getattr(line, "text", "") or ""
-            if t.strip():
-                text_parts.append(t)
-        full_text = " ".join(text_parts)
-        if not full_text.strip():
-            continue
-        per_model: list[PiiSpan]
-        if analyzer is not None:
-            per_model = _scan_with_presidio(
-                full_text,
-                asr_model,
-                pass_label,
-                analyzer=analyzer,
-                score_threshold=presidio_score_threshold,
+    for asr_model, raw_spans in spans_by_asr_raw.items():
+        seen_per_detector: set[tuple[str, str, str]] = set()
+        per_model: list[PiiSpan] = []
+        for raw in raw_spans:
+            text: str = raw.get("text") or ""
+            category: str = raw.get("category") or ""
+            source: str = raw.get("source") or "unknown"
+            normalized = text.strip().lower()
+            dedup_key: tuple[str, str, str] = (category, normalized, source)
+            if not normalized or dedup_key in seen_per_detector:
+                continue
+            seen_per_detector.add(dedup_key)
+            score = raw.get("score")
+            per_model.append(
+                PiiSpan(
+                    text=text,
+                    category=category,
+                    source=source,
+                    asr_model=asr_model,
+                    pass_label=pass_label,
+                    score=float(score) if score is not None else None,
+                )
             )
-        else:
-            per_model = _scan_with_spacy(full_text, asr_model, pass_label, nlp=nlp)
         spans_by_asr[asr_model] = per_model
         spans.extend(per_model)
 
-    # Decide ``contains_pii``. Cross-model corroboration filters out
-    # hallucinated entities that only one ASR backend produced.
+    # Cross-ASR-model corroboration. A ``(category, normalized_text)``
+    # pair detected by at least two ASR backends is treated as real PII;
+    # everything else is a candidate that might be an ASR hallucination.
+    # When the workflow only invokes one ASR backend, any single hit
+    # counts (the corroboration check is informative, not load-bearing,
+    # in that case).
     if not spans:
         contains_pii = False
     elif not require_cross_model_corroboration:
         contains_pii = True
     else:
-        from collections import Counter
-
         norm_keys: Counter[tuple[str, str]] = Counter()
         for asr_model, per_model in spans_by_asr.items():
             seen_in_model: set[tuple[str, str]] = set()
             for s in per_model:
                 key = (s.category, s.text.strip().lower())
-                if key not in seen_in_model:
-                    seen_in_model.add(key)
-                    norm_keys[key] += 1
+                if key in seen_in_model:
+                    continue
+                seen_in_model.add(key)
+                norm_keys[key] += 1
         contains_pii = any(count >= 2 for count in norm_keys.values())
-        # When fewer than 2 ASR models are available, any single detection counts.
         if not contains_pii and len(spans_by_asr) < 2 and spans:
             contains_pii = True
 
@@ -331,7 +308,7 @@ def detect_pii_in_pass(
         categories=categories,
         spans=spans,
         failures=failures,
-        detector_used=detector_used,
+        detector_used=",".join(detectors_used) if detectors_used else None,
     )
 
 

--- a/src/senselab/audio/workflows/audio_analysis/pii.py
+++ b/src/senselab/audio/workflows/audio_analysis/pii.py
@@ -10,8 +10,11 @@ venv contents and worker. Two detectors run in parallel inside the venv:
    cards, IP addresses, dates, and locations.
 2. **GLiNER PII** (``nvidia/gliner-pii`` by default) — a transformer-
    based zero-shot NER model fine-tuned on ~100k synthetic PII / PHI
-   records. Catches the long tail Presidio misses (especially medical /
-   health entities).
+   records. Defaults to the HIPAA Safe Harbor 18 identifiers (matches
+   b2aiprep #256) — catches PHI categories Presidio doesn't natively
+   recognize (medical record number, health plan number, account
+   number, fax number, URL, biometric / device / vehicle identifiers,
+   unique identifier, ...).
 
 GLiNER's lowercase labels are normalized to Presidio's uppercase scheme
 inside the worker so the cross-model corroboration logic below — which

--- a/src/senselab/audio/workflows/audio_analysis/pii_subprocess.py
+++ b/src/senselab/audio/workflows/audio_analysis/pii_subprocess.py
@@ -322,16 +322,21 @@ try:
     def _presidio_scan(text):
         if analyzer is None:
             return []
+        # Pass the entity list through unchanged so an empty list means
+        # "scan for nothing" (Presidio semantics: entities=None scans for
+        # ALL entity types — collapsing [] → None would invert intent).
         results = analyzer.analyze(
             text=text,
-            entities=presidio_entities or None,  # None → all entities
+            entities=presidio_entities,
             language="en",
             score_threshold=presidio_score_threshold,
         )
         out = []
         for r in results:
-            # Filter to the curated PII set even when entities=None was passed.
-            if presidio_entities and r.entity_type not in presidio_entities:
+            # Belt-and-suspenders filter against Presidio returning a
+            # category outside the requested set. `is not None` rather
+            # than truthiness so an explicit empty list filters everything.
+            if presidio_entities is not None and r.entity_type not in presidio_entities:
                 continue
             out.append({
                 "text": text[r.start:r.end],

--- a/src/senselab/audio/workflows/audio_analysis/pii_subprocess.py
+++ b/src/senselab/audio/workflows/audio_analysis/pii_subprocess.py
@@ -20,8 +20,10 @@ are merged:
    entity type like ``PERSON`` / ``EMAIL_ADDRESS``.
 2. **GLiNER PII** (``nvidia/gliner-pii`` by default) — a transformer-
    based zero-shot NER model fine-tuned on ~100k synthetic PII / PHI
-   records. Catches the long tail Presidio misses (especially medical /
-   health entities and unstructured personal-context references).
+   records. Catches the HIPAA Safe Harbor identifiers Presidio doesn't
+   natively recognize (``medical_record_number``,
+   ``health_plan_number``, ``account_number``, ``fax_number``, ``url``,
+   ``biometric_identifier``, ``unique_identifier``, etc.).
 
 GLiNER's lowercase labels (``"person"``, ``"phone_number"``, ...) are
 normalized to Presidio's uppercase scheme inside the worker so the
@@ -91,9 +93,8 @@ _PII_REQUIREMENTS = [
 _DEFAULT_GLINER_MODEL = "nvidia/gliner-pii"
 
 # Labels passed to GLiNER's ``predict_entities``. The set below is the
-# HIPAA Safe Harbor 18 identifiers (matches b2aiprep PR #256) plus two
-# clinical-voice-specific extensions (``health_condition``,
-# ``medication``). Callers can override via ``gliner_labels``.
+# HIPAA Safe Harbor 18 identifiers (matches b2aiprep PR #256 verbatim).
+# Callers can override via ``gliner_labels``.
 #
 # ──────────────────────────────────────────────────────────────────────
 # DO NOT add overlapping labels to this list.
@@ -121,10 +122,26 @@ _DEFAULT_GLINER_MODEL = "nvidia/gliner-pii"
 # ``date`` not ``date``+``date_of_birth``). If you need finer granularity
 # downstream, derive it from the matched substring or layer a second
 # model — don't fight the GLiNER trainer here.
+#
+# ──────────────────────────────────────────────────────────────────────
+# DO NOT extend this list beyond the HIPAA-18 either.
+# ──────────────────────────────────────────────────────────────────────
+# An earlier revision of this constant tacked on two clinical-voice
+# extensions (``health_condition``, ``medication``) on top of the
+# HIPAA list. They aren't semantically overlapping with anything in the
+# HIPAA-18 — they cover spans neither ``email`` nor ``name`` would —
+# but adding them was enough to drop the email's GLiNER score below
+# the 0.5 threshold and cause it to silently disappear. The mechanism
+# isn't fully understood (label-list length effect on the model's
+# projection space, possibly) but the symptom is robust. Until we
+# understand it, ship the HIPAA-18 exactly. Callers who need extra
+# labels can pass them via ``gliner_labels=[...]`` and verify that
+# their specific labels don't trip the same interference on their
+# test corpus.
 _DEFAULT_GLINER_LABELS = [
-    # HIPAA Safe Harbor 18 identifiers (per 45 CFR §164.514(b)(2), and
-    # matching b2aiprep's ``hipaa_labels.json`` in PR #256 so the two
-    # projects' PII outputs share a vocabulary).
+    # HIPAA Safe Harbor 18 identifiers (per 45 CFR §164.514(b)(2),
+    # matching b2aiprep's ``hipaa_labels.json`` in PR #256 verbatim so
+    # the two projects' PII outputs share a vocabulary).
     "name",
     "address",
     "date",
@@ -143,12 +160,6 @@ _DEFAULT_GLINER_LABELS = [
     "biometric_identifier",
     "photographic_image",
     "unique_identifier",
-    # Clinical-voice-specific extensions. Not HIPAA Safe Harbor
-    # identifiers themselves but useful for the b2ai voice-data
-    # analysis workflow. Both are non-overlapping with the HIPAA list
-    # above so they don't trigger the competing-claim interference.
-    "health_condition",
-    "medication",
 ]
 
 # GLiNER returns lowercase labels matching the prompt; Presidio returns
@@ -419,10 +430,12 @@ def detect_pii_via_subprocess(
             multilingual coverage or smaller-model variants.
         gliner_labels: Labels passed to GLiNER's ``predict_entities``.
             ``None`` uses ``_DEFAULT_GLINER_LABELS`` — the HIPAA Safe
-            Harbor 18 identifiers (matches b2aiprep #256) plus two
-            clinical-voice extensions. **Keep label sets flat — see
-            the ``DO NOT add overlapping labels`` warning above the
-            constant for the empirical justification.**
+            Harbor 18 identifiers verbatim (matches b2aiprep #256).
+            **Keep label sets flat AND don't extend past the HIPAA-18
+            unless you've verified your specific additions don't trip
+            the competing-claim interference — see the ``DO NOT``
+            warnings above the constant for the empirical
+            justification.**
         gliner_threshold: Drop GLiNER predictions below this score.
         timeout: Subprocess wall-clock cap. 10 minutes is generous for
             one pass's worth of transcripts; the bulk of the time is the

--- a/src/senselab/audio/workflows/audio_analysis/pii_subprocess.py
+++ b/src/senselab/audio/workflows/audio_analysis/pii_subprocess.py
@@ -90,27 +90,65 @@ _PII_REQUIREMENTS = [
 # coverage (urchade/gliner_multi-v2.1 is the usual swap).
 _DEFAULT_GLINER_MODEL = "nvidia/gliner-pii"
 
-# Labels passed to GLiNER's ``predict_entities``. nvidia/gliner-pii was
-# trained on 55+ categories; this is a curated subset that aligns with
-# Presidio's coverage and adds the medical entities Presidio doesn't
-# natively recognize. Callers can override via ``gliner_labels``.
+# Labels passed to GLiNER's ``predict_entities``. The set below is the
+# HIPAA Safe Harbor 18 identifiers (matches b2aiprep PR #256) plus two
+# clinical-voice-specific extensions (``health_condition``,
+# ``medication``). Callers can override via ``gliner_labels``.
+#
+# ──────────────────────────────────────────────────────────────────────
+# DO NOT add overlapping labels to this list.
+# ──────────────────────────────────────────────────────────────────────
+# ``nvidia/gliner-pii`` exhibits competing-claim interference: when two
+# labels can plausibly cover the same span, the model commits the span
+# to one and silently drops it from consideration under the other —
+# *even when the other would have been correct*. We discovered this
+# empirically with a diagnostic on ``john.doe@example.com``:
+#
+#   Labels passed: [person, first_name, last_name, email, email_address, ...]
+#   GLiNER output: ``John`` and ``Doe`` classified as first/last_name at
+#     score 1.0; the full ``john.doe@example.com`` substring received
+#     NO email span at any score above 0.0.
+#
+#   Labels passed: [name, address, date, phone_number, email, ssn, ...]
+#     (a flat HIPAA-style set with one ``name`` and one ``email``)
+#   GLiNER output: ``John`` and ``Doe`` as ``name`` at score 1.0,
+#     ``john.doe@example.com`` as ``email`` at score 1.0. Both caught.
+#
+# Same model, same threshold, same input — the only difference was
+# label-set granularity. The flat set wins because nothing competes.
+# So: keep this list flat (e.g. ``name`` not ``person``+``first_name``+
+# ``last_name``; ``address`` not ``address``+``street_address``+``city``;
+# ``date`` not ``date``+``date_of_birth``). If you need finer granularity
+# downstream, derive it from the matched substring or layer a second
+# model — don't fight the GLiNER trainer here.
 _DEFAULT_GLINER_LABELS = [
-    "person",
-    "first_name",
-    "last_name",
-    "email",
-    "phone_number",
+    # HIPAA Safe Harbor 18 identifiers (per 45 CFR §164.514(b)(2), and
+    # matching b2aiprep's ``hipaa_labels.json`` in PR #256 so the two
+    # projects' PII outputs share a vocabulary).
+    "name",
     "address",
-    "street_address",
-    "city",
+    "date",
+    "phone_number",
+    "fax_number",
+    "email",
     "social_security_number",
-    "credit_card_number",
-    "date_of_birth",
     "medical_record_number",
-    "patient_id",
+    "health_plan_number",
+    "account_number",
+    "license_number",
+    "vehicle_identifier",
+    "device_identifier",
+    "url",
+    "ip_address",
+    "biometric_identifier",
+    "photographic_image",
+    "unique_identifier",
+    # Clinical-voice-specific extensions. Not HIPAA Safe Harbor
+    # identifiers themselves but useful for the b2ai voice-data
+    # analysis workflow. Both are non-overlapping with the HIPAA list
+    # above so they don't trigger the competing-claim interference.
     "health_condition",
     "medication",
-    "ip_address",
 ]
 
 # GLiNER returns lowercase labels matching the prompt; Presidio returns
@@ -380,8 +418,11 @@ def detect_pii_via_subprocess(
             Pass a different id (e.g. ``urchade/gliner_multi-v2.1``) for
             multilingual coverage or smaller-model variants.
         gliner_labels: Labels passed to GLiNER's ``predict_entities``.
-            ``None`` uses the curated default mirroring Presidio's
-            coverage plus medical entities.
+            ``None`` uses ``_DEFAULT_GLINER_LABELS`` — the HIPAA Safe
+            Harbor 18 identifiers (matches b2aiprep #256) plus two
+            clinical-voice extensions. **Keep label sets flat — see
+            the ``DO NOT add overlapping labels`` warning above the
+            constant for the empirical justification.**
         gliner_threshold: Drop GLiNER predictions below this score.
         timeout: Subprocess wall-clock cap. 10 minutes is generous for
             one pass's worth of transcripts; the bulk of the time is the

--- a/src/senselab/audio/workflows/audio_analysis/pii_subprocess.py
+++ b/src/senselab/audio/workflows/audio_analysis/pii_subprocess.py
@@ -1,0 +1,472 @@
+"""Isolated subprocess venv that runs PII detection on ASR transcripts.
+
+Why a subprocess at all
+-----------------------
+The host venv may be on a Python version that doesn't yet have wheels for
+``spaCy`` (which tops out at cp313 as of writing) or for transformer-backed
+GLiNER. Rather than pinning the entire project to an older Python — a heavy
+constraint when only one downstream feature needs it — PII detection runs in
+its own Python-3.13 venv created via ``ensure_venv``. The host can stay on
+whatever recent Python it wants; PII still works.
+
+What runs inside the venv
+-------------------------
+Two PII detectors run in series on each input transcript and their spans
+are merged:
+
+1. **Microsoft Presidio Analyzer** — regex + spaCy-NER orchestrator with
+   purpose-built recognizers for emails, phones, SSNs, credit cards, IPs,
+   dates, and so on. Each span carries a confidence score and a Presidio
+   entity type like ``PERSON`` / ``EMAIL_ADDRESS``.
+2. **GLiNER PII** (``nvidia/gliner-pii`` by default) — a transformer-
+   based zero-shot NER model fine-tuned on ~100k synthetic PII / PHI
+   records. Catches the long tail Presidio misses (especially medical /
+   health entities and unstructured personal-context references).
+
+GLiNER's lowercase labels (``"person"``, ``"phone_number"``, ...) are
+normalized to Presidio's uppercase scheme inside the worker so the
+downstream corroboration logic in ``pii.py`` — which treats ``(category,
+text.lower())`` as the dedupe key — sees the two detectors' findings as
+referring to the same entity when they do.
+
+What lives in this module
+-------------------------
+- Venv constants (name, Python version, requirements list).
+- Default GLiNER model id and label set, plus the GLiNER → Presidio
+  category map.
+- The worker script that ``ensure_venv`` runs inside the isolated venv.
+- ``detect_pii_via_subprocess`` — the dispatch function called by
+  ``pii.py``.
+
+The first call after a fresh venv build pays ~30 s for the GLiNER + spaCy
+model loads (in addition to the venv build itself). Subsequent calls pay
+the load cost again because each call is a fresh subprocess; batching all
+of a subject's transcripts into one call is a worthwhile follow-up
+optimization but isn't required for correctness.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any, Optional
+
+from senselab.utils.subprocess_venv import _clean_subprocess_env, ensure_venv, parse_subprocess_result, venv_python
+
+_PII_VENV = "pii-detection"
+_PII_PYTHON = "3.13"
+
+# en_core_web_lg pinned as a direct wheel URL so uv installs it as part
+# of the venv resolution (no separate post-install ``python -m spacy
+# download`` step needed). 3.8.0 matches the Presidio default NLP
+# config's expected spaCy schema.
+_EN_CORE_WEB_LG_WHEEL = (
+    "en_core_web_lg @ "
+    "https://github.com/explosion/spacy-models/releases/download/"
+    "en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl"
+)
+
+# ``torch`` is named here explicitly so ``ensure_venv``'s auto-detection
+# (post-PR #516) triggers Stage 1 routing through the matched CUDA wheel
+# index. GLiNER pulls torch transitively; without the explicit pin, the
+# transitive resolve in Stage 2 would skip the CUDA-aware routing and
+# could land on a CPU-only wheel even on GPU hosts. ``torchaudio`` is
+# NOT in this list — neither Presidio nor GLiNER decode audio.
+_PII_REQUIREMENTS = [
+    "presidio-analyzer>=2.2",
+    "spacy>=3.7,<3.9",
+    _EN_CORE_WEB_LG_WHEEL,
+    "gliner>=0.2",
+    "transformers>=4.40",
+    "torch>=2.8,<2.9",
+]
+
+# nvidia/gliner-pii: 570M-param GLiNER variant fine-tuned on a ~100k
+# synthetic PII/PHI dataset. English-only, NVIDIA Open Model License.
+# 55+ pre-trained PII categories including medical / health info — a
+# better fit for clinical voice data than zero-shotting a general-
+# purpose GLiNER model at PII labels. Override via the dispatch
+# function's ``gliner_model`` argument if you need multilingual
+# coverage (urchade/gliner_multi-v2.1 is the usual swap).
+_DEFAULT_GLINER_MODEL = "nvidia/gliner-pii"
+
+# Labels passed to GLiNER's ``predict_entities``. nvidia/gliner-pii was
+# trained on 55+ categories; this is a curated subset that aligns with
+# Presidio's coverage and adds the medical entities Presidio doesn't
+# natively recognize. Callers can override via ``gliner_labels``.
+_DEFAULT_GLINER_LABELS = [
+    "person",
+    "first_name",
+    "last_name",
+    "email",
+    "phone_number",
+    "address",
+    "street_address",
+    "city",
+    "social_security_number",
+    "credit_card_number",
+    "date_of_birth",
+    "medical_record_number",
+    "patient_id",
+    "health_condition",
+    "medication",
+    "ip_address",
+]
+
+# GLiNER returns lowercase labels matching the prompt; Presidio returns
+# uppercase entity types like ``PERSON``. Normalize GLiNER → Presidio so
+# the downstream cross-model corroboration logic in ``pii.py`` (which
+# keys on ``(category, text.lower())``) treats both detectors' hits on
+# the same span as the same finding. Labels missing from this map fall
+# through to ``str.upper()`` so they remain consistent in scheme even
+# if they don't have a direct Presidio analogue.
+_GLINER_TO_PRESIDIO_CATEGORY: dict[str, str] = {
+    "person": "PERSON",
+    "first_name": "PERSON",
+    "last_name": "PERSON",
+    "full_name": "PERSON",
+    "name": "PERSON",
+    "email": "EMAIL_ADDRESS",
+    "email_address": "EMAIL_ADDRESS",
+    "phone_number": "PHONE_NUMBER",
+    "phone": "PHONE_NUMBER",
+    "address": "LOCATION",
+    "street_address": "LOCATION",
+    "city": "LOCATION",
+    "state": "LOCATION",
+    "country": "LOCATION",
+    "location": "LOCATION",
+    "social_security_number": "US_SSN",
+    "ssn": "US_SSN",
+    "credit_card_number": "CREDIT_CARD",
+    "credit_card": "CREDIT_CARD",
+    "card_number": "CREDIT_CARD",
+    "date_of_birth": "DATE_TIME",
+    "birth_date": "DATE_TIME",
+    "date": "DATE_TIME",
+    "ip_address": "IP_ADDRESS",
+    "ip": "IP_ADDRESS",
+    # Medical entities Presidio doesn't cover get their own category
+    # names rather than being shoehorned into MEDICAL_LICENSE.
+    "medical_record_number": "MEDICAL_RECORD_NUMBER",
+    "mrn": "MEDICAL_RECORD_NUMBER",
+    "patient_id": "MEDICAL_RECORD_NUMBER",
+    "health_condition": "HEALTH_CONDITION",
+    "medical_condition": "HEALTH_CONDITION",
+    "diagnosis": "HEALTH_CONDITION",
+    "medication": "MEDICATION",
+    "drug": "MEDICATION",
+}
+
+# Default Presidio entity types treated as PII inside the worker. Mirrors
+# the set ``pii.py`` historically used in-process so the subprocess-only
+# refactor preserves behavior — Presidio detects many entity types
+# (URL, etc.) that aren't PII per se and we don't want them flagged.
+_PRESIDIO_PII_ENTITIES = [
+    "PERSON",
+    "EMAIL_ADDRESS",
+    "PHONE_NUMBER",
+    "US_SSN",
+    "CREDIT_CARD",
+    "IP_ADDRESS",
+    "LOCATION",
+    "DATE_TIME",
+    "NRP",
+    "MEDICAL_LICENSE",
+    "US_DRIVER_LICENSE",
+    "US_BANK_NUMBER",
+    "US_PASSPORT",
+    "IBAN_CODE",
+    "CRYPTO",
+]
+
+
+# Recognized detector names — the public surface for opt-in / opt-out.
+# Aliased to the canonical strings ``detect_pii_via_subprocess`` accepts
+# in its ``detectors`` kwarg.
+DETECTOR_PRESIDIO = "presidio"
+DETECTOR_GLINER = "gliner"
+_KNOWN_DETECTORS = frozenset({DETECTOR_PRESIDIO, DETECTOR_GLINER})
+
+
+# Worker script — runs inside the isolated venv. Reads a single JSON
+# request from stdin and writes a single JSON response to stdout.
+#
+# Request shape:
+#   {
+#     "transcripts": {asr_model: full_text_string, ...},
+#     "detectors": [str, ...],   # subset of {"presidio", "gliner"}
+#     "presidio_entities": [str, ...],
+#     "presidio_score_threshold": float,
+#     "gliner_model": str,
+#     "gliner_labels": [str, ...],
+#     "gliner_threshold": float,
+#     "gliner_label_map": {str: str, ...},   # gliner_label → normalized_category
+#   }
+#
+# Detectors not named in the request are NOT loaded — saves ~5-10 s of
+# model-load time per skipped detector. A detector that fails to load
+# is recorded in ``failures[name]`` and silently sits out; the other
+# may still produce results.
+#
+# Response shape (success):
+#   {
+#     "spans_by_asr": {asr_model: [{text, category, source, score}, ...]},
+#     "failures": {detector_name: error_message},
+#     "detectors_used": [str, ...]
+#   }
+#
+# Response shape (catastrophic failure, e.g. unparsable input):
+#   {"error": {"type": ..., "message": ..., "traceback": ...}}
+_PII_WORKER_SCRIPT = r"""
+import json
+import sys
+import traceback
+
+try:
+    args = json.loads(sys.stdin.read())
+    transcripts = args["transcripts"]
+    detectors_requested = set(args.get("detectors") or [])
+    presidio_entities = args.get("presidio_entities") or []
+    presidio_score_threshold = float(args.get("presidio_score_threshold", 0.4))
+    gliner_model_id = args.get("gliner_model")
+    gliner_labels = args.get("gliner_labels") or []
+    gliner_threshold = float(args.get("gliner_threshold", 0.5))
+    gliner_label_map = args.get("gliner_label_map") or {}
+
+    failures = {}
+    detectors_used = []
+
+    # ── Presidio ──────────────────────────────────────────────────
+    analyzer = None
+    if "presidio" in detectors_requested:
+        try:
+            from presidio_analyzer import AnalyzerEngine
+            analyzer = AnalyzerEngine()
+            detectors_used.append("presidio")
+        except Exception as exc:
+            failures["presidio"] = f"{type(exc).__name__}: {exc}"
+
+    # ── GLiNER ────────────────────────────────────────────────────
+    gliner_model = None
+    if "gliner" in detectors_requested and gliner_model_id and gliner_labels:
+        try:
+            import torch
+            from gliner import GLiNER
+            gliner_model = GLiNER.from_pretrained(gliner_model_id)
+            if torch.cuda.is_available():
+                # GLiNER 0.2+ exposes the wrapped HF model on .model; older
+                # builds use the wrapper directly. Try both gracefully so
+                # the worker doesn't fail just because the API shifts.
+                try:
+                    gliner_model.model = gliner_model.model.cuda()
+                except AttributeError:
+                    gliner_model = gliner_model.cuda()
+            detectors_used.append("gliner")
+        except Exception as exc:
+            failures["gliner"] = f"{type(exc).__name__}: {exc}"
+            gliner_model = None
+
+    def _normalize_category(label):
+        return gliner_label_map.get(label, label.upper())
+
+    def _presidio_scan(text):
+        if analyzer is None:
+            return []
+        results = analyzer.analyze(
+            text=text,
+            entities=presidio_entities or None,  # None → all entities
+            language="en",
+            score_threshold=presidio_score_threshold,
+        )
+        out = []
+        for r in results:
+            # Filter to the curated PII set even when entities=None was passed.
+            if presidio_entities and r.entity_type not in presidio_entities:
+                continue
+            out.append({
+                "text": text[r.start:r.end],
+                "category": r.entity_type,
+                "source": "presidio",
+                "score": float(r.score),
+            })
+        return out
+
+    def _gliner_scan(text):
+        if gliner_model is None:
+            return []
+        entities = gliner_model.predict_entities(
+            text,
+            gliner_labels,
+            threshold=gliner_threshold,
+        )
+        out = []
+        for ent in entities:
+            label_raw = ent.get("label", "")
+            out.append({
+                "text": ent.get("text", ""),
+                "category": _normalize_category(label_raw),
+                "source": f"gliner/{label_raw}",
+                "score": float(ent.get("score", 0.0)),
+            })
+        return out
+
+    spans_by_asr = {}
+    for asr_model, full_text in transcripts.items():
+        if not isinstance(full_text, str) or not full_text.strip():
+            spans_by_asr[asr_model] = []
+            continue
+        merged = []
+        merged.extend(_presidio_scan(full_text))
+        merged.extend(_gliner_scan(full_text))
+        spans_by_asr[asr_model] = merged
+
+    print(json.dumps({
+        "spans_by_asr": spans_by_asr,
+        "failures": failures,
+        "detectors_used": detectors_used,
+    }))
+except Exception as exc:
+    err = {
+        "type": type(exc).__name__,
+        "message": str(exc),
+        "traceback": traceback.format_exc(limit=8),
+    }
+    print(json.dumps({"error": err}))
+    sys.exit(1)
+"""
+
+
+def detect_pii_via_subprocess(
+    transcripts_by_asr: dict[str, str],
+    *,
+    detectors: Optional[list[str]] = None,
+    presidio_score_threshold: float = 0.4,
+    presidio_entities: Optional[list[str]] = None,
+    gliner_model: str = _DEFAULT_GLINER_MODEL,
+    gliner_labels: Optional[list[str]] = None,
+    gliner_threshold: float = 0.5,
+    timeout: int = 600,
+) -> dict[str, Any]:
+    """Run Presidio + GLiNER PII detection on per-ASR-model transcripts.
+
+    The call is hermetic: ``ensure_venv`` builds (or reuses) the
+    ``pii-detection`` venv at first call, then spawns a fresh worker
+    process for each invocation that loads the requested detector(s),
+    scans every transcript, and exits. Cold-start cost is dominated by
+    the model loads — ~5 s for Presidio + spaCy, ~5 s for GLiNER; the
+    ``detectors`` parameter lets callers skip whichever they don't need.
+
+    Args:
+        transcripts_by_asr: Mapping ``asr_model_id → concatenated transcript``.
+            One entry per ASR backend whose output should be scanned.
+            Empty / whitespace-only values are returned with an empty
+            spans list and never reach the detectors.
+        detectors: Which detectors to run. ``None`` (default) runs both
+            ``"presidio"`` and ``"gliner"``. Passing a single-element
+            list like ``["presidio"]`` skips the GLiNER load entirely;
+            ``["gliner"]`` skips Presidio. An empty list short-circuits
+            without invoking the subprocess at all (mirrors the
+            "PII detection disabled" case). Unknown detector names raise
+            ``ValueError`` immediately.
+        presidio_score_threshold: Drop Presidio spans below this score.
+            0.4 matches the in-process default tuned to catch standard
+            phone-number formats without a "tel:" / "phone:" lead-in.
+        presidio_entities: Restrict Presidio to this allow-list of entity
+            types (e.g. ``["PERSON", "EMAIL_ADDRESS"]``). ``None`` uses
+            the curated default set defined in ``_PRESIDIO_PII_ENTITIES``.
+        gliner_model: HuggingFace model id. Default
+            ``nvidia/gliner-pii`` (English, PII-fine-tuned, ~570 M params).
+            Pass a different id (e.g. ``urchade/gliner_multi-v2.1``) for
+            multilingual coverage or smaller-model variants.
+        gliner_labels: Labels passed to GLiNER's ``predict_entities``.
+            ``None`` uses the curated default mirroring Presidio's
+            coverage plus medical entities.
+        gliner_threshold: Drop GLiNER predictions below this score.
+        timeout: Subprocess wall-clock cap. 10 minutes is generous for
+            one pass's worth of transcripts; the bulk of the time is the
+            initial model loads.
+
+    Returns:
+        Dict with three keys:
+
+        - ``"spans_by_asr"`` — ``{asr_model: [{text, category, source, score}, ...]}``.
+          Spans from each requested detector are concatenated per ASR
+          model; the ``source`` field distinguishes ``"presidio"`` from
+          ``"gliner/<original_label>"`` so callers can audit which
+          detector produced what.
+        - ``"failures"`` — ``{detector_name: error_message}``. Empty when
+          every requested detector loaded cleanly. A populated entry
+          means that detector silently sat out for this call but any
+          other requested detector may still have produced results.
+        - ``"detectors_used"`` — list of detector names that successfully
+          loaded. ``[]`` means no detector ran and the spans list will
+          always be empty for every ASR model.
+
+    Raises:
+        ValueError: If ``detectors`` contains an unknown detector name.
+        subprocess.CalledProcessError or RuntimeError reconstructed from
+            the worker's error JSON. Either case means the subprocess
+            couldn't produce ANY result; the caller should record a
+            failure and proceed without PII findings rather than crash.
+    """
+    if detectors is None:
+        detectors_resolved = sorted(_KNOWN_DETECTORS)
+    else:
+        unknown = [d for d in detectors if d not in _KNOWN_DETECTORS]
+        if unknown:
+            raise ValueError(f"Unknown PII detector(s): {unknown!r}. Known: {sorted(_KNOWN_DETECTORS)!r}.")
+        # Preserve caller's order but dedupe; the worker treats the field
+        # as a set anyway, so ordering only matters for readability.
+        seen: set[str] = set()
+        detectors_resolved = []
+        for d in detectors:
+            if d not in seen:
+                seen.add(d)
+                detectors_resolved.append(d)
+
+    # An empty detector list is a valid "skip everything" signal — return
+    # the same shape as a successful run with no detectors loaded, but
+    # don't spend the time spawning the subprocess or building the venv.
+    if not detectors_resolved:
+        return {
+            "spans_by_asr": {asr_model: [] for asr_model in transcripts_by_asr},
+            "failures": {},
+            "detectors_used": [],
+        }
+
+    venv_dir = ensure_venv(_PII_VENV, _PII_REQUIREMENTS, python_version=_PII_PYTHON)
+    python = venv_python(venv_dir)
+
+    labels = gliner_labels if gliner_labels is not None else list(_DEFAULT_GLINER_LABELS)
+    entities = presidio_entities if presidio_entities is not None else list(_PRESIDIO_PII_ENTITIES)
+
+    input_json = json.dumps(
+        {
+            "transcripts": transcripts_by_asr,
+            "detectors": detectors_resolved,
+            "presidio_entities": entities,
+            "presidio_score_threshold": float(presidio_score_threshold),
+            "gliner_model": gliner_model,
+            "gliner_labels": labels,
+            "gliner_threshold": float(gliner_threshold),
+            "gliner_label_map": _GLINER_TO_PRESIDIO_CATEGORY,
+        }
+    )
+
+    env = _clean_subprocess_env()
+    result = subprocess.run(
+        [python, "-c", _PII_WORKER_SCRIPT],
+        input=input_json,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+
+    output = parse_subprocess_result(result, "PII subprocess")
+    return {
+        "spans_by_asr": output.get("spans_by_asr", {}),
+        "failures": output.get("failures", {}),
+        "detectors_used": output.get("detectors_used", []),
+    }

--- a/src/tests/audio/workflows/audio_analysis/pii_subprocess_test.py
+++ b/src/tests/audio/workflows/audio_analysis/pii_subprocess_test.py
@@ -1,0 +1,240 @@
+"""Tests for the subprocess-venv PII dispatcher.
+
+All ``subprocess.run`` calls are mocked. The real worker (Presidio +
+GLiNER inside the isolated Python-3.13 venv) is exercised only by
+out-of-band runs against a real machine — exercising it here would
+require building the actual venv on every test run.
+
+Coverage focuses on the dispatch surface: detector selection (the
+``detectors`` arg), JSON-request construction, response parsing, and
+the empty-detector short-circuit.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import pytest
+
+from senselab.audio.workflows.audio_analysis import pii_subprocess
+from senselab.audio.workflows.audio_analysis.pii_subprocess import (
+    _DEFAULT_GLINER_LABELS,
+    _DEFAULT_GLINER_MODEL,
+    _GLINER_TO_PRESIDIO_CATEGORY,
+    _PRESIDIO_PII_ENTITIES,
+    DETECTOR_GLINER,
+    DETECTOR_PRESIDIO,
+    detect_pii_via_subprocess,
+)
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_venv(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Skip the real venv build; return a tmp path as the resolved venv dir."""
+    venv_dir = tmp_path / "pii-detection"
+    (venv_dir / "bin").mkdir(parents=True)
+    (venv_dir / "bin" / "python").write_text("#!/bin/sh\nexit 0\n")
+    monkeypatch.setattr(pii_subprocess, "ensure_venv", lambda *_, **__: venv_dir)
+    return venv_dir
+
+
+class _SubprocessRecorder:
+    """Records calls + returns canned JSON output. Mirrors subprocess.run's signature."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._response_json = json.dumps(response)
+        self.input_hook: Optional[Callable[[dict[str, Any]], dict[str, Any]]] = None
+
+    def __call__(
+        self,
+        argv: list[str],
+        input: str = "",  # noqa: A002 — subprocess.run uses this kw name
+        capture_output: bool = False,
+        text: bool = False,
+        timeout: int = 0,
+        env: Optional[dict[str, str]] = None,
+        **_: object,
+    ) -> subprocess.CompletedProcess:
+        parsed_input = json.loads(input) if input else {}
+        self.calls.append({"argv": argv, "input": parsed_input, "timeout": timeout})
+        response = self._response_json
+        if self.input_hook is not None:
+            response = json.dumps(self.input_hook(parsed_input))
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout=response, stderr="")
+
+
+# ── Default-detectors behavior ──────────────────────────────────────
+
+
+def test_default_runs_both_presidio_and_gliner(fake_venv: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without an explicit ``detectors`` argument both detectors are requested."""
+    recorder = _SubprocessRecorder(
+        {"spans_by_asr": {"whisper": []}, "failures": {}, "detectors_used": ["presidio", "gliner"]}
+    )
+    monkeypatch.setattr(subprocess, "run", recorder)
+
+    detect_pii_via_subprocess({"whisper": "Sample transcript."})
+
+    sent = recorder.calls[0]["input"]
+    assert set(sent["detectors"]) == {DETECTOR_PRESIDIO, DETECTOR_GLINER}
+
+
+def test_explicit_presidio_only_skips_gliner(fake_venv: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``detectors=["presidio"]`` keeps GLiNER out of the worker request."""
+    recorder = _SubprocessRecorder({"spans_by_asr": {"whisper": []}, "failures": {}, "detectors_used": ["presidio"]})
+    monkeypatch.setattr(subprocess, "run", recorder)
+
+    detect_pii_via_subprocess({"whisper": "Sample."}, detectors=[DETECTOR_PRESIDIO])
+
+    sent = recorder.calls[0]["input"]
+    assert sent["detectors"] == [DETECTOR_PRESIDIO]
+    assert DETECTOR_GLINER not in sent["detectors"]
+
+
+def test_explicit_gliner_only_skips_presidio(fake_venv: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``detectors=["gliner"]`` keeps Presidio out of the worker request."""
+    recorder = _SubprocessRecorder({"spans_by_asr": {"whisper": []}, "failures": {}, "detectors_used": ["gliner"]})
+    monkeypatch.setattr(subprocess, "run", recorder)
+
+    detect_pii_via_subprocess({"whisper": "Sample."}, detectors=[DETECTOR_GLINER])
+
+    sent = recorder.calls[0]["input"]
+    assert sent["detectors"] == [DETECTOR_GLINER]
+
+
+def test_empty_detector_list_short_circuits_without_spawning_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``detectors=[]`` returns immediately — no venv build, no subprocess.
+
+    This is the explicit-disable signal; ``ensure_venv`` is never even
+    consulted, so a host that's never built the venv before pays nothing
+    for opting out.
+    """
+    monkeypatch.setattr(
+        pii_subprocess,
+        "ensure_venv",
+        lambda *_, **__: (_ for _ in ()).throw(AssertionError("must not build venv when detectors=[]")),
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_, **__: (_ for _ in ()).throw(AssertionError("must not spawn subprocess when detectors=[]")),
+    )
+
+    result = detect_pii_via_subprocess({"whisper": "Some text.", "canary": "Other text."}, detectors=[])
+
+    assert result["detectors_used"] == []
+    assert result["failures"] == {}
+    # Same shape as a successful run — empty list per ASR model.
+    assert result["spans_by_asr"] == {"whisper": [], "canary": []}
+
+
+def test_unknown_detector_name_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unrecognized detector names fail fast at the dispatch layer."""
+    monkeypatch.setattr(
+        pii_subprocess,
+        "ensure_venv",
+        lambda *_, **__: (_ for _ in ()).throw(AssertionError("must not build venv with bad detector")),
+    )
+
+    with pytest.raises(ValueError, match="Unknown PII detector"):
+        detect_pii_via_subprocess({"whisper": "x"}, detectors=["regex", "presidio"])
+
+
+def test_detectors_argument_dedupes_preserving_order(fake_venv: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeated entries in ``detectors`` are collapsed but order is kept."""
+    recorder = _SubprocessRecorder(
+        {"spans_by_asr": {"whisper": []}, "failures": {}, "detectors_used": ["gliner", "presidio"]}
+    )
+    monkeypatch.setattr(subprocess, "run", recorder)
+
+    detect_pii_via_subprocess(
+        {"whisper": "Sample."},
+        detectors=[DETECTOR_GLINER, DETECTOR_PRESIDIO, DETECTOR_GLINER],
+    )
+
+    sent = recorder.calls[0]["input"]
+    assert sent["detectors"] == [DETECTOR_GLINER, DETECTOR_PRESIDIO]
+
+
+# ── Argument plumbing ──────────────────────────────────────────────
+
+
+def test_request_carries_defaults_for_threshold_and_gliner_settings(
+    fake_venv: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default thresholds + GLiNER model id + labels flow through unchanged."""
+    recorder = _SubprocessRecorder(
+        {"spans_by_asr": {"whisper": []}, "failures": {}, "detectors_used": ["presidio", "gliner"]}
+    )
+    monkeypatch.setattr(subprocess, "run", recorder)
+
+    detect_pii_via_subprocess({"whisper": "Sample."})
+
+    sent = recorder.calls[0]["input"]
+    assert sent["presidio_score_threshold"] == 0.4
+    assert sent["gliner_model"] == _DEFAULT_GLINER_MODEL
+    assert sent["gliner_threshold"] == 0.5
+    assert sent["gliner_labels"] == list(_DEFAULT_GLINER_LABELS)
+    assert sent["presidio_entities"] == list(_PRESIDIO_PII_ENTITIES)
+    # The full GLiNER → Presidio category map ships every call.
+    assert sent["gliner_label_map"] == _GLINER_TO_PRESIDIO_CATEGORY
+
+
+def test_caller_overrides_for_gliner_model_and_labels_flow_through(
+    fake_venv: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``gliner_model`` and ``gliner_labels`` reach the worker as supplied."""
+    recorder = _SubprocessRecorder({"spans_by_asr": {"whisper": []}, "failures": {}, "detectors_used": ["gliner"]})
+    monkeypatch.setattr(subprocess, "run", recorder)
+
+    detect_pii_via_subprocess(
+        {"whisper": "Sample."},
+        gliner_model="urchade/gliner_multi-v2.1",
+        gliner_labels=["person", "email"],
+        gliner_threshold=0.7,
+    )
+
+    sent = recorder.calls[0]["input"]
+    assert sent["gliner_model"] == "urchade/gliner_multi-v2.1"
+    assert sent["gliner_labels"] == ["person", "email"]
+    assert sent["gliner_threshold"] == 0.7
+
+
+# ── Response parsing ───────────────────────────────────────────────
+
+
+def test_response_passes_through_spans_failures_and_detectors_used(
+    fake_venv: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The worker's three response fields are returned unmodified."""
+    canned = {
+        "spans_by_asr": {
+            "whisper": [
+                {"text": "John Doe", "category": "PERSON", "source": "presidio", "score": 0.85},
+                {"text": "John Doe", "category": "PERSON", "source": "gliner/person", "score": 0.92},
+            ],
+            "canary": [],
+        },
+        "failures": {"presidio": "config glitch"},
+        "detectors_used": ["gliner"],
+    }
+    monkeypatch.setattr(subprocess, "run", _SubprocessRecorder(canned))
+
+    result = detect_pii_via_subprocess({"whisper": "x", "canary": "y"})
+
+    assert result["spans_by_asr"] == canned["spans_by_asr"]
+    assert result["failures"] == canned["failures"]
+    assert result["detectors_used"] == canned["detectors_used"]
+
+
+def test_known_detectors_constant_matches_aliases() -> None:
+    """The frozenset and the alias constants must agree — guards against drift."""
+    from senselab.audio.workflows.audio_analysis.pii_subprocess import _KNOWN_DETECTORS
+
+    assert _KNOWN_DETECTORS == {DETECTOR_PRESIDIO, DETECTOR_GLINER}

--- a/src/tests/audio/workflows/audio_analysis/pii_test.py
+++ b/src/tests/audio/workflows/audio_analysis/pii_test.py
@@ -1,0 +1,223 @@
+"""Tests for ``pii.detect_pii_in_pass`` and ``pii._compute_detection_confidence``.
+
+Mocks ``detect_pii_via_subprocess`` (the subprocess dispatch layer) so this
+file exercises the in-host plumbing: report construction, cross-detector
+and cross-ASR-model agreement weighting, and ``None`` propagation for the
+"detectors didn't run" case.
+"""
+
+import pytest
+
+from senselab.audio.workflows.audio_analysis import pii as pii_module
+from senselab.audio.workflows.audio_analysis.pii import (
+    PiiSpan,
+    _compute_detection_confidence,
+    detect_pii_in_pass,
+)
+
+# ── _compute_detection_confidence — unit-level ──────────────────────
+
+
+def _span(*, text: str, category: str, source: str, asr_model: str, score: float) -> PiiSpan:
+    """Shorthand for a fully-populated PiiSpan."""
+    return PiiSpan(text=text, category=category, source=source, asr_model=asr_model, score=score)
+
+
+def test_confidence_empty_spans_returns_zero() -> None:
+    """No spans → confident negative. ``None`` is reserved for "detectors didn't run"."""
+    assert _compute_detection_confidence([], n_asr_models=3) == 0.0
+
+
+def test_confidence_single_detector_single_asr_halves_score() -> None:
+    """One detector × one of one ASR → score × 0.5 × 1.0."""
+    spans = [
+        _span(text="John Doe", category="PERSON", source="presidio", asr_model="whisper", score=0.8),
+    ]
+    conf = _compute_detection_confidence(spans, n_asr_models=1)
+    # 0.8 * (1/2) * (1/1) = 0.4
+    assert conf == pytest.approx(0.4)
+
+
+def test_confidence_two_detectors_agreeing_doubles_factor() -> None:
+    """Presidio + GLiNER on the same span → detector factor 1.0 instead of 0.5."""
+    spans = [
+        _span(text="John Doe", category="PERSON", source="presidio", asr_model="whisper", score=0.8),
+        _span(text="John Doe", category="PERSON", source="gliner/person", asr_model="whisper", score=0.9),
+    ]
+    conf = _compute_detection_confidence(spans, n_asr_models=1)
+    # max_score=0.9 * detector_agreement=1.0 * asr_agreement=1.0 = 0.9
+    assert conf == pytest.approx(0.9)
+
+
+def test_confidence_cross_asr_corroboration_scales_with_fraction() -> None:
+    """Two of three ASRs flag the same finding → asr_agreement = 2/3."""
+    spans = [
+        _span(text="John Doe", category="PERSON", source="presidio", asr_model="whisper", score=0.8),
+        _span(text="John Doe", category="PERSON", source="presidio", asr_model="canary", score=0.7),
+    ]
+    conf = _compute_detection_confidence(spans, n_asr_models=3)
+    # max_score=0.8 * detector_agreement=0.5 * asr_agreement=(2/3) ≈ 0.267
+    assert conf == pytest.approx(0.8 * 0.5 * (2 / 3))
+
+
+def test_confidence_max_across_independent_findings() -> None:
+    """Multiple distinct findings → return the strongest, not the sum."""
+    spans = [
+        _span(text="John", category="PERSON", source="presidio", asr_model="whisper", score=0.4),
+        _span(text="John", category="PERSON", source="gliner/person", asr_model="whisper", score=0.4),
+        _span(text="555-1234", category="PHONE_NUMBER", source="presidio", asr_model="whisper", score=0.95),
+    ]
+    # Phone-number finding wins: 0.95 * 0.5 * 1.0 = 0.475
+    # Person finding: 0.4 * 1.0 * 1.0 = 0.4
+    conf = _compute_detection_confidence(spans, n_asr_models=1)
+    assert conf == pytest.approx(0.475)
+
+
+def test_confidence_whitespace_only_text_dropped() -> None:
+    """Spans whose normalized text is empty after stripping are ignored."""
+    spans = [
+        _span(text="   ", category="PERSON", source="presidio", asr_model="whisper", score=0.9),
+        _span(text="real", category="PERSON", source="presidio", asr_model="whisper", score=0.3),
+    ]
+    conf = _compute_detection_confidence(spans, n_asr_models=1)
+    # Only the "real" span counts: 0.3 * 0.5 * 1.0 = 0.15
+    assert conf == pytest.approx(0.15)
+
+
+def test_confidence_missing_per_span_score_treated_as_zero() -> None:
+    """A span without a confidence score contributes max_score=0 to its group.
+
+    Doesn't crash; just lowers the per-finding contribution. Matters when
+    a detector emits no score (legacy spaCy NER pattern, possible future
+    backends).
+    """
+    spans = [
+        PiiSpan(text="John", category="PERSON", source="presidio", asr_model="whisper", score=None),
+    ]
+    conf = _compute_detection_confidence(spans, n_asr_models=1)
+    # max_score collapses to 0.0 → overall 0.0
+    assert conf == 0.0
+
+
+# ── detect_pii_in_pass — integration with mocked subprocess ─────────
+
+
+def _mock_subprocess_result(
+    spans_by_asr: dict[str, list[dict]],
+    detectors_used: list[str] | None = None,
+    failures: dict[str, str] | None = None,
+) -> dict:
+    return {
+        "spans_by_asr": spans_by_asr,
+        "detectors_used": list(detectors_used) if detectors_used is not None else ["presidio", "gliner"],
+        "failures": failures or {},
+    }
+
+
+def test_detect_pii_in_pass_populates_detection_confidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Happy path: confidence computed and stored on the report."""
+
+    def fake_subprocess(transcripts_by_asr: dict[str, str], **_: object) -> dict:
+        return _mock_subprocess_result(
+            spans_by_asr={
+                "whisper": [
+                    {"text": "John Doe", "category": "PERSON", "source": "presidio", "score": 0.85},
+                ],
+                "canary": [
+                    {"text": "John Doe", "category": "PERSON", "source": "gliner/person", "score": 0.9},
+                ],
+            },
+        )
+
+    monkeypatch.setattr(pii_module, "detect_pii_via_subprocess", fake_subprocess)
+
+    report = detect_pii_in_pass(
+        pass_label="raw_16k",
+        asr_resolved={
+            "whisper": [{"text": "Hi I am John Doe."}],
+            "canary": [{"text": "Hi I am John Doe."}],
+        },
+    )
+    # max_score=0.9 × detector_agreement=1.0 (both Presidio + GLiNER) ×
+    # asr_agreement=1.0 (2/2 ASRs) = 0.9.
+    assert report.detection_confidence == pytest.approx(0.9)
+    assert report.detector_used == "presidio,gliner"
+
+
+def test_detect_pii_in_pass_detection_confidence_none_when_subprocess_finds_no_detectors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both detectors failed to load → detector_used None → confidence None."""
+
+    def fake_subprocess(*_: object, **__: object) -> dict:
+        return _mock_subprocess_result(
+            spans_by_asr={"whisper": []},
+            detectors_used=[],
+            failures={"presidio": "ImportError: ...", "gliner": "ImportError: ..."},
+        )
+
+    monkeypatch.setattr(pii_module, "detect_pii_via_subprocess", fake_subprocess)
+
+    report = detect_pii_in_pass(
+        pass_label="raw_16k",
+        asr_resolved={"whisper": [{"text": "Some text."}]},
+    )
+    assert report.detector_used is None
+    assert report.detection_confidence is None
+
+
+def test_detect_pii_in_pass_detection_confidence_none_when_subprocess_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Subprocess crash → report still produced, confidence stays None."""
+
+    def fake_subprocess(*_: object, **__: object) -> dict:
+        raise RuntimeError("subprocess venv build failed")
+
+    monkeypatch.setattr(pii_module, "detect_pii_via_subprocess", fake_subprocess)
+
+    report = detect_pii_in_pass(
+        pass_label="raw_16k",
+        asr_resolved={"whisper": [{"text": "Some text."}]},
+    )
+    assert report.detector_used is None
+    assert report.detection_confidence is None
+    assert "pii_subprocess" in report.failures
+
+
+def test_detect_pii_in_pass_detection_confidence_zero_when_detectors_ran_clean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detectors ran, no spans → 0.0, not None. Distinct signal from "didn't run"."""
+
+    def fake_subprocess(*_: object, **__: object) -> dict:
+        return _mock_subprocess_result(spans_by_asr={"whisper": []})
+
+    monkeypatch.setattr(pii_module, "detect_pii_via_subprocess", fake_subprocess)
+
+    report = detect_pii_in_pass(
+        pass_label="raw_16k",
+        asr_resolved={"whisper": [{"text": "Some text."}]},
+    )
+    assert report.detector_used == "presidio,gliner"
+    assert report.detection_confidence == 0.0
+
+
+def test_detect_pii_in_pass_disabled_path_yields_none_confidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``detectors=[]`` short-circuit: no subprocess spawn, confidence None."""
+
+    def fake_subprocess(*_: object, **__: object) -> dict:
+        raise AssertionError("must not call subprocess when detectors=[]")
+
+    monkeypatch.setattr(pii_module, "detect_pii_via_subprocess", fake_subprocess)
+
+    report = detect_pii_in_pass(
+        pass_label="raw_16k",
+        asr_resolved={"whisper": [{"text": "Some text."}]},
+        detectors=[],
+    )
+    assert report.detector_used is None
+    assert report.detection_confidence is None
+    assert "pii_disabled" in report.failures


### PR DESCRIPTION
## Summary
  
  Make PII detection actually run on Python 3.14 hosts (it was silently no-op'ing because spaCy / Presidio top out at cp313 wheels), and pass through richer per-detection
  signal to consumers instead of just a single boolean.

  Three logical changes stacked, each in its own commit so they're individually reviewable and revertible:

  1. **`91ec2327`** — Move PII detection into a new `pii-detection` subprocess venv (Python 3.13) running Presidio + GLiNER (`nvidia/gliner-pii`). Subprocess-only, no
  in-process fallback. Per-detector opt-in via a `detectors=[...]` argument symmetrical to ASR-model selection elsewhere.
  2. **`4129b49d`** — Add `detection_confidence` to `PiiPassReport`: a continuous `[0, 1]` aggregated from per-detector scores × cross-detector agreement × cross-ASR-model
  agreement. Replaces the prior `1.0 if contains_pii else 0.0` boolean in `global_summary`. `None` propagates when no detector actually ran (subprocess crash, both detectors
  failed to load, or caller passed `detectors=[]`) — distinct from `0.0` ("ran, found nothing").
  3. **`a2f384ce` + `628973cc`** — GLiNER default labels set to the HIPAA Safe Harbor 18 identifiers verbatim, matching b2aiprep PR #256 so the two projects' PII outputs share
  a vocabulary.

  ## Why a subprocess at all

  The host venv may be on a Python version newer than spaCy ships wheels for (3.14 today). Pre-this-PR the host-side detector chain silently fell back to
  `failures["no_pii_detector"]` + `contains_pii: False` on every clip — a privacy-meaningful false negative on b2ai voice data. Moving Presidio + GLiNER into their own
  Python-3.13 subprocess venv (built and cached via `ensure_venv`) keeps the host on whatever recent Python it likes while making the PII path actually run.
  
  ## What runs inside the venv

  Two detectors run on every transcript and their spans are merged before cross-ASR-model corroboration in `pii.py`:

  - **Microsoft Presidio Analyzer** — regex + spaCy-NER recognizers for emails, phone numbers, SSNs, credit cards, IPs, dates, locations.
  - **GLiNER PII** (`nvidia/gliner-pii`) — a 570M-param transformer fine-tuned on ~100k synthetic PII/PHI records. Catches HIPAA PHI categories Presidio doesn't natively
  recognize (`medical_record_number`, `health_plan_number`, `account_number`, `fax_number`, `url`, `biometric_identifier`, `unique_identifier`, ...).

  GLiNER's lowercase labels are normalized to Presidio's uppercase scheme inside the worker so the existing `(category, text.lower())` dedupe key in `pii.py` treats both
  detectors' hits on the same entity as the same finding.

  ## Per-detector opt-in

  ```python
  # Default — both detectors
  detect_pii_in_pass(pass_label="raw_16k", asr_resolved=...)

  # Presidio only — skip GLiNER's ~5 s model load
  detect_pii_in_pass(..., detectors=["presidio"])

  # GLiNER only — skip Presidio
  detect_pii_in_pass(..., detectors=["gliner"])

  # Explicit disable — no subprocess spawn, no venv build attempt;
  # report carries failures["pii_disabled"] so an auditor can tell
  # "didn't run on purpose" apart from "ran and found nothing"
  # and "subprocess crashed"
  detect_pii_in_pass(..., detectors=[])
```

  gliner_model, gliner_labels, and gliner_threshold are also exposed on detect_pii_in_pass so callers can swap in a different GLiNER variant (e.g. urchade/gliner_multi-v2.1 for
   multilingual coverage) or restrict the label set without touching the worker.

  detection_confidence vs contains_pii

  The PII axis previously surfaced only contains_pii ? 1.0 : 0.0 to global_summary and threw away every per-span detector score the worker produced. Worse, when the subprocess
  crashed or no detector loaded, the report fell to 0.0 — indistinguishable from "we checked, found nothing."

  detection_confidence is now a continuous [0, 1] combining three signals per unique (category, normalized_text) finding:

  - per-span detector score — Presidio analyzer score or GLiNER prediction probability, max() within the finding's group.
  - cross-detector agreement — Presidio AND GLiNER both flagged the same finding (factor 1.0) vs only one detector (0.5). The strongest "real entity vs hallucination?" signal
  at this layer.
  - cross-ASR-model agreement — fraction of available ASR transcripts that contained the finding. Spans only one ASR transcribed and no sibling ASR confirms are the
  prototypical hallucination case.

  Then max() across findings — matches how the transcript and single-speaker axes already combine their internal sub-signals.

  Deliberately NO category-severity weighting. In pediatric / clinical voice data the categories nominally most "severe" (US_SSN, CREDIT_CARD, MEDICAL_RECORD_NUMBER) have
  near-zero true-positive rate — children don't speak SSNs aloud — and the synthetic-PII-trained detectors gladly flag any 9-digit ASR hallucination as SSN. Weighting them up
  would inflate exactly the findings a reviewer should de-prioritize. Heuristic enhancements deferred as later goals.
  
  None propagation

  detection_confidence is None when no detector ran:

  - subprocess raised at dispatch (CalledProcessError / RuntimeError)
  - both detectors failed to load inside the subprocess venv
  - caller passed detectors=[] (explicit-disable short-circuit)

  0.0 is reserved for "detectors ran, found nothing" — the confident-negative case. global_summary.compute_pass_global_summary propagates the same distinction into
  no_pii_uncertainty so the combined_uncertainty consumer can tell "didn't actually check" apart from "checked clean." No silent demotion to 0.

  Why the HIPAA-18 labels (and why exactly that list)

  GLiNER picks were tuned via an out-of-band diagnostic (temp/diag_gliner_email.py) on john.doe@example.com. Two non-obvious findings drove the final label set:

  1. nvidia/gliner-pii exhibits competing-claim interference. When two labels can plausibly cover the same span, the model commits the span to one and silently drops it from
  consideration under the other — even when the other would have been the right answer. Passing [person, first_name, last_name, email, email_address, ...] lost the email
  entirely; the model classified John and Doe as first_name/last_name at score 1.0 and emitted no span containing @. A flat label set with one name and one email caught both at
   score 1.0. Keep label sets flat.

  2. Even flat label sets have a length / projection-space effect we don't fully understand. Tacking the two clinical-voice extensions health_condition and medication onto the
  end of the HIPAA-18 list (semantically non-overlapping with anything) was enough to push the email's score below the 0.5 threshold and lose it. The HIPAA-18 verbatim catches
  it cleanly. Don't extend past the HIPAA-18 unless you've verified your specific additions don't trip the interference on your corpus.
  
  Both findings are captured as DO NOT warnings above _DEFAULT_GLINER_LABELS so a future contributor doesn't walk back into either trap.

  Architectural changes
  
  - New module src/senselab/audio/workflows/audio_analysis/pii_subprocess.py — venv constants (_PII_VENV = "pii-detection", Python 3.13, presidio-analyzer + spacy +
  en_core_web_lg wheel via direct URL + gliner + transformers + torch), GLiNER → Presidio category map, worker script, and the detect_pii_via_subprocess dispatch function.
  torch named explicitly in _PII_REQUIREMENTS so the auto-detect in ensure_venv routes it through the matched CUDA index. torchaudio intentionally omitted (no audio decoding).
  - pii.py simplified — removed _load_presidio_analyzer, _load_spacy_nlp, _scan_with_presidio, _scan_with_spacy, and the in-process tier-fallback chain. Dispatch now goes to
  the subprocess; everything else (transcript concatenation, PiiSpan materialization, cross-ASR-model corroboration, PiiPassReport construction) stays in-process.
  - global_summary.compute_pass_global_summary reads pii_report.detection_confidence instead of the boolean for the no_pii_uncertainty field. Adds a pii_report.detector_used is
   None branch so the "didn't actually run" signal surfaces as None, not silently 0.0. New detection_confidence field also emitted in the per-pass no_pii block for downstream
  tools.

  Performance notes

  - First subprocess invocation per host: ~60–120 s for the venv install (torch + nvidia-cuda-runtime + transformers are the heavy parts; everything else is small) plus ~30 s
  for the first GLiNER model download from HuggingFace.
  - Subsequent invocations on the same host: ~10 s cold-start per call (Presidio + spaCy + GLiNER model load).
  - For a typical analyze_audio.py run (≈138 detect_pii_in_pass calls per subject), that's ~15–20 min of model-load overhead added per subject. Batching all of a subject's
  transcripts into a single subprocess invocation is a worthwhile follow-up but isn't required for correctness.

  Tests
  
  32 tests added across two new files:

  - src/tests/audio/workflows/audio_analysis/pii_subprocess_test.py (10 tests) — dispatch-surface coverage: detector selection, JSON-request construction, response parsing,
  empty-detector short-circuit, unknown-detector ValueError, dedupe-with-order, default-arg pass-through, caller overrides.
  - src/tests/audio/workflows/audio_analysis/pii_test.py (12 tests) — _compute_detection_confidence unit cases (empty → 0.0, single detector / single ASR → 0.5 × score, both
  detectors → 1.0 factor, cross-ASR scaling by fraction, max across independent findings, whitespace-only text filtered, missing per-span score collapses to 0) and
  detect_pii_in_pass integration with a mocked detect_pii_via_subprocess (happy path, no-detectors → None, subprocess raise → None, ran-no-spans → 0.0, detectors=[]
  short-circuit → None plus failures["pii_disabled"]).
  
  All 32 pass. Pre-commit hooks (ruff, mypy, codespell) clean.

  The real Presidio + GLiNER worker inside the subprocess venv is exercised by the out-of-band scripts temp/test_pii_subprocess.py and temp/diag_gliner_email.py — including
  them in the unit test suite would require building the actual ~5 GB venv on every test run.

  Test plan

  - uv run pytest src/tests/audio/workflows/audio_analysis/pii_subprocess_test.py src/tests/audio/workflows/audio_analysis/pii_test.py --noconftest — 22 / 22 pass.
  - temp/test_pii_subprocess.py smoke test on ORCD: builds the venv, both Presidio and GLiNER load, both detectors flag known PII strings, detection_confidence aggregates
  correctly, all four detectors=[...] selection paths behave as designed.
  - temp/diag_gliner_email.py diagnostic confirms nvidia/gliner-pii catches john.doe@example.com at score 1.0 with the flat HIPAA-18 set and does not catch it with overlapping
  name-related labels (the empirical justification for the label-set choice).
  - Run full analyze_audio.py on a real b2ai subject and confirm per-clip pii.json files now show non-None detector_used + non-None detection_confidence.

  Out-of-band reviewer notes

  - Cold-start cost per call is real and observable. If it turns out to dominate runtime on production-size subjects, the natural follow-up is to batch all transcripts for one
  subject into a single subprocess invocation at the analyze_audio.py level rather than per-pass-per-clip. The dispatch function already accepts an arbitrary number of
  (asr_model, full_text) entries, so the change would be at the call site, not the API.
  - GLiNER label set is intentionally narrow. Callers who need a wider label set can pass gliner_labels=[...] to detect_pii_in_pass; the contributor warnings above
  _DEFAULT_GLINER_LABELS capture the two empirical traps (overlapping labels, extending past HIPAA-18) so the caller can verify their additions don't trip them.
  - No category-severity weighting is a deliberate choice for the pediatric / clinical voice domain, where the most-"severe" Presidio categories (US_SSN, CREDIT_CARD) have the
  highest false-positive rate. Reintroducing severity weighting for a different downstream domain should be opt-in, not the default.

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.3.1-alpha.32`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - Feat/pii subprocess venv [#519](https://github.com/sensein/senselab/pull/519) ([@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: route torch/torchaudio via CUDA-aware PyTorch index [#516](https://github.com/sensein/senselab/pull/516) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: two-stage install to fix torch/torchaudio CUDA-tag s… [#518](https://github.com/sensein/senselab/pull/518) ([@wilke0818](https://github.com/wilke0818))
  - Fix/ser wav2vec2 regression head [#511](https://github.com/sensein/senselab/pull/511) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818) [@claude](https://github.com/claude))
  - comparison & uncertainty stage for analyze_audio.py [#512](https://github.com/sensein/senselab/pull/512) ([@satra](https://github.com/satra))
  - audio analysis script + multilingual MMS aligner + 4 new ASR backends [#510](https://github.com/sensein/senselab/pull/510) ([@satra](https://github.com/satra))
  
  #### Authors: 3
  
  - Claude ([@claude](https://github.com/claude))
  - Jordan Wilke ([@wilke0818](https://github.com/wilke0818))
  - Satrajit Ghosh ([@satra](https://github.com/satra))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
