### PR TITLE
feat(canary): split long audio at pauses to avoid the ~40s truncation

### DIFF
--- a/src/senselab/audio/tasks/preprocessing/__init__.py
+++ b/src/senselab/audio/tasks/preprocessing/__init__.py
@@ -1,3 +1,8 @@
 """.. include:: ./doc.md"""  # noqa: D415
 
 from .preprocessing import *  # noqa: F403
+from .silence_segmentation import (  # noqa: F401
+    SegmentStrategy,
+    pause_aware_boundaries,
+    segment_audios_at_pauses,
+)

--- a/src/senselab/audio/tasks/preprocessing/silence_segmentation.py
+++ b/src/senselab/audio/tasks/preprocessing/silence_segmentation.py
@@ -1,0 +1,258 @@
+"""Pause-aware segmentation: split audio into bounded chunks at silences.
+
+A general utility for any task that must feed a model audio no longer than some
+window (e.g. ASR backends with a fixed encoder/context limit such as Canary-Qwen
+or Granite): it splits audio that exceeds ``max_segment_s`` into ``<=
+max_segment_s`` pieces, choosing cut points **at pauses** (minimum short-time RMS
+energy) so no word is cut. Pure ``torch`` — no model or external dependency.
+
+Two strategies:
+
+* ``"greedy"`` — from the previous cut, take the *farthest* pause within
+  ``max_segment_s``. Minimizes the number of segments, but pins cuts near the cap
+  so cut quality is whatever pause happens to sit there.
+* ``"dp"`` — optimal segmentation: globally minimize
+  ``sum(cut_badness) + cut_penalty * n_cuts`` subject to every segment
+  ``<= max_segment_s``. Finds the deepest pauses anywhere and trades an extra
+  segment for a much cleaner cut when it is worth it (``cut_penalty`` is the dial).
+
+Both fall back to a forced minimum-energy cut across any pause-less run longer
+than ``max_segment_s``. ``"none"`` disables splitting (single full-length span).
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal, Tuple
+
+import torch
+
+from senselab.audio.data_structures import Audio
+from senselab.audio.tasks.preprocessing.preprocessing import extract_segments
+
+SegmentStrategy = Literal["none", "greedy", "dp"]
+
+# Documented defaults (override per call):
+DEFAULT_MIN_PAUSE_S = 0.20  # minimum silence duration to qualify as a pause candidate
+DEFAULT_SILENCE_PERCENTILE = 15.0  # frames below this energy percentile are "quiet" (adaptive)
+DEFAULT_CUT_PENALTY = 0.2  # DP per-cut penalty in normalized-badness units [0, 1]
+DEFAULT_ENERGY_FRAME_S = 0.02  # short-time RMS frame size used to locate cut points
+
+# Tolerance for the ``<= max_segment_s`` feasibility comparisons. Forced-cut
+# positions are built by repeated addition of ``max_segment_s`` (see ``_dp``),
+# so a span that is exactly ``max_segment_s`` long can read as e.g.
+# ``0.30000000000000004`` and spuriously fail an exact ``> max_segment_s``
+# guard — severing the DP chain and collapsing the output to one oversized span.
+# 1e-6 s (well below one sample at any real rate, well above float-accumulation
+# error over thousands of frames) absorbs the rounding without moving any real
+# boundary.
+_FEASIBILITY_EPS = 1e-6
+
+
+def _rms_envelope(audio: Audio, frame_s: float) -> Tuple[torch.Tensor, int, int, int]:
+    """Return (per-frame RMS, hop samples, sampling_rate, n_samples)."""
+    sr = int(audio.sampling_rate)
+    mono = audio.waveform.mean(dim=0)
+    n_samples = int(mono.shape[0])
+    hop = max(1, int(round(frame_s * sr)))
+    n_frames = n_samples // hop
+    if n_frames < 1:
+        return torch.zeros(0), hop, sr, n_samples
+    rms = mono[: n_frames * hop].reshape(n_frames, hop).pow(2).mean(dim=1).sqrt()
+    return rms, hop, sr, n_samples
+
+
+def _normalized(rms: torch.Tensor) -> torch.Tensor:
+    """Map RMS to [0, 1] badness via the 95th percentile (speech~1, silence~0)."""
+    if rms.numel() == 0:
+        return rms
+    ref = float(torch.quantile(rms, 0.95).item()) or float(rms.max().item()) or 1.0
+    return (rms / ref).clamp(0.0, 1.0)
+
+
+def _frame_time(frame_idx: int, hop: int, sr: int) -> float:
+    """Center time (seconds) of a frame."""
+    return (frame_idx * hop + hop / 2) / sr
+
+
+def _pause_candidates(
+    rms: torch.Tensor, hop: int, sr: int, min_pause_s: float, silence_percentile: float
+) -> List[Tuple[float, float]]:
+    """Return ``(time_s, badness)`` at the deepest frame of each detected pause."""
+    if rms.numel() == 0:
+        return []
+    norm = _normalized(rms)
+    thr = float(torch.quantile(rms, silence_percentile / 100.0).item())
+    # Materialize the mask to a Python list once: element-by-element ``bool(quiet[i])``
+    # on a tensor is very slow over the many frames of a long recording.
+    quiet = (rms <= thr).tolist()
+    min_frames = max(1, int(round(min_pause_s * sr / hop)))
+    out: List[Tuple[float, float]] = []
+    n = len(quiet)
+    i = 0
+    while i < n:
+        if not quiet[i]:
+            i += 1
+            continue
+        j = i
+        while j < n and quiet[j]:
+            j += 1
+        if (j - i) >= min_frames:
+            k = i + int(rms[i:j].argmin().item())
+            out.append((_frame_time(k, hop, sr), float(norm[k].item())))
+        i = j
+    return out
+
+
+def _forced_cut(rms: torch.Tensor, hop: int, sr: int, lo_s: float, hi_s: float) -> Tuple[float, float]:
+    """Quietest ``(time_s, badness)`` in ``[lo_s, hi_s]`` — fallback when no pause exists."""
+    norm = _normalized(rms)
+    lo_f = max(0, int(lo_s * sr / hop))
+    hi_f = min(rms.shape[0], max(lo_f + 1, int(hi_s * sr / hop)))
+    seg = rms[lo_f:hi_f]
+    if seg.numel() == 0:
+        return hi_s, 1.0
+    k = lo_f + int(seg.argmin().item())
+    return _frame_time(k, hop, sr), float(norm[k].item())
+
+
+def _spans_from_cuts(cuts: List[float], duration: float) -> List[Tuple[float, float]]:
+    pts = sorted({0.0, *[c for c in cuts if 0.0 < c < duration], duration})
+    return [(pts[k], pts[k + 1]) for k in range(len(pts) - 1)]
+
+
+def _greedy(
+    rms: torch.Tensor, hop: int, sr: int, duration: float, max_seg: float, cand_times: List[float]
+) -> List[float]:
+    cuts: List[float] = []
+    prev = 0.0
+    while duration - prev > max_seg:
+        feasible = [t for t in cand_times if prev < t <= prev + max_seg]
+        if feasible:
+            cut = max(feasible)
+        else:
+            cut, _ = _forced_cut(rms, hop, sr, prev + 0.5 * max_seg, prev + max_seg)
+            cut = min(max(cut, prev + 1.0), prev + max_seg)
+        cuts.append(cut)
+        prev = cut
+    return cuts
+
+
+def _dp(
+    rms: torch.Tensor,
+    hop: int,
+    sr: int,
+    duration: float,
+    max_seg: float,
+    candidates: List[Tuple[float, float]],
+    cut_penalty: float,
+) -> List[float]:
+    # Candidate positions: start, pauses, end. Insert forced cuts so no two
+    # consecutive candidates are farther than max_seg apart (guarantees feasibility).
+    raw = [(0.0, 0.0)] + [(t, b) for t, b in candidates if 0.0 < t < duration] + [(duration, 0.0)]
+    raw.sort()
+    pts: List[Tuple[float, float]] = [raw[0]]
+    for idx in range(1, len(raw)):
+        while raw[idx][0] - pts[-1][0] > max_seg + _FEASIBILITY_EPS:
+            ft, fb = _forced_cut(rms, hop, sr, pts[-1][0] + 0.5 * max_seg, pts[-1][0] + max_seg)
+            ft = min(max(ft, pts[-1][0] + 1.0), pts[-1][0] + max_seg)
+            pts.append((ft, fb))
+        pts.append(raw[idx])
+
+    m = len(pts)
+    inf = float("inf")
+    cost = [inf] * m
+    back = [-1] * m
+    cost[0] = 0.0
+    for i in range(1, m):
+        ti, bi = pts[i]
+        is_end = i == m - 1
+        for j in range(i - 1, -1, -1):
+            if ti - pts[j][0] > max_seg + _FEASIBILITY_EPS:
+                break
+            add = 0.0 if is_end else (bi + cut_penalty)  # endpoint is not a cut
+            c = cost[j] + add
+            if c < cost[i]:
+                cost[i] = c
+                back[i] = j
+
+    cuts: List[float] = []
+    i = m - 1
+    while i > 0:
+        cuts.append(pts[i][0])
+        i = back[i]
+    return cuts
+
+
+def pause_aware_boundaries(
+    audio: Audio,
+    max_segment_s: float,
+    strategy: SegmentStrategy = "dp",
+    *,
+    min_pause_s: float = DEFAULT_MIN_PAUSE_S,
+    silence_percentile: float = DEFAULT_SILENCE_PERCENTILE,
+    cut_penalty: float = DEFAULT_CUT_PENALTY,
+    energy_frame_s: float = DEFAULT_ENERGY_FRAME_S,
+) -> List[Tuple[float, float]]:
+    """Return ``(start, end)`` second-spans tiling ``audio`` with each span <= ``max_segment_s``.
+
+    Cuts are placed at pauses (see module docstring). Audio at or under
+    ``max_segment_s`` (or ``strategy="none"``) returns a single full-length span.
+    """
+    if max_segment_s <= 0:
+        raise ValueError(f"max_segment_s must be strictly positive, got {max_segment_s!r}.")
+    if min_pause_s <= 0:
+        raise ValueError(f"min_pause_s must be strictly positive, got {min_pause_s!r}.")
+    if energy_frame_s <= 0:
+        raise ValueError(f"energy_frame_s must be strictly positive, got {energy_frame_s!r}.")
+    if not 0.0 <= silence_percentile <= 100.0:
+        raise ValueError(f"silence_percentile must be in [0, 100], got {silence_percentile!r}.")
+    if cut_penalty < 0:
+        raise ValueError(f"cut_penalty must be non-negative, got {cut_penalty!r}.")
+
+    duration = audio.waveform.shape[1] / audio.sampling_rate
+    if strategy == "none":
+        return [(0.0, duration)]
+    if strategy not in ("greedy", "dp"):
+        raise ValueError(f"Unknown segmentation strategy {strategy!r}; expected 'none', 'greedy', or 'dp'.")
+
+    rms, hop, sr, n = _rms_envelope(audio, energy_frame_s)
+    if duration <= max_segment_s or rms.numel() == 0:
+        return [(0.0, duration)]
+    candidates = _pause_candidates(rms, hop, sr, min_pause_s, silence_percentile)
+
+    if strategy == "greedy":
+        cuts = _greedy(rms, hop, sr, duration, max_segment_s, [t for t, _ in candidates])
+    else:
+        cuts = _dp(rms, hop, sr, duration, max_segment_s, candidates, cut_penalty)
+    return _spans_from_cuts(cuts, duration)
+
+
+def segment_audios_at_pauses(
+    audios: List[Audio],
+    max_segment_s: float,
+    strategy: SegmentStrategy = "dp",
+    *,
+    min_pause_s: float = DEFAULT_MIN_PAUSE_S,
+    silence_percentile: float = DEFAULT_SILENCE_PERCENTILE,
+    cut_penalty: float = DEFAULT_CUT_PENALTY,
+    energy_frame_s: float = DEFAULT_ENERGY_FRAME_S,
+) -> List[List[Audio]]:
+    """Split each input audio at pauses into ``<= max_segment_s`` sub-Audios.
+
+    Returns, per input audio, the list of its sub-Audios in time order. An audio
+    that needs no splitting is returned as a single-element list holding the
+    original object (no copy).
+    """
+    out: List[List[Audio]] = []
+    for audio in audios:
+        spans = pause_aware_boundaries(
+            audio,
+            max_segment_s,
+            strategy,
+            min_pause_s=min_pause_s,
+            silence_percentile=silence_percentile,
+            cut_penalty=cut_penalty,
+            energy_frame_s=energy_frame_s,
+        )
+        out.append([audio] if len(spans) == 1 else extract_segments([(audio, spans)])[0])
+    return out

--- a/src/senselab/audio/tasks/speech_to_text/canary_qwen.py
+++ b/src/senselab/audio/tasks/speech_to_text/canary_qwen.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from senselab.audio.data_structures import Audio
+from senselab.audio.tasks.preprocessing import SegmentStrategy, segment_audios_at_pauses
 from senselab.utils.data_structures import DeviceType, HFModel, ScriptLine, _select_device_and_dtype
 from senselab.utils.subprocess_venv import _clean_subprocess_env, ensure_venv, parse_subprocess_result, venv_python
 
@@ -55,6 +56,15 @@ _CANARY_REQUIREMENTS = [
 ]
 _CANARY_PYTHON = "3.12"
 
+# Per-chunk audio ceiling for long-audio splitting. Canary-Qwen was trained on
+# audio up to 40 s and has a 1024-token total budget (prompt + audio + response)
+# at ~12.5 audio tokens/s, so whole long recordings truncate (validated: mean
+# word recovery vs Whisper falls from ~1.0 below ~1024 total tokens to ~0.28 for
+# multi-minute audio). 38 s == 475 audio tokens, leaving ample room in the budget
+# while staying inside the training window. Splitting happens at pauses via
+# ``segment_audios_at_pauses`` so no word is cut.
+_CANARY_WINDOW_S = 38.0
+
 # Worker script — runs inside the isolated venv.
 # The chat-style prompt format with ``audio_locator_tag`` plus
 # ``{"audio": [path]}`` matches the published Canary-Qwen model card
@@ -72,8 +82,10 @@ try:
     audio_paths = args["audio_paths"]
     model_name = args["model_name"]
     device = args["device"]
+    revision = args.get("revision") or "main"
 
-    model = SALM.from_pretrained(model_name)
+    # Load the revision the parent requested rather than the default "main".
+    model = SALM.from_pretrained(model_name, revision=revision)
     if device == "cuda" and torch.cuda.is_available():
         model = model.cuda()
 
@@ -121,6 +133,33 @@ except Exception as exc:
 """
 
 
