### PR TITLE
fix(speech-enhancement): pick speechbrain loader by model name

### DIFF
--- a/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
+++ b/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
@@ -1,7 +1,7 @@
 """This module provides the Speechbrain interface for speech enhancement."""
 
 import time
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -26,6 +26,35 @@ class SpeechBrainEnhancer:
     MAX_DURATION_SECONDS = 60  # Maximum duration per segment in seconds
     MIN_LENGTH = 16  # kernel size for speechbrain/sepformer-wham16k-enhancement
     _models: Dict[str, Union["separator", "enhance_model"]] = {}
+
+    @staticmethod
+    def _loader_for(model_uri: str) -> Any:  # noqa: ANN401  # the speechbrain class (untyped third-party)
+        """Return the speechbrain inference class for an *enhancement* ``model_uri``.
+
+        Both supported model families are enhancers (denoisers); they differ only in
+        architecture, which dictates the speechbrain inference wrapper:
+
+        - SepFormer-architecture enhancement checkpoints (e.g. ``sepformer-wham16k-enhancement``,
+          ``sepformer-dns4-16k-enhancement``) load via ``SepformerSeparation`` — that is just
+          SepFormer's inference class; for an enhancement checkpoint it emits a single cleaned source.
+        - Spectral-mask checkpoints (e.g. ``metricgan-plus-voicebank``, ``mtl-mimic-voicebank``)
+          load via ``SpectralMaskEnhancement``.
+
+        The architecture is an unambiguous discriminator in the name, so we map it directly
+        rather than loading one class and falling back on the ``compute_stft``/hparams error the
+        wrong class would raise. NOTE: this is keyed on ``sepformer`` (the architecture), not on
+        "separation" — true multi-speaker separation checkpoints (e.g. ``sepformer-wsj02mix``)
+        are out of scope here, because :meth:`enhance_audios_with_speechbrain` reshapes the model
+        output to a single waveform and would garble multiple separated sources.
+
+        Args:
+            model_uri (str): The model path or URI.
+
+        Returns:
+            type: ``SepformerSeparation`` for SepFormer enhancement checkpoints,
+                else ``SpectralMaskEnhancement``.
+        """
+        return separator if "sepformer" in model_uri.lower() else enhance_model
 
     @classmethod
     def _get_speechbrain_model(
@@ -57,22 +86,15 @@ class SpeechBrainEnhancer:
         key = f"{model.path_or_uri}-{model.revision}-{device.value}"
         if key not in cls._models:
             savedir = speechbrain_savedir(str(model.path_or_uri), model.revision)
+            loader = cls._loader_for(str(model.path_or_uri))
+            logger.debug("Loading %s as %s", model.path_or_uri, loader.__name__)
             with speechbrain_loading_cwd(savedir):
-                try:
-                    cls._models[key] = retry_on_transient_error(
-                        enhance_model.from_hparams,
-                        source=model.path_or_uri,
-                        savedir=str(savedir),
-                        run_opts={"device": device.value},
-                    )
-                except Exception as e:
-                    logger.info("Trying SepformerSeparation model after SpectralMaskEnhancement failed: %s", e)
-                    cls._models[key] = retry_on_transient_error(
-                        separator.from_hparams,
-                        source=model.path_or_uri,
-                        savedir=str(savedir),
-                        run_opts={"device": device.value},
-                    )
+                cls._models[key] = retry_on_transient_error(
+                    loader.from_hparams,
+                    source=model.path_or_uri,
+                    savedir=str(savedir),
+                    run_opts={"device": device.value},
+                )
 
         return cls._models[key], device, dtype
 

--- a/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
+++ b/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
@@ -1,7 +1,7 @@
 """This module provides the Speechbrain interface for speech enhancement."""
 
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -28,7 +28,7 @@ class SpeechBrainEnhancer:
     _models: Dict[str, Union["separator", "enhance_model"]] = {}
 
     @staticmethod
-    def _loader_for(model_uri: str) -> Any:  # noqa: ANN401  # the speechbrain class (untyped third-party)
+    def _loader_for(model_uri: str) -> Union[type["separator"], type["enhance_model"]]:
         """Return the speechbrain inference class for an *enhancement* ``model_uri``.
 
         Both supported model families are enhancers (denoisers); they differ only in
@@ -51,8 +51,8 @@ class SpeechBrainEnhancer:
             model_uri (str): The model path or URI.
 
         Returns:
-            type: ``SepformerSeparation`` for SepFormer enhancement checkpoints,
-                else ``SpectralMaskEnhancement``.
+            The ``SepformerSeparation`` class for SepFormer enhancement checkpoints,
+            else the ``SpectralMaskEnhancement`` class.
         """
         return separator if "sepformer" in model_uri.lower() else enhance_model
 
@@ -89,12 +89,32 @@ class SpeechBrainEnhancer:
             loader = cls._loader_for(str(model.path_or_uri))
             logger.debug("Loading %s as %s", model.path_or_uri, loader.__name__)
             with speechbrain_loading_cwd(savedir):
-                cls._models[key] = retry_on_transient_error(
-                    loader.from_hparams,
-                    source=model.path_or_uri,
-                    savedir=str(savedir),
-                    run_opts={"device": device.value},
-                )
+                try:
+                    cls._models[key] = retry_on_transient_error(
+                        loader.from_hparams,
+                        source=model.path_or_uri,
+                        savedir=str(savedir),
+                        run_opts={"device": device.value},
+                    )
+                except Exception as e:
+                    # _loader_for routes by name; it is wrong only for off-convention
+                    # models — e.g. a custom SepFormer checkpoint whose path lacks
+                    # "sepformer", which routes to SpectralMaskEnhancement. Fall back to
+                    # SepformerSeparation for that catch-all branch; a sepformer-named
+                    # model that fails to load is a genuine error, so re-raise.
+                    if loader is not enhance_model:
+                        raise
+                    logger.info(
+                        "SpectralMaskEnhancement failed for %s; trying SepformerSeparation: %s",
+                        model.path_or_uri,
+                        e,
+                    )
+                    cls._models[key] = retry_on_transient_error(
+                        separator.from_hparams,
+                        source=model.path_or_uri,
+                        savedir=str(savedir),
+                        run_opts={"device": device.value},
+                    )
 
         return cls._models[key], device, dtype
 

--- a/src/tests/audio/tasks/speech_enhancement_test.py
+++ b/src/tests/audio/tasks/speech_enhancement_test.py
@@ -3,12 +3,27 @@
 from typing import List
 
 import pytest
+from speechbrain.inference.enhancement import SpectralMaskEnhancement as enhance_model
 from speechbrain.inference.separation import SepformerSeparation as separator
 
 from senselab.audio.data_structures import Audio
 from senselab.audio.tasks.speech_enhancement import enhance_audios
 from senselab.audio.tasks.speech_enhancement.speechbrain import SpeechBrainEnhancer
 from senselab.utils.data_structures import DeviceType, SpeechBrainModel
+
+
+@pytest.mark.parametrize(
+    ("model_uri", "expected"),
+    [
+        ("speechbrain/sepformer-wham16k-enhancement", separator),
+        ("speechbrain/sepformer-wsj02mix", separator),
+        ("speechbrain/metricgan-plus-voicebank", enhance_model),
+        ("speechbrain/mtl-mimic-voicebank", enhance_model),
+    ],
+)
+def test_loader_for_selects_class_by_name(model_uri: str, expected: type) -> None:
+    """The interface class is chosen directly from the model name, no load needed."""
+    assert SpeechBrainEnhancer._loader_for(model_uri) is expected
 
 
 @pytest.fixture


### PR DESCRIPTION
The default enhancement model (speechbrain/sepformer-wham16k-enhancement) is a SepFormer separation checkpoint, but the loader always tried SpectralMaskEnhancement first — which fails on it (compute_stft/hparams mismatch), logged a misleading error, wasted a load attempt, then fell back to SepformerSeparation. Select the inference class directly from the model name instead (sepformer -> SepformerSeparation, else SpectralMaskEnhancement): one deterministic load, fail loudly on a genuinely unloadable model. Add a unit test for the selection logic.
