### PR TITLE
ScriptLine: accept empty text as "model produced no transcript" signal

### DIFF
--- a/src/senselab/utils/data_structures/script_line.py
+++ b/src/senselab/utils/data_structures/script_line.py
@@ -79,6 +79,16 @@ class ScriptLine(BaseModel):
     def validate_text_and_speaker(cls, values: Dict[str, Any], _: ValidationInfo) -> Dict[str, Any]:
         """Ensure that at least one of `text` or `speaker` is provided.
 
+        A field counts as "provided" if its value is not `None`. Empty
+        strings (`text=""`) are accepted — they represent a valid "the
+        model was called but produced no transcript for this audio"
+        signal, distinct from "the model was never called" (`text=None`).
+        This matters for ASR backends that honestly emit empty output on
+        unintelligible / silent audio (e.g. IBM Granite-Speech on heavily-
+        enhanced short clips) rather than hallucinating filler. Whitespace-
+        only strings are also accepted; the field validator below strips
+        them, so they end up indistinguishable from explicit empty input.
+
         Args:
             values: Incoming field values prior to model construction.
 
@@ -86,9 +96,9 @@ class ScriptLine(BaseModel):
             The (possibly modified) values dict.
 
         Raises:
-            ValueError: If both `text` and `speaker` are missing/empty.
+            ValueError: If both `text` and `speaker` are `None` or absent.
         """
-        if not values.get("text") and not values.get("speaker"):
+        if values.get("text") is None and values.get("speaker") is None:
             raise ValueError("At least text or speaker must be provided.")
         return values
 

--- a/src/senselab/utils/data_structures/script_line.py
+++ b/src/senselab/utils/data_structures/script_line.py
@@ -228,13 +228,15 @@ class ScriptLine(BaseModel):
             start = None
             end = None
 
-        # Filter out fully-empty children (no text/speaker) so they do not trip
-        # ScriptLine's "at least one of text/speaker" validator. MMS-style
-        # aligners can emit placeholder subsegments with text="" and empty
-        # chunks for unrecognized characters; those carry no signal and
-        # should not block construction of the parent line.
+        # Drop children that are wholly absent of text and speaker — those
+        # would trip ScriptLine's "at least one of text/speaker" validator.
+        # Empty-string text is preserved: it's a meaningful "model produced
+        # no transcript for this subsegment" signal (distinct from the key
+        # being absent / None), matching the invariant the root validator
+        # now upholds. Truthiness checks (`bool("") == False`) would silently
+        # drop those signals.
         def _is_meaningful(c: Dict[str, Any]) -> bool:
-            return bool(c.get("text")) or bool(c.get("speaker"))
+            return c.get("text") is not None or c.get("speaker") is not None
 
         chunks_raw = d.get("chunks") if "chunks" in d else None
         chunks = [cls.from_dict(c) for c in chunks_raw if _is_meaningful(c)] if chunks_raw is not None else None

--- a/src/tests/utils/data_structures/script_line_test.py
+++ b/src/tests/utils/data_structures/script_line_test.py
@@ -110,6 +110,41 @@ def test_from_dict_rejects_dict_with_no_text_or_speaker() -> None:
         ScriptLine.from_dict({})
 
 
+def test_from_dict_preserves_empty_text_in_nested_chunks() -> None:
+    """Nested chunks with ``text=""`` survive ``from_dict``'s child filter.
+
+    The internal ``_is_meaningful`` filter used to drop any chunk whose
+    text was falsy, including the empty string. After the validator
+    change, empty text is a meaningful "model produced no transcript for
+    this subsegment" signal, so the filter must keep it — only chunks
+    where BOTH text and speaker are absent / ``None`` should be dropped.
+
+    Without this guarantee the empty-text fix is silently undone for
+    payloads that travel through ``from_dict`` (subprocess IPC, saved
+    JSON), which is the very path that motivated the validator change.
+    """
+    line = ScriptLine.from_dict({"text": "parent", "chunks": [{"text": ""}]})
+    assert line.chunks is not None
+    assert len(line.chunks) == 1
+    assert line.chunks[0].text == ""
+
+
+def test_from_dict_still_drops_chunks_missing_both_text_and_speaker() -> None:
+    """Children with neither text nor speaker still get filtered out.
+
+    The original purpose of the ``_is_meaningful`` filter (avoid tripping
+    the root validator on wholly-empty placeholder children, e.g. from
+    MMS-style aligners) is preserved — only its overly-aggressive
+    truthiness check is loosened.
+    """
+    line = ScriptLine.from_dict({"text": "parent", "chunks": [{"text": ""}, {}, {"start": 0.0, "end": 1.0}]})
+    # The empty-text chunk survives; the two text-and-speaker-absent
+    # chunks are dropped before they reach the validator.
+    assert line.chunks is not None
+    assert len(line.chunks) == 1
+    assert line.chunks[0].text == ""
+
+
 # ── Score / timestamp interactions (unchanged behavior, asserted here
 #     so future validator tweaks don't quietly regress them) ─────────
 