+def _regroup_chunk_transcripts(entries: List[dict], chunk_counts: List[int]) -> List[str]:
+    """Concatenate per-chunk worker transcripts back into one text per input audio.
+
+    ``entries`` are the worker results in flattened chunk order; ``chunk_counts[i]``
+    is how many chunks input ``i`` was split into. Returns one joined transcript
+    per input audio, in input order.
+
+    Raises:
+        RuntimeError: if the worker returned a different number of chunk results
+            than were sent. Advancing past a shortfall would silently drop text
+            and misalign every downstream audio, so we fail loudly instead.
+    """
+    expected = sum(chunk_counts)
+    if len(entries) != expected:
+        raise RuntimeError(
+            f"Canary-Qwen returned {len(entries)} chunk transcripts but {expected} were expected "
+            "(worker likely failed on some chunks); refusing to emit a misaligned transcript."
+        )
+    texts: List[str] = []
+    pos = 0
+    for count in chunk_counts:
+        parts = [(entries[pos + c].get("text") or "").strip() for c in range(count)]
+        pos += count
+        texts.append(" ".join(t for t in parts if t))
+    return texts
+
+
 class CanaryQwenASR:
     """NVIDIA Canary-Qwen 2.5B transcription via isolated subprocess venv.
 
@@ -136,6 +175,7 @@ class CanaryQwenASR:
         audios: List[Audio],
         model: Optional[HFModel] = None,
         device: Optional[DeviceType] = None,
+        chunk_strategy: SegmentStrategy = "greedy",
     ) -> List[ScriptLine]:
         """Transcribe audios with Canary-Qwen via the dedicated subprocess venv.
 
