### PR TITLE
fix(asr): CrisperWhisper ct2 venv needs torch+transformers for HF→CT2 conversion

### DIFF
--- a/src/senselab/audio/tasks/speech_to_text/crisperwhisper.py
+++ b/src/senselab/audio/tasks/speech_to_text/crisperwhisper.py
@@ -34,7 +34,16 @@ _CRISPER_VENV = "crisperwhisper"
 # ``CrisperWhisperModel`` API, so the worker is backend-agnostic.
 _IS_LINUX_X86 = sys.platform.startswith("linux") and platform.machine().lower() in ("x86_64", "amd64")
 if _IS_LINUX_X86:
-    _CRISPER_REQUIREMENTS = ["crisperwhisper[ct2]==2.0.1"]
+    # CT2 *inference* is torch-free, but the first-run HF->CT2 *conversion* goes through
+    # ``ctranslate2.converters.transformers``, whose ``try: import huggingface_hub, torch,
+    # transformers`` block leaves those names unbound when absent; ``_load()`` then calls
+    # ``torch.no_grad()`` + the transformers loader -> ``NameError: name 'torch' /
+    # 'transformers' is not defined``. The venv "builds" but transcription fails on every
+    # clip. So the ct2 venv also needs the conversion stack: use the ``[transformers]``
+    # extra (== [all] with ct2: transformers + torch + accelerate) and pin torch/torchaudio
+    # explicitly so ensure_venv routes them through the CUDA index. None of this is loaded
+    # at CT2 inference time — only for the one-time, cached HF->CT2 conversion.
+    _CRISPER_REQUIREMENTS = ["crisperwhisper[ct2,transformers]==2.0.1", "torch>=2.4", "torchaudio>=2.4"]
 else:
     _CRISPER_REQUIREMENTS = [
         "crisperwhisper[transformers]==2.0.1",


### PR DESCRIPTION
## Problem
On Linux x86_64, the CrisperWhisper backend builds its subprocess venv from `crisperwhisper[ct2]` only. CT2 *inference* is torch-free, but the first-run HF→CT2 **conversion** (`model._init_v2` → `converter.ensure_ct2_model` → `ctranslate2.converters.transformers._load`) needs **torch and transformers**: that module does `try: import huggingface_hub, torch, transformers` and, when they're absent, leaves the names unbound; `_load()` then calls `torch.no_grad()` and the transformers loader → `NameError: name 'torch' / 'transformers' is not defined`.

**Impact:** the venv "builds" but every clip's CrisperWhisper ASR fails in ~0.7 s with that `NameError`, silently dropping the `whisper` model from multi-ASR runs (found on a CUDA-13.1 GPU batch; `canary-qwen` + `Qwen3-ASR` still succeed). macOS is unaffected — it uses the transformers backend (torch already declared) and never invokes the CT2 converter.

## Fix
Add the `[transformers]` extra (`== [all]` alongside ct2: transformers + torch + accelerate) to the Linux-x86 ct2 requirements, and pin `torch`/`torchaudio` so `ensure_venv` routes them through the CUDA-aware index. The conversion result is cached, so torch/transformers are installed but never loaded at CT2 inference time.

```python
# before
_CRISPER_REQUIREMENTS = ["crisperwhisper[ct2]==2.0.1"]
# after
_CRISPER_REQUIREMENTS = ["crisperwhisper[ct2,transformers]==2.0.1", "torch>=2.4", "torchaudio>=2.4"]
```

## Why CI didn't catch it
`crisperwhisper_test.py`:
- the assembly test mocks `ensure_venv` / `venv_python` / `subprocess` → the ct2 venv is never built;
- `test_crisperwhisper_transcribes_when_venv_present` is `@skipif(not CRISPER_VENV.exists())` → skipped in CI, and where a dev *has* the venv (macOS) it runs the torch-having transformers backend.

So no test builds the `[ct2]` venv on Linux-x86 and runs a conversion — the only path that hits this. A GPU-gated regression test mirroring `brouhaha_venv_gpu_test.py` (build ct2 venv + transcribe) would cover it; happy to add as a follow-up.

## Validation
Rebuilt the venv on a GPU node: CrisperWhisper now transcribes (e.g. "blue or maybe green blue red blue blue" on a Word-color-Stroop clip) and all three ASR models return.

## Notes
Base: `alpha`. Independent of #539 (HF-cache) — the two touch different regions of `crisperwhisper.py` (requirements list vs `hf_subprocess_env` model staging) and merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.3.1-alpha.39`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - fix(asr): CrisperWhisper ct2 venv needs torch+transformers for HF→CT2 conversion [#540](https://github.com/sensein/senselab/pull/540) ([@wilke0818](https://github.com/wilke0818))
  - hf-cache: stop HF Hub 429s under parallel batch (resolve-once + SHA-pin) [#539](https://github.com/sensein/senselab/pull/539) ([@wilke0818](https://github.com/wilke0818))
  - fix(adaptive): guard None history in convergence improvement delta [#541](https://github.com/sensein/senselab/pull/541) ([@wilke0818](https://github.com/wilke0818))
  - refactor(cache): cached-inference layer out of analyze_audio.py (T051, parts 1-2) [#538](https://github.com/sensein/senselab/pull/538) ([@satra](https://github.com/satra))
  - Scene-aware presence/quality axis + ASR transcription overhaul (CrisperWhisper 2.0, Qwen) [#536](https://github.com/sensein/senselab/pull/536) ([@satra](https://github.com/satra) [@claude](https://github.com/claude))
  - feat(canary): split long audio at pauses to avoid the ~40s truncation [#534](https://github.com/sensein/senselab/pull/534) ([@wilke0818](https://github.com/wilke0818))
  - ScriptLine: accept empty text as "model produced no transcript" signal [#520](https://github.com/sensein/senselab/pull/520) ([@wilke0818](https://github.com/wilke0818))
  - Feat/pii subprocess venv [#519](https://github.com/sensein/senselab/pull/519) ([@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: route torch/torchaudio via CUDA-aware PyTorch index [#516](https://github.com/sensein/senselab/pull/516) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: two-stage install to fix torch/torchaudio CUDA-tag s… [#518](https://github.com/sensein/senselab/pull/518) ([@wilke0818](https://github.com/wilke0818))
  - Fix/ser wav2vec2 regression head [#511](https://github.com/sensein/senselab/pull/511) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818) [@claude](https://github.com/claude))
  - comparison & uncertainty stage for analyze_audio.py [#512](https://github.com/sensein/senselab/pull/512) ([@satra](https://github.com/satra))
  - audio analysis script + multilingual MMS aligner + 4 new ASR backends [#510](https://github.com/sensein/senselab/pull/510) ([@satra](https://github.com/satra))
  
  #### Authors: 3
  
  - Claude ([@claude](https://github.com/claude))
  - Jordan Wilke ([@wilke0818](https://github.com/wilke0818))
  - Satrajit Ghosh ([@satra](https://github.com/satra))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
