### PR TITLE
fix(adaptive): guard None history in convergence improvement delta

### DIFF
--- a/src/senselab/audio/workflows/audio_analysis/adaptive/convergence.py
+++ b/src/senselab/audio/workflows/audio_analysis/adaptive/convergence.py
@@ -45,7 +45,16 @@ def apply_convergence_marks(
                 hist = row.get("history") or []
                 improvement = None
                 if len(hist) >= 2:
-                    improvement = hist[-2]["aggregated_uncertainty"] - hist[-1]["aggregated_uncertainty"]
+                    # aggregated_uncertainty is float | None: a bucket is None when the axis
+                    # couldn't score that round (e.g. utterance comparison_status="incomparable"
+                    # — no comparable ASR words in the window, common on sparse/gappy speech).
+                    # A bucket can flip None<->float across rounds, so guard both history
+                    # entries; if either is None we can't measure improvement across it, so
+                    # leave it unmeasured (not "stalled") rather than crashing None - float.
+                    prev_u = hist[-2].get("aggregated_uncertainty")
+                    last_u = hist[-1].get("aggregated_uncertainty")
+                    if prev_u is not None and last_u is not None:
+                        improvement = prev_u - last_u
                 stalled = improvement is not None and improvement < epsilon
                 if touches >= max_touch and stalled:
                     floor = float(row.get("aleatoric_floor") or 0.0)


### PR DESCRIPTION
## Problem
`apply_convergence_marks` (`adaptive/convergence.py`) computed the per-bucket round-over-round improvement as `hist[-2]["aggregated_uncertainty"] - hist[-1]["aggregated_uncertainty"]` with **no `None` guard**.

`aggregated_uncertainty` is `float | None` — a bucket is `None` when the axis can't score that round. The **utterance axis** marks a bucket `comparison_status="incomparable"` (→ `None`) when a window has **no comparable ASR words**, common on **sparse/gappy speech**. A bucket can flip `None`↔`float` across adaptive rounds (reprocessing adds/removes words), so its history can hold a `None` next to a `float`, and the subtraction raises `TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'` — crashing the loop for the whole clip, even though the *current* value is already guarded a few lines up (`if u is None: continue`).

**Impact:** `adaptive_loop` failed on **5/30 clips** in a real batch — all sparse-speech (Word-color-Stroop, Random-Item-Generation, Story-recall, Picture-description), which have many incomparable utterance buckets.

## Fix
Guard both history entries; if either round was `None`, improvement is unmeasurable across it, so leave `improvement=None` (bucket stays `open`, not `stalled`) instead of crashing. No behavior change when both rounds are scored.

## Testing gap
Same blind spot as the recent subprocess-venv fixes: the adaptive tests don't exercise a clip whose cross-round history contains incomparable (`None`) buckets. A fixture with a `None`→`float` history transition would regression-cover it.

Base: `alpha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.3.1-alpha.37`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - fix(adaptive): guard None history in convergence improvement delta [#541](https://github.com/sensein/senselab/pull/541) ([@wilke0818](https://github.com/wilke0818))
  - refactor(cache): cached-inference layer out of analyze_audio.py (T051, parts 1-2) [#538](https://github.com/sensein/senselab/pull/538) ([@satra](https://github.com/satra))
  - Scene-aware presence/quality axis + ASR transcription overhaul (CrisperWhisper 2.0, Qwen) [#536](https://github.com/sensein/senselab/pull/536) ([@satra](https://github.com/satra) [@claude](https://github.com/claude))
  - feat(canary): split long audio at pauses to avoid the ~40s truncation [#534](https://github.com/sensein/senselab/pull/534) ([@wilke0818](https://github.com/wilke0818))
  - ScriptLine: accept empty text as "model produced no transcript" signal [#520](https://github.com/sensein/senselab/pull/520) ([@wilke0818](https://github.com/wilke0818))
  - Feat/pii subprocess venv [#519](https://github.com/sensein/senselab/pull/519) ([@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: route torch/torchaudio via CUDA-aware PyTorch index [#516](https://github.com/sensein/senselab/pull/516) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: two-stage install to fix torch/torchaudio CUDA-tag s… [#518](https://github.com/sensein/senselab/pull/518) ([@wilke0818](https://github.com/wilke0818))
  - Fix/ser wav2vec2 regression head [#511](https://github.com/sensein/senselab/pull/511) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818) [@claude](https://github.com/claude))
  - comparison & uncertainty stage for analyze_audio.py [#512](https://github.com/sensein/senselab/pull/512) ([@satra](https://github.com/satra))
  - audio analysis script + multilingual MMS aligner + 4 new ASR backends [#510](https://github.com/sensein/senselab/pull/510) ([@satra](https://github.com/satra))
  
  #### Authors: 3
  
  - Claude ([@claude](https://github.com/claude))
  - Jordan Wilke ([@wilke0818](https://github.com/wilke0818))
  - Satrajit Ghosh ([@satra](https://github.com/satra))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