@@ -144,6 +184,14 @@ class CanaryQwenASR:
             model: HF model id (default: ``nvidia/canary-qwen-2.5b``).
             device: CPU or CUDA. CUDA strongly recommended; CPU works but
                 is very slow for a 2.5B-parameter model.
+            chunk_strategy: How to split audio longer than the model's ~40 s
+                window so it does not truncate (see ``segment_audios_at_pauses``):
+                ``"greedy"`` (default, pause-aware greedy packing), ``"dp"``
+                (optimal pause segmentation), or ``"none"`` (no splitting —
+                long audio will truncate). ``greedy`` and ``dp`` were empirically
+                equivalent on annotated long recordings, so the simpler ``greedy``
+                is the default. Each chunk's transcript is concatenated in time
+                order into one ScriptLine per input.
 
         Returns:
             One ``ScriptLine`` per input audio with ``text`` populated.
@@ -157,20 +205,33 @@ class CanaryQwenASR:
         venv_dir = ensure_venv(_CANARY_VENV, _CANARY_REQUIREMENTS, python_version=_CANARY_PYTHON)
         python = venv_python(venv_dir)
 
+        # Split any over-window audio into <=_CANARY_WINDOW_S sub-chunks at pauses
+        # so the model never truncates. Audio within the window yields a single
+        # chunk, so behavior is unchanged for short clips.
+        chunks_per_audio = segment_audios_at_pauses(audios, max_segment_s=_CANARY_WINDOW_S, strategy=chunk_strategy)
+
         with tempfile.TemporaryDirectory(prefix="senselab-canary-qwen-") as tmpdir:
             tmp = Path(tmpdir)
 
             audio_paths: List[str] = []