--- a/src/tests/utils/data_structures/script_line_test.py
+++ b/src/tests/utils/data_structures/script_line_test.py
@@ -1,0 +1,131 @@
+"""Tests the ScriptLine data structure.
+
+Focus is on the ``validate_text_and_speaker`` rule: empty ``text`` is a
+meaningful "model called, no speech detected" signal and must be
+distinguishable from ``text=None`` (model never called / field absent).
+Earlier behavior rejected ``ScriptLine(text="")`` outright, which caused
+ASR backends honest enough to emit empty transcripts on silent /
+unintelligible audio (notably IBM Granite-Speech on heavily-enhanced
+short clips) to fail validation while less-honest models silently
+hallucinated filler and passed.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from senselab.utils.data_structures import ScriptLine
+
+# ── Empty / None / whitespace text handling ────────────────────────
+
+
+def test_empty_text_without_speaker_is_accepted() -> None:
+    """``ScriptLine(text="")`` is a valid "model returned no transcript" signal.
+
+    Regression test for the Granite-Speech failure mode observed on
+    enhanced short clips, where the model honestly emits ``""`` instead
+    of hallucinating filler. The earlier validator rejected this with
+    ``"At least text or speaker must be provided."`` even though the
+    intent was clearly "the call happened and produced nothing".
+    """
+    line = ScriptLine(text="")
+    assert line.text == ""
+    assert line.speaker is None
+    assert line.get_text() == ""
+
+
+def test_whitespace_only_text_is_accepted_and_normalized_to_empty() -> None:
+    """Whitespace-only ``text`` survives validation and is stripped to ``""``.
+
+    Without this, the system would treat ``text=" "`` and ``text=""`` as
+    behaving differently — the former passing the truthy check then
+    being normalized, the latter being rejected. With the fix, both are
+    accepted and converge on ``text=""``.
+    """
+    line = ScriptLine(text="   ")
+    assert line.text == ""
+
+
+def test_text_none_without_speaker_still_rejected() -> None:
+    """``ScriptLine()`` with both fields absent / None must still raise.
+
+    ``None`` means "the field was never set" — the validator's whole job
+    is to refuse rows with no signal at all.
+    """
+    with pytest.raises(ValidationError):
+        ScriptLine()
+    with pytest.raises(ValidationError):
+        ScriptLine(text=None)
+    with pytest.raises(ValidationError):
+        ScriptLine(text=None, speaker=None)
+
+
+def test_only_speaker_provided_is_accepted() -> None:
+    """Speaker without text is a valid diarization line."""
+    line = ScriptLine(speaker="spk1")
+    assert line.speaker == "spk1"
+    assert line.text is None
+
+
+def test_empty_text_with_speaker_is_accepted() -> None:
+    """Diarization line with explicit empty transcript is valid.
+
+    This is the "speaker turn detected, but the ASR returned nothing for
+    that turn" case — surprisingly common at silence boundaries.
+    """
+    line = ScriptLine(text="", speaker="spk1")
+    assert line.text == ""
+    assert line.speaker == "spk1"
+
+
+def test_normal_text_unchanged() -> None:
+    """Existing behavior preserved: real transcripts still construct cleanly."""
+    line = ScriptLine(text="hello world")
+    assert line.text == "hello world"
+
+
+def test_text_stripped_of_surrounding_whitespace() -> None:
+    """Field validator still strips whitespace from non-empty input."""
+    line = ScriptLine(text="  hello  ")
+    assert line.text == "hello"
+
+
+# ── from_dict shape coverage ───────────────────────────────────────
+
+
+def test_from_dict_accepts_empty_text_entry() -> None:
+    """``ScriptLine.from_dict({"text": ""})`` no longer raises.
+
+    Matters because some ASR backends serialize their output through a
+    dict-shaped IPC payload (e.g. subprocess workers) before reaching
+    ``ScriptLine``; an empty transcript shouldn't be lost or remapped
+    along the way.
+    """
+    line = ScriptLine.from_dict({"text": ""})
+    assert line.text == ""
+
+
+def test_from_dict_rejects_dict_with_no_text_or_speaker() -> None:
+    """A bare ``from_dict({})`` still raises — nothing to construct from."""
+    with pytest.raises(ValidationError):
+        ScriptLine.from_dict({})
+
+
+# ── Score / timestamp interactions (unchanged behavior, asserted here
+#     so future validator tweaks don't quietly regress them) ─────────
+
+
+def test_empty_text_with_timestamps_is_accepted() -> None:
+    """A timestamped empty transcript is valid.
+
+    The segment exists, it just didn't transcribe to anything.
+    """
+    line = ScriptLine(text="", start=0.0, end=1.5)
+    assert line.text == ""
+    assert line.start == 0.0
+    assert line.end == 1.5
+
+
+def test_negative_timestamp_still_rejected_independent_of_text() -> None:
+    """Timestamp validator is independent of the text/speaker rule."""
+    with pytest.raises(ValidationError):
+        ScriptLine(text="", start=-1.0)


### PR DESCRIPTION
## Summary

Stop rejecting `ScriptLine(text="")` as invalid when its `speaker` field is also unset. Empty text is a valid "the ASR was called but produced no transcript" signal — distinct from `text=None` ("the ASR was never called"). The pre-change validator collapsed both into a single failure case, which caused legitimately-empty ASR output to crash the audio-analysis pipeline.

## Why

Surfaced during a full-pipeline run on a b2ai pediatric voice subject. Out of 92 audio clips, 5 failed with:

```
[asr[ibm-granite/granite-speech-3.3-8b]] FAILED in 0.1s:
  1 validation error for ScriptLine
  Value error, At least text or speaker must be provided.
  [type=value_error, input_value={'text': ''}, input_type=dict]
```

All 5 were the same shape: short clips (1.4–3.4 s) on the `enhanced_16k` pass where Granite-Speech correctly decoded "no recognizable speech" and emitted `{"text": ""}`. The `ScriptLine` validator then rejected the construction, the per-clip ASR result was lost, and the pass's PII / alignment / corroboration logic ran with one ASR backend silently missing.

The vulnerability is shared across every senselab ASR backend (`nemo.py:145`, `granite.py:142`, `canary_qwen.py:191`, `qwen.py:223`, `huggingface.py:284` via `.from_dict()`) — each one constructs `ScriptLine(text=...)` directly. Granite-Speech happens to be the one that triggers it in this dataset because it's the most honest of the bunch: when its acoustic model decodes nothing, it returns `""`. Whisper hallucinates filler ("Thanks for watching!", "..."), and the LLM-augmented Canary-Qwen and Qwen3-ASR's instruct-tuned heads almost always emit something under their "Transcribe the following:" prompt, so they slip past the same validator. The bug is in `ScriptLine`, not Granite.

## The fix

`src/senselab/utils/data_structures/script_line.py:78-93` — single-line semantic change from a falsiness check to a presence check:

```python
# Before
if not values.get("text") and not values.get("speaker"):
    raise ValueError("At least text or speaker must be provided.")

# After
if values.get("text") is None and values.get("speaker") is None:
    raise ValueError("At least text or speaker must be provided.")
```

In Python `not ""` is `True`. The previous rule rejected `text=""` exactly the same as `text=None` or missing-entirely. The new rule treats `text=""` and `text=" "` and `text="hello"` as all "provided" — only `None` (or absent) counts as "missing." Whitespace-only strings remain valid: the existing field validator strips them, so `text=" "` and `text=""` converge on the same final state. (Previously they took different validator paths and `text=" "` survived while `text=""` did not — a real inconsistency this also closes.)

Behavior preserved unchanged:

- `ScriptLine(text="hello")` — works (it always did).
- `ScriptLine(speaker="spk1")` — works (diarization-only line).
- `ScriptLine()` with both fields absent or both `None` — still raises.
- Negative-timestamp validation, whitespace-stripping, all other field validators — untouched.

## Behavior change

- `ScriptLine(text="")` now constructs cleanly (was raising `ValidationError`).
- `ScriptLine(text="", start=0.0, end=1.5)` now constructs cleanly.
- `ScriptLine.from_dict({"text": ""})` now constructs cleanly.

Downstream consumers (`global_summary`, the harvesters, the cross-ASR corroboration in `pii.py`) all already handle empty / whitespace text gracefully — they filter it from `_build_full_text`, they check `if t.strip()` before scanning, they drop empty utterances from voting. So letting an empty `ScriptLine` exist in the report just means the "Granite was called on this clip and decided there's no speech" signal is preserved rather than discarded. No downstream code needs updating.

## Tests

New file `src/tests/utils/data_structures/script_line_test.py` — 11 tests covering both directions of the rule.

Empty / whitespace / None text handling:

- `test_empty_text_without_speaker_is_accepted` — `ScriptLine(text="")` now constructs.
- `test_whitespace_only_text_is_accepted_and_normalized_to_empty` — `text="   "` survives validation, gets stripped to `""`. Fixes the inconsistency where `" "` was previously accepted but `""` wasn't.
- `test_text_none_without_speaker_still_rejected` — `ScriptLine()`, `ScriptLine(text=None)`, and `ScriptLine(text=None, speaker=None)` all still raise.

Speaker-only / mixed:

- `test_only_speaker_provided_is_accepted` — `ScriptLine(speaker="spk1")` works (diarization line with no transcript).
- `test_empty_text_with_speaker_is_accepted` — `ScriptLine(text="", speaker="spk1")` works (speaker turn detected, ASR returned nothing for it — common at silence boundaries).

Happy-path regression:

- `test_normal_text_unchanged` — `ScriptLine(text="hello world")` constructs and preserves the text.
- `test_text_stripped_of_surrounding_whitespace` — `text="  hello  "` strips to `"hello"`. Unchanged behavior; asserted to guard against future regressions.

`from_dict`:

- `test_from_dict_accepts_empty_text_entry` — `ScriptLine.from_dict({"text": ""})` now constructs.
- `test_from_dict_rejects_dict_with_no_text_or_speaker` — `ScriptLine.from_dict({})` still raises.

Field-validator interaction:

- `test_empty_text_with_timestamps_is_accepted` — `ScriptLine(text="", start=0.0, end=1.5)` works.
- `test_negative_timestamp_still_rejected_independent_of_text` — timestamp validator stays orthogonal; `ScriptLine(text="", start=-1.0)` still raises.

All 11 pass under `--noconftest`. Pre-commit (ruff + mypy + codespell) clean.

The existing `forced_alignment_test.py` (the only other test that constructs `ScriptLine` via `.from_dict`) continues to pass — it uses a real fixture, not an empty-text edge case.

## Test plan

- [x] `uv run pytest src/tests/utils/data_structures/script_line_test.py --noconftest` — 11 / 11 pass.
- [x] Verified the same 5 Granite-Speech failures from the original b2ai run no longer manifest: re-running the smoke path with `Granite.transcribe_with_granite_speech(audio)` returning `[ScriptLine(text="")]` from the worker no longer raises at the host-side construction site.
- [ ] Out-of-band: re-run `bash scripts/submit_subject_audio.sh /path/to/dataset sub-XXX` on a subject that previously had Granite failures and confirm exit code 0 across all clips, with the affected clips' `summary.json` now showing Granite-Speech as `ok` rather than dropped.

## Out-of-band reviewer notes

**Why this is a `ScriptLine` change, not a `granite.py` change.** Could fix this in the Granite wrapper alone (e.g., `granite.py:142` filters empty-text and returns `[]` instead of `[ScriptLine(text="")]`). That would silence the symptom for Granite but leave the latent vulnerability in every other backend — the moment a future Whisper / Canary / Qwen build returns an empty transcript the bug resurfaces. Fixing it once in the validator addresses the class of bug.

**Why empty is a meaningful signal.** "ASR was called, returned nothing" is genuinely different from "ASR was never called." The first is evidence that the audio doesn't contain decodable speech according to this model; multiple ASRs returning empty on the same clip is a corroborated "no-speech" signal. Collapsing both into `text=None` / construction-failure throws away that distinction. The pipeline's existing cross-ASR-model corroboration logic (used by `pii.py` and indirectly by `global_summary`) is happier with empty `ScriptLine`s than with missing ones.

**No call-site changes needed.** Every `ScriptLine(text=...)` construction site I traced (5 in `senselab/audio/tasks/speech_to_text/`, plus `talk_bank_helpers.py`) was already passing along whatever the upstream model returned. The change just allows the empty case through; it doesn't require existing producers to do anything new.

**Branch is independent of `feat/pii-subprocess-venv`** — they touch unrelated files and either can merge first. They're filed off `alpha` separately to keep the diffs and blame surfaces clean.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.3.1-alpha.33`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - ScriptLine: accept empty text as "model produced no transcript" signal [#520](https://github.com/sensein/senselab/pull/520) ([@wilke0818](https://github.com/wilke0818))
  - Feat/pii subprocess venv [#519](https://github.com/sensein/senselab/pull/519) ([@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: route torch/torchaudio via CUDA-aware PyTorch index [#516](https://github.com/sensein/senselab/pull/516) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: two-stage install to fix torch/torchaudio CUDA-tag s… [#518](https://github.com/sensein/senselab/pull/518) ([@wilke0818](https://github.com/wilke0818))
  - Fix/ser wav2vec2 regression head [#511](https://github.com/sensein/senselab/pull/511) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818) [@claude](https://github.com/claude))
  - comparison & uncertainty stage for analyze_audio.py [#512](https://github.com/sensein/senselab/pull/512) ([@satra](https://github.com/satra))
  - audio analysis script + multilingual MMS aligner + 4 new ASR backends [#510](https://github.com/sensein/senselab/pull/510) ([@satra](https://github.com/satra))
  
  #### Authors: 3
  
  - Claude ([@claude](https://github.com/claude))
  - Jordan Wilke ([@wilke0818](https://github.com/wilke0818))
  - Satrajit Ghosh ([@satra](https://github.com/satra))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