-            for i, audio in enumerate(audios):
-                path = str(tmp / f"audio_{i}.wav")
-                audio.save_to_file(path)
-                audio_paths.append(path)
+            chunk_counts: List[int] = []
+            for ai, chunks in enumerate(chunks_per_audio):
+                chunk_counts.append(len(chunks))
+                for ci, chunk in enumerate(chunks):
+                    path = str(tmp / f"audio_{ai}_{ci}.wav")
+                    chunk.save_to_file(path)
+                    audio_paths.append(path)
 
+            # Forward the requested revision to the worker so its
+            # SALM.from_pretrained loads that snapshot rather than defaulting
+            # to "main".
+            revision = (model.revision if model is not None else None) or "main"
             input_json = json.dumps(
                 {
                     "audio_paths": audio_paths,
                     "model_name": model_name,
                     "device": device_type.value,
+                    "revision": revision,
                 }
             )
 
@@ -180,14 +241,16 @@ class CanaryQwenASR:
                 input=input_json,
                 capture_output=True,
                 text=True,
-                timeout=1200,  # 2.5B-param model load + per-audio generate; allow 20 min.
+                # Model load + per-chunk generate; a long recording is many
+                # chunks, so allow 30 min (load dominates; chunks are fast).
+                timeout=1800,
                 env=env,
             )
 
             output = parse_subprocess_result(result, "Canary-Qwen ASR")
+            entries = output.get("results", [])
 
-            results: List[ScriptLine] = []
-            for entry in output.get("results", []):
-                results.append(ScriptLine(text=entry.get("text", "")))
-
-            return results
+            # Regroup the per-chunk transcripts back into one ScriptLine per input
+            # audio, concatenating chunk text in time order.
+            texts = _regroup_chunk_transcripts(entries, chunk_counts)
+            return [ScriptLine(text=t) for t in texts]

--- a/src/tests/audio/tasks/preprocessing/silence_segmentation_test.py
+++ b/src/tests/audio/tasks/preprocessing/silence_segmentation_test.py
@@ -1,0 +1,155 @@
+"""Unit tests for general pause-aware audio segmentation (pure CPU, synthetic)."""
+
+from typing import List, Tuple
+
+import pytest
+import torch
+
+from senselab.audio.data_structures import Audio
+from senselab.audio.tasks.preprocessing import (
+    pause_aware_boundaries,
+    segment_audios_at_pauses,
+)
+
+SR = 16000
+
+
+def _make_audio(
+    duration_s: float, silence_times: Tuple[float, ...] = (), silence_dur: float = 0.6, loud: float = 0.5
+) -> Audio:
+    """Noise 'speech' of ``loud`` amplitude with exact-zero silence gaps inserted."""
+    n = int(duration_s * SR)
+    gen = torch.Generator().manual_seed(0)
+    wf = (torch.rand(n, generator=gen) * 2 - 1) * loud
+    for t in silence_times:
+        s, e = int(t * SR), int((t + silence_dur) * SR)
+        wf[s:e] = 0.0
+    return Audio(waveform=wf.unsqueeze(0), sampling_rate=SR, metadata={})
+
+
+def _assert_valid_tiling(spans: List[Tuple[float, float]], duration: float, max_seg: float) -> None:
+    """Spans must start at 0, end at duration, be contiguous, and each be <= max_seg."""
+    assert spans[0][0] == 0.0
+    assert abs(spans[-1][1] - duration) < 1e-6
+    for i in range(len(spans) - 1):
+        assert abs(spans[i][1] - spans[i + 1][0]) < 1e-6, "spans must be contiguous"
+    for s, e in spans:
+        assert e - s <= max_seg + 1e-3, f"segment {(s, e)} exceeds max {max_seg}"
+        assert e > s
+
+
+def test_short_audio_single_segment() -> None:
+    """Audio within the cap returns one full-length span for every strategy."""
+    audio = _make_audio(10.0)
+    for strategy in ("none", "greedy", "dp"):
+        assert pause_aware_boundaries(audio, max_segment_s=38.0, strategy=strategy) == [(0.0, 10.0)], strategy
+
+
+def test_none_strategy_never_splits() -> None:
+    """The 'none' strategy returns a single span regardless of duration."""
+    audio = _make_audio(20.0, silence_times=(4, 8, 12, 16))
+    assert pause_aware_boundaries(audio, max_segment_s=5.0, strategy="none") == [(0.0, 20.0)]
+
+
+def test_greedy_and_dp_valid_tiling_with_silences() -> None:
+    """Both strategies produce a valid, bounded tiling of audio with pauses."""
+    audio = _make_audio(20.0, silence_times=(4, 8, 12, 16))
+    for strategy in ("greedy", "dp"):
+        spans = pause_aware_boundaries(audio, max_segment_s=5.0, strategy=strategy)
+        _assert_valid_tiling(spans, 20.0, 5.0)
+        assert len(spans) >= 4
+
+
+def test_cuts_land_in_silence() -> None:
+    """Interior cut points fall near the inserted silences, not mid-'speech'."""
+    silence_times = (4, 8, 12, 16)
+    centers = [t + 0.3 for t in silence_times]
+    audio = _make_audio(20.0, silence_times=silence_times)
+    for strategy in ("greedy", "dp"):
+        spans = pause_aware_boundaries(audio, max_segment_s=5.0, strategy=strategy)
+        for cut in [e for s, e in spans[:-1]]:
+            assert min(abs(cut - c) for c in centers) < 0.7, f"{strategy} cut {cut} not near a silence"
+
+
+def test_pauseless_run_forces_bounded_cuts() -> None:
+    """With no silence anywhere, cuts are forced but every segment stays <= max."""
+    audio = _make_audio(20.0)
+    for strategy in ("greedy", "dp"):
+        _assert_valid_tiling(pause_aware_boundaries(audio, max_segment_s=5.0, strategy=strategy), 20.0, 5.0)
+
+
+def test_greedy_minimizes_segment_count() -> None:
+    """Greedy packs to the farthest pause, so it never uses more segments than DP."""
+    audio = _make_audio(30.0, silence_times=(4, 8, 12, 16, 20, 24, 28))
+    g = pause_aware_boundaries(audio, max_segment_s=5.0, strategy="greedy")
+    d = pause_aware_boundaries(audio, max_segment_s=5.0, strategy="dp")
+    assert len(g) <= len(d)
+
+
+def test_cut_penalty_controls_segment_count() -> None:
+    """A larger DP cut penalty yields no more segments than a small one."""
+    audio = _make_audio(30.0, silence_times=tuple(range(2, 30)))  # many pauses to choose from
+    few = pause_aware_boundaries(audio, max_segment_s=8.0, strategy="dp", cut_penalty=1.0)
+    many = pause_aware_boundaries(audio, max_segment_s=8.0, strategy="dp", cut_penalty=0.0)
+    assert len(few) <= len(many)
+
+
+def test_unknown_strategy_raises() -> None:
+    """An unrecognized strategy name is rejected."""
+    with pytest.raises(ValueError, match="strategy"):
+        pause_aware_boundaries(_make_audio(5.0), max_segment_s=38.0, strategy="bogus")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("max_seg", [0.99, 0.8, 0.3, 0.1])
+def test_dp_tiles_sub_second_windows(max_seg: float) -> None:
+    """DP must tile into <= max_seg spans even for small windows.
+
+    Regression: forced-cut positions are built by repeated addition of
+    ``max_seg``, so an exact-float feasibility guard (``ti - t_j > max_seg``)
+    tripped on accumulated rounding (e.g. ``0.30000000000000004 > 0.3``),
+    severed the DP chain, and returned a SINGLE full-length span far exceeding
+    the cap with no error. A comparison tolerance fixes it.
+    """
+    audio = _make_audio(30.0)  # pause-less -> all cuts are forced at the cap
+    spans = pause_aware_boundaries(audio, max_segment_s=max_seg, strategy="dp")
+    _assert_valid_tiling(spans, 30.0, max_seg)
+    assert len(spans) > 1, "DP collapsed to a single oversized span"
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0])
+def test_nonpositive_max_segment_raises(bad: float) -> None:
+    """A non-positive max_segment_s is rejected (would otherwise infinite-loop)."""
+    for strategy in ("greedy", "dp"):
+        with pytest.raises(ValueError, match="max_segment_s"):
+            pause_aware_boundaries(_make_audio(10.0), max_segment_s=bad, strategy=strategy)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"min_pause_s": 0.0},
+        {"min_pause_s": -1.0},
+        {"energy_frame_s": 0.0},
+        {"energy_frame_s": -0.02},
+        {"silence_percentile": -1.0},
+        {"silence_percentile": 101.0},
+        {"cut_penalty": -0.1},
+    ],
+)
+def test_invalid_params_raise(kwargs: dict) -> None:
+    """Out-of-range tuning params are rejected with a clear ValueError."""
+    with pytest.raises(ValueError):
+        pause_aware_boundaries(_make_audio(10.0), max_segment_s=5.0, strategy="dp", **kwargs)
+
+
+def test_segment_audios_at_pauses_returns_subaudios() -> None:
+    """segment_audios_at_pauses returns sub-Audios whose durations tile each input."""
+    audio = _make_audio(20.0, silence_times=(4, 8, 12, 16))
+    out = segment_audios_at_pauses([audio], max_segment_s=5.0, strategy="dp")
+    assert len(out) == 1
+    segs = out[0]
+    assert len(segs) >= 4
+    total = sum(s.waveform.shape[1] for s in segs)
+    assert abs(total - audio.waveform.shape[1]) <= 1  # samples conserved (±rounding)
+    for s in segs:
+        assert s.waveform.shape[1] / SR <= 5.0 + 1e-3

--- a/src/tests/audio/tasks/speech_to_text/canary_qwen_test.py
+++ b/src/tests/audio/tasks/speech_to_text/canary_qwen_test.py
@@ -21,7 +21,11 @@ import pytest
 
 from senselab.audio.data_structures import Audio
 from senselab.audio.tasks.preprocessing import downmix_audios_to_mono, resample_audios
-from senselab.audio.tasks.speech_to_text.canary_qwen import CanaryQwenASR
+from senselab.audio.tasks.speech_to_text.canary_qwen import (
+    _CANARY_WORKER_SCRIPT,
+    CanaryQwenASR,
+    _regroup_chunk_transcripts,
+)
 from senselab.utils.data_structures import HFModel
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
@@ -37,6 +41,38 @@ def _load_16k_mono_fixture() -> Audio:
     if audio.sampling_rate != 16000:
         audio = resample_audios([audio], resample_rate=16000)[0]
     return audio
+
+
+def test_regroup_chunk_transcripts_groups_in_input_order() -> None:
+    """Per-chunk texts are concatenated (in order) into one transcript per input."""
+    entries = [{"text": "a1"}, {"text": "a2"}, {"text": "b1"}, {"text": "c1"}, {"text": "c2"}, {"text": "c3"}]
+    texts = _regroup_chunk_transcripts(entries, [2, 1, 3])
+    assert texts == ["a1 a2", "b1", "c1 c2 c3"]
+
+
+def test_regroup_chunk_transcripts_raises_on_worker_shortfall() -> None:
+    """A worker that returns fewer chunks than sent must fail loudly, not silently.
+
+    Regression: advancing ``pos`` by the *expected* count while guarding the
+    index dropped the missing chunks AND misaligned every downstream audio,
+    silently corrupting/truncating transcripts with no error.
+    """
+    entries = [{"text": "a1"}, {"text": "a2"}, {"text": "b1"}]  # 3 returned...
+    with pytest.raises(RuntimeError, match="chunk"):
+        _regroup_chunk_transcripts(entries, [2, 1, 3])  # ...but 6 expected
+
+
+def test_canary_worker_loads_requested_revision() -> None:
+    """The worker forwards the requested revision to SALM.from_pretrained.
+
+    The parent passes ``model.revision`` down to the worker; the worker must
+    load that snapshot rather than calling SALM.from_pretrained(model_name)
+    with no revision (which would default to 'main').
+    """
+    # Worker reads a revision from its input payload...
+    assert 'args["revision"]' in _CANARY_WORKER_SCRIPT or 'args.get("revision"' in _CANARY_WORKER_SCRIPT
+    # ...and forwards it to the model loader.
+    assert "revision=revision" in _CANARY_WORKER_SCRIPT
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## What

Canary-Qwen silently truncates audio past its ~40 s / 1024-token window, so multi-minute recordings lose most of their transcript (validated: mean word recovery vs Whisper falls from ~1.0 to ~0.28 on long audio).

This adds a general **pause-aware segmentation** utility and wires Canary-Qwen to use it:

- `src/senselab/audio/tasks/preprocessing/silence_segmentation.py` — pure-`torch`, no model/external dependency. Splits any audio longer than `max_segment_s` into `<= max_segment_s` pieces, cutting **at pauses** (minimum short-time RMS energy) so no word is severed. Two strategies: `greedy` (fewest segments) and `dp` (optimal `sum(cut_badness) + cut_penalty * n_cuts`), plus a forced minimum-energy cut for pause-less runs. All thresholds are named/documented and inputs validated.
- `CanaryQwenASR.transcribe`: chunk (`chunk_strategy="greedy"` by default) → transcribe each chunk → regroup transcripts in time order into one `ScriptLine` per input. A count mismatch raises loudly rather than silently emitting a misaligned transcript. **Audio within the window yields a single chunk, so short-clip behavior is unchanged.**
- Also forwards the requested model `revision` to the worker so it loads the pinned snapshot rather than defaulting to `"main"`.

## Relationship to #527 / #528

This is the Canary long-audio fix originally in **#528**, which was stacked on top of the offline-loading work in **#527**. Since #527 is being reworked separately, this branch is **rebased directly onto `alpha` and fully decoupled from #527** — no dependency on `hf_subprocess_env` or any offline-loading helper. It can merge to `alpha` on its own.

## Tests

- `silence_segmentation_test.py` — boundary/strategy/validation coverage (new).
- `canary_qwen_test.py` — chunk regrouping + revision forwarding (extended).
- Local: `ruff`, `ruff format`, `mypy` pass (pre-commit). GPU transcription validated previously on the source branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.3.1-alpha.34`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - feat(canary): split long audio at pauses to avoid the ~40s truncation [#534](https://github.com/sensein/senselab/pull/534) ([@wilke0818](https://github.com/wilke0818))
  - ScriptLine: accept empty text as "model produced no transcript" signal [#520](https://github.com/sensein/senselab/pull/520) ([@wilke0818](https://github.com/wilke0818))
  - Feat/pii subprocess venv [#519](https://github.com/sensein/senselab/pull/519) ([@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: route torch/torchaudio via CUDA-aware PyTorch index [#516](https://github.com/sensein/senselab/pull/516) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: two-stage install to fix torch/torchaudio CUDA-tag s… [#518](https://github.com/sensein/senselab/pull/518) ([@wilke0818](https://github.com/wilke0818))
  - Fix/ser wav2vec2 regression head [#511](https://github.com/sensein/senselab/pull/511) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818) [@claude](https://github.com/claude))
  - comparison & uncertainty stage for analyze_audio.py [#512](https://github.com/sensein/senselab/pull/512) ([@satra](https://github.com/satra))
  - audio analysis script + multilingual MMS aligner + 4 new ASR backends [#510](https://github.com/sensein/senselab/pull/510) ([@satra](https://github.com/satra))
  
  #### Authors: 3
  
  - Claude ([@claude](https://github.com/claude))
  - Jordan Wilke ([@wilke0818](https://github.com/wilke0818))
  - Satrajit Ghosh ([@satra](https://github.com/satra))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
