### PR TITLE
feat(scripts): local PII detection + task compliance pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,11 @@ src/senselab/video/tasks/pose_estimation/models/
 tutorials/audio/tutorial_audio_files/
 tutorials/video/tutorial_images/
 tutorials/video/visualize/
+
+# PII compliance pipeline outputs (scripts/pii_compliance_pipeline.py).
+# These contain participant transcripts, real subject/session IDs and raw PII spans.
+# Treat them as sensitive as the recordings themselves -- never commit them.
+pii_compliance_report.json
+pii_compliance_summary.csv
+flagged_files.txt
+scripts/eval_out/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,12 @@ repos:
   hooks:
   - id: codespell
     args: [--skip=*.ipynb, --ignore-words-list, AER]
+    # scripts/task_reference.json holds the exact sentences participants are asked to
+    # read aloud (Harvard/IEEE lists). Its wording must match what they were given --
+    # "correcting" it would give every recording of that task a permanent word-error-rate
+    # mismatch. It trips codespell on the corpus's own "busses" and on "wit" (cleverness,
+    # not a typo for "with"), so the data file is excluded rather than spell-corrected.
+    exclude: ^scripts/task_reference\.json$
     additional_dependencies:
     - tomli
 - repo: local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,12 @@ pii = [
   # spaCy model itself is not pulled by pip — install it separately:
   # uv run python -m spacy download en_core_web_lg
   "presidio-analyzer>=2.2",
-  "spacy>=3.7"
+  "spacy>=3.7",
+  # Additional engines used by scripts/pii_compliance_pipeline.py. All optional at
+  # run time — the pipeline skips any that are missing and says so — but installing
+  # the extra should give the full detector set.
+  "gliner>=0.2.28",  # HIPAA-identifier detector
+  "wordfreq>=3.1.1"  # word frequencies behind the rare-word / rare-role guards
 ]
 text = [
   "sentence-transformers>=5.1",

--- a/scripts/pii_compliance_pipeline.md
+++ b/scripts/pii_compliance_pipeline.md
@@ -1,0 +1,363 @@
+# PII Detection + Task Compliance Pipeline
+
+`pii_compliance_pipeline.py` screens a folder of `.pt` feature files containing ASR
+transcripts and answers two questions per recording:
+
+1. **Does this recording contain personally identifying information?** — names, ages over 90,
+   dates, locations, contact details, ID numbers, and subtler *quasi-identifiers* that can
+   single a participant out.
+2. **Did the participant actually do the task they were asked to do?** — did they read the
+   passage, sustain the vowel, answer the question, or is the recording empty / off-script?
+
+Each file comes back as **`pass`** (nothing worth a human's time) or **`review`** (a human
+should look at it). **Nothing is ever auto-deleted, auto-redacted, or auto-rejected** — the
+tool builds a triage queue and a person always makes the final call.
+
+**Everything runs locally.** Transcript text is only ever processed in-process (spaCy / GLiNER /
+Presidio) or sent to `localhost` (Ollama). **No transcript text leaves the machine.** The only
+network traffic is a one-time download of model weights and gazetteers — never your data.
+
+This implements the two text-level checks — **(3) PII Detection** and **(4) Task Compliance** —
+from the poster *"An AI Pipeline for Ensuring Audio Data Quality"* (Ng, Wilke, Johnson, Ghosh),
+operationalising the companion proposal *"Unified Framework for PII Detection and Task
+Compliance Verification in Clinical Voice Recordings."*
+
+## Two files, and they travel together
+
+| File | What it is |
+|---|---|
+| `scripts/pii_compliance_pipeline.py` | The pipeline. Self-contained — imports nothing from `senselab`. |
+| `scripts/task_reference.json` | 797 task definitions (Bridge2AI acoustic tasks): task → instructions + expected read-aloud prompts. Drives Tier A/B/C routing. |
+
+The JSON is resolved **relative to the script's own folder**, not your working directory, so the
+pair runs from anywhere. If it is missing the run **stops** rather than quietly skipping every
+scripted-task check — see *Known limitations*.
+
+The script is deliberately standalone: it is a research/ops tool that happens to live in this
+repo, not a `senselab` module, and nothing in the package imports it.
+
+## Install
+
+Only `torch` is strictly required (to read the `.pt` files). Every detection engine is
+optional and degrades gracefully with a printed notice if absent — run with none of them and
+you still get the rule cascade plus task compliance.
+
+```bash
+uv sync --extra pii --extra nlp
+uv run python -m spacy download en_core_web_lg
+```
+
+> **Python version.** spaCy currently publishes wheels for CPython 3.11–3.13 only, so on a
+> **3.14** environment `--extra pii` cannot install spaCy or Presidio. The pipeline still runs
+> — it prints `[spaCy] not importable` / `[Presidio] not importable` and continues on the rule
+> cascade plus GLiNER — but with two of four PII engines silently absent, which will show up as
+> lower name/location recall. **Check those two startup lines before trusting a run's numbers.**
+> Use a 3.12/3.13 environment for the full engine set.
+
+The optional local LLM additionally needs [Ollama](https://ollama.com) running on
+`localhost`, with a model pulled:
+
+```bash
+ollama pull gemma4
+```
+
+## Quickstart
+
+```bash
+uv run python scripts/pii_compliance_pipeline.py --selftest
+```
+
+That runs 127 checks on synthetic data in a temp directory and touches no real files. Then
+point it at some data:
+
+```bash
+uv run python scripts/pii_compliance_pipeline.py /path/to/pt_files
+```
+
+Or set `INPUT_FOLDER` in the CONFIG block and run the file straight from your IDE — see
+*Configuration*. Either way you get a JSON report, a CSV summary, and the flagged file list
+printed at the end.
+
+> **Sanity check before a big run:** set `MAX_FILES = 20` to process just the first 20 files.
+
+## Configuration
+
+All settings live in **one place**: the `MODES` and `SETTINGS` blocks at the top of the script.
+There are no environment variables and no config file. Command-line flags exist for one-off
+overrides, but running the file from an IDE uses exactly what is written in those blocks.
+
+`MODES` is the panel of on/off toggles — engines, LLM, precision vs recall posture, always-flag
+rules. `SETTINGS` holds paths, model names and thresholds. A `NOTES` section below them records
+*why* each default is what it is. Every run prints the modes actually in force, so an IDE run
+without a visible command line still tells you what was on.
+
+The one value you must set is `INPUT_FOLDER`. With no input path the script stops immediately
+and says so — it does not guess, and it does not scan the working directory.
+
+## Modes — pick your operating point first
+
+This is a **triage screen**, and screens have no single "best" setting. Everything below trades
+the same two quantities: **how many real problems you catch** against **how many files a human
+has to open**. Nothing here can auto-reject a recording; only the size and purity of the review
+queue changes.
+
+Numbers are from the study corpus — **894 recordings, 42 genuinely non-compliant**. Treat them
+as the shape of the trade, not as guarantees for your data.
+
+| Mode | How | Catches | Queue | Use when |
+|---|---|---|---|---|
+| **Precision-first** | *(defaults)* | ~12 / 42 | ~13 files, ~92% real | Reviewer time is scarce; you want a short list that's almost all real. |
+| **+ open-task judging** | `ENABLE_LLM = True` | **20 / 42** † | ~100 files, ~20% real † | You need free-speech / story-recall tasks checked at all. Adds ~1–2 s per file. |
+| **+ recall nets** | `HIGH_RECALL = True` | more | larger | Thin open responses and weak PII should surface too. |
+| **+ acoustic with speech** | `RECALL_FLAG_ACOUSTIC = True` | more | much larger | A vowel/breath task that transcribed as words is worth a look. |
+| **Maximum recall** | above, plus `RECALL_ACOUSTIC_MAX_CONTENT_WORDS = -1` | ~41 / 42 | ~620 files (~69%) | A missed problem is unacceptable and you will screen most of the corpus. |
+
+† Measured with a previous model (phi4); the default is now gemma4, so treat those two figures
+as indicative until re-measured. Every other row is unaffected.
+
+**Do not steer by accuracy.** Only ~5% of this corpus is non-compliant, so a screen that flags
+*nothing* scores ~95% and catches nothing.
+
+Two switches are orthogonal to that ladder — combine them with any mode above:
+
+| Switch | Effect |
+|---|---|
+| `COMPLIANCE_ONLY = True` | Skip PII detection entirely. Much faster (no spaCy/GLiNER/Presidio load). PII is reported as **skipped**, not as clean. |
+| `PRECISION_MODE = False` | Drop the PII false-positive guards. Affects PII only, never task compliance. |
+
+## How it works
+
+```mermaid
+flowchart TD
+    A[".pt file<br/>(transcript + optional metadata)"] --> B["Task identified from<br/>filename: task-&lt;Name&gt;"]
+    A --> C[PII DETECTION]
+    B --> D[TASK COMPLIANCE]
+
+    C --> C1["Rule cascade<br/>regex · gazetteers · spaCy NER<br/>honorifics · professions<br/>demographics · rare roles · age&gt;90"]
+    C --> C2["GLiNER<br/>HIPAA identifiers"]
+    C --> C3["Presidio<br/>Microsoft NER"]
+    C --> C4["Local LLM<br/>(optional)"]
+    C1 & C2 & C3 & C4 --> C5["Cross-validate + merge<br/>agreement boosts confidence"]
+    C5 --> C6{"review_worthy?<br/>always-flag rules:<br/>any NAME, any age &gt; 90"}
+
+    D --> D1["Modality → Tier<br/>scripted=A · acoustic=B · open=C"]
+    D1 --> D2["Tier A: word error rate + coverage<br/>Tier B: skipped (needs audio)<br/>Tier C: LLM judge (opt-in)"]
+    D --> D3["Transcript-quality floor<br/>empty / non-speech / filler-only"]
+
+    C6 --> E["Composite score Q, confidence C"]
+    D2 & D3 --> E
+    E --> F{"Decision"}
+    F --> G["pass"]
+    F --> H["review<br/>(human triage queue)"]
+```
+
+### Step 1 — Load the transcript
+
+Each `.pt` is loaded exactly as:
+
+```python
+data = torch.load(path, map_location="cpu", weights_only=False)
+transcription = data["transcription"]
+```
+
+Optional keys are used if present and ignored if absent: `task`/`task_id`/`task_name`,
+`reference_text`/`reference`/`target_text`, `prompt`/`instruction`/`rubric`, `tier`.
+
+### Step 2 — PII detection: several engines in parallel, then cross-validated
+
+| Engine | Role |
+|---|---|
+| **Rule cascade** | regex for structured identifiers (SSN, email, phone, URL, MRN), name/place gazetteers, spaCy NER, honorifics, professions, rare-word MISC, self-disclosed **demographics**, **rare roles**, **age > 90**, and a **combinatorial** sliding window catching re-identification from several weak details together |
+| **GLiNER** | HIPAA-identifier detector (names, dates, phone/fax, email, SSN, MRN, device/vehicle IDs, URLs, IPs, biometrics, geo) |
+| **Presidio** | Microsoft's NER-based PII analyzer |
+| **Local LLM** *(optional)* | Independent judgement on ambiguous spans, plus a "do these details *together* identify someone?" call |
+
+Engines run independently and are then merged. Where they agree, confidence is boosted
+(`cross_validated: true`); where they disagree the span is surfaced rather than silently
+resolved. Categories map onto the annotation-guideline label set: `AGE, NAME, DATE, TIME, ORG,
+IDNUM, LOC, PROFESSION, CONTACT, URL, MISC`.
+
+**The key concept — `review_worthy`.** Every detection is recorded in the JSON report, but a
+file is only *flagged* if it has at least one review-worthy span. This is the main defence
+against drowning reviewers in false alarms. A span is review-worthy when it is a confirmed
+direct identifier, **any** name, **any** age over 90, a cross-validated (≥2 engine)
+`ORG`/`LOC`/`DATE`/ID, a combinatorial cluster, or a quasi-identifier.
+
+#### Always-flagged identifiers
+
+Two types bypass every precision guard and always route to review:
+
+- **Every personal `NAME`** — regardless of whose it is or how weak the signal. A spoken name
+  belongs in the redaction queue, so even a lone common word tagged as a name (`Will`, `May`,
+  `Grant`) flags the file. Expect some NER false positives; that's the intended trade. Names
+  are still **never** auto-failed. Toggle: `FLAG_ALL_NAMES`. This changes how a detected name
+  is *treated*, not whether it is *detected* — a name the NER engines miss can't be flagged.
+- **Any age over 90** — at the top of the age distribution the population thins out enough that
+  age alone can identify someone. (HIPAA Safe Harbor treats *all* ages over 89 as identifiers —
+  set `AGE_REVIEW_OVER_YEARS = 89` for strict alignment.) Catches the phrasings ASR really
+  produces: `95 years old`, `97-year-old`, `aged 102`, spelled-out numbers (`ninety-five`,
+  `a hundred and two`), plus `in her nineties` / `centenarian`. Non-age numbers
+  (`100 percent`, `95 dollars`) are never misread as ages.
+
+#### Quasi-identifiers (the subtle cases)
+
+- **Unusually specific roles.** The motivating real example: a participant mentioning being a
+  *professional figure skater* — ethics judged that "a bit too much info". Distinguishing
+  qualifiers (*professional / Olympic / former …*) and self-described uncommon occupations flag
+  as review-worthy `MISC`. Common jobs ("I'm a teacher", "professional development") are
+  deliberately excluded.
+- **Self-disclosed demographics.** Gender / gender identity (*"I identify as nonbinary"*) and
+  race / ethnicity (*"I'm Black"*) are protected attributes that aid re-identification, so they
+  route to review as `MISC`. Deliberately high-precision: only *self-* or *person-anchored*
+  mentions fire, so *"black coffee"*, *"Chinese food"* and the rainbow passage's *"white light"*
+  all stay clean. Toggle: `DEMOGRAPHIC_PII`.
+
+### Step 3 — Task compliance: identify the task, then route it to the right test
+
+The task is read from the `.pt` **filename's** BIDS-style `task-<Name>` field
+(`sub-…_ses-…_task-Rainbow_features.pt` → `Rainbow`), looked up in `task_reference.json`, and
+classified into a **modality** that determines how — or whether — compliance can be judged from
+text alone:
+
+| Modality | Example tasks | Tier | How it's scored |
+|---|---|---|---|
+| **scripted** | Rainbow passage, Caterpillar, Cape-V, Harvard sentences | **A** | word error rate + reference coverage against the reference prompt |
+| **acoustic** | DDK, max phonation, prolonged vowel, glides, loudness, breath/cough | **B** | **skipped** — non-verbal; a near-empty transcript is *expected* and never failed |
+| **open** | free speech, picture description, story recall, fluency | **C** | LLM judge against the task's instruction (needs `ENABLE_LLM`) |
+
+Matching tolerates case, `-`/`_`/space differences, subtype variants (`diadochokinesis-PA`,
+`cape-V-sentences-3`) and a trailing `-features`. Sibling variants are resolved most-specific
+first, so `Picture-description` never silently pulls in `picture-description-option2`'s prompt.
+
+#### Tier A in detail — "did they read the script?", not "how clean is the ASR?"
+
+Those are very different bars, and conflating them is the single biggest source of false
+positives here. On clinical read-aloud speech a **WER of 0.1–0.4 is the normal cost** of
+dysphonia, accent, room noise and ASR error on a participant who read the script perfectly
+well. Someone who read the *wrong* text lands far higher — 0.6 to over 1.0. So WER is mapped
+onto the compliance score through explicit thresholds rather than used raw:
+
+| Word error rate | Score | Decision |
+|---|---|---|
+| ≤ `TIER_A_WER_REVIEW` (0.50) | 1.0 → 0.9 | **pass** — they read it; the rest is ASR noise |
+| 0.50 → `TIER_A_WER_FAIL` (0.80) | 0.9 → 0.5 | **review** — doubtful read |
+| > 0.80 | 0.5 → 0.0 | hard fail → **review** — wrong text or no read |
+
+Two further guards stop the two ways WER lies about read speech. **Both can only move a file
+towards `pass`** — neither can create a flag, so neither trades away recall:
+
+- **Absolute error floor** (`TIER_A_MIN_WORD_ERRORS`, default 4). WER is a *ratio*, so it
+  punishes short references hardest: three misheard words in a 5-word Cape-V sentence is WER
+  0.6, while the same three errors in the 64-word rainbow passage is WER 0.05. The short
+  sentence is not twelve times less compliant.
+- **Reference coverage** (`TIER_A_COVERAGE_PASS`, **off by default**). WER also counts
+  *insertions*, so someone who reads correctly then adds anything — "sorry, let me start again",
+  an aside to the researcher — can exceed WER 1.0 having said every reference word. Coverage is
+  insertion-blind by construction, so it answers *was the script read?* where WER answers *how
+  cleanly?*. **This guard is an assumption about your annotators, not about ASR**, which is why
+  it ships disabled: in the study corpus reviewers labelled two such recordings `partial`, so
+  enabling it turned two catches into misses while rescuing no false positives. Set it to
+  `0.90` and re-measure to find out which way your own labels go.
+
+Every Tier A result reports `wer`, `coverage`, `word_errors`, `ref_words`, the
+substitution/deletion/insertion split, and which guard (if any) fired — so a reviewer can see
+*why* a read passed or was queued.
+
+> **The reference text has to be right.** Tier A is only as good as `task_reference.json`: if a
+> task's prompt there isn't the text participants were actually given, *every* recording of that
+> task gets a large, near-identical WER and the whole batch lands in the queue. That signature —
+> one task, many subjects, the same WER — means a wrong reference, not non-compliant
+> participants. Check it before retuning thresholds.
+
+**Transcript-quality floor (always on).** Independent of the task, a degenerate transcript means
+the task was never performed — a signal needing no metadata at all:
+
+| Transcript | Outcome |
+|---|---|
+| empty / whitespace only | hard compliance failure → **review** |
+| only non-speech markers (`[noise]`, `(coughing)`) | hard compliance failure → **review** |
+| only filler vocalizations (`uh`, `um`) | hard compliance failure → **review** |
+| 1–2 content words, or mostly filler | **review** (near-degenerate) |
+| real, substantive content | treated as a valid attempt |
+
+This floor is **suppressed for acoustic tasks** (a breath recording has little text by design)
+and wherever a Tier A/C score is authoritative, so those are never falsely failed.
+
+### Step 4 — Score and decide
+
+`Q = Σ wᵢ·cᵢ·sᵢ` (weighted quality) and confidence `C = weighted_mean(c)·(1 − λ·std(c))`, so
+**disagreement between engines widens the review band** rather than being averaged away.
+
+The three-way logic (`pass` / `review` / `fail`) is computed and then **collapsed to two-way:
+`fail` is folded into `review`**, so the final decision is only ever `pass` or `review`. Nothing
+is auto-rejected. The underlying severity is still reported per file:
+
+| Field | Meaning |
+|---|---|
+| `flagged_by_pii` | The file has review-worthy PII. |
+| `pii_confirmed` | Stronger: a confirmed direct identifier (`HARD_GATE_PII_LABELS`, default `{IDNUM, CONTACT, URL}`). |
+| `flagged_by_compliance` | A task / quality / protocol issue. |
+| `compliance_fail` | Stronger: a hard failure (degenerate transcript, missing required step, or score below cutoff). |
+
+A spoken `NAME` is deliberately **not** in `HARD_GATE_PII_LABELS`: it is redactable PII that
+belongs in the review queue, not a reject.
+
+### Optional: interview-style protocol steps
+
+Set `PROTOCOL_SPEC` to a spec JSON and the pipeline additionally checks whether required
+protocol steps happened (consent obtained, identity confirmed, …) via a keyword/phrase
+gazetteer → sequence verification → the LLM on residual steps. This needs curated
+`canonical_phrases`, which is why it lives in an optional file. Most per-recording task
+compliance does not need it.
+
+## Outputs
+
+| Output | Contents |
+|---|---|
+| `OUTPUT_JSON` | Full report: every detection, span offsets, per-tier scores, masked preview, and `summary.flagged_files`. |
+| `OUTPUT_CSV` | One row per recording: decision, Q/C, PII labels, WER/coverage, quality status. |
+| `OUTPUT_FLAGGED_LIST` | Just the flagged file paths, one per line — the plain-text handoff to whatever does review next. |
+
+The flagged list is also printed at the end of every run with a short reason per file
+(`pii:confirmed`, `compliance:fail`, …).
+
+## Known limitations — read before trusting the numbers
+
+**This tool reads text only.** Poster steps needing raw audio — **(1) Audio & Environment
+Quality**, **(2) Unconsented Speaker Detection**, and **Compliance Tier B** — are reported as
+`skipped: requires audio`. That leads to three honest blind spots:
+
+1. **Acoustic-task non-compliance is largely invisible, and this is measurable.** A participant
+   who did too few repetitions, or didn't attempt the task, produces a near-empty transcript —
+   *identical* to a perfectly compliant breath or vowel recording. Meanwhile compliant
+   DDK/counting tasks often *do* transcribe as words. On the study corpus: of ~200 acoustic
+   recordings whose transcript is `too_short`, about 5% are the ones humans marked
+   non-compliant; of ~76 with an `empty` transcript, roughly 1. **No transcript-level feature
+   separates them** — every threshold that catches a miss drags in ~20 compliant files. That is
+   why `RECALL_FLAG_ACOUSTIC` is off by default, and why the fix is audio-level analysis
+   (energy, repetition counting, duration), not better text thresholds.
+2. **"Answered the wrong question" needs the LLM.** Whether a free-speech response actually
+   addresses the prompt is a semantic judgement only the Tier C judge can make. By default open
+   tasks are carried by the transcript-quality floor alone, which sees only *whether* someone
+   spoke. Every open-task miss on the study corpus was a fluent, substantial response that
+   simply didn't do what was asked.
+3. **Subtle contextual PII can be unflaggable.** Some human `context` judgements rest on details
+   no span-level detector can see.
+
+**If the LLM can't be reached** the run prints `[LLM] Ollama not reachable …` or `model … is not
+installed` and continues *without* Tier C — which looks exactly like a fast successful run.
+Check that line. With the LLM on, budget ~1–2 s per file once warm, so tens of minutes for a few
+hundred recordings; pilot with `MAX_FILES` first. The pipeline uses **one** model on purpose:
+Ollama holds a limited set resident, so rotating across several forces a disk reload on nearly
+every call, and that reload tax dominates runtime.
+
+## Data safety
+
+- The pipeline only ever **reads** `.pt` files. Masked previews live in the report and are never
+  written back; nothing is auto-redacted.
+- **Outputs are sensitive.** The JSON and CSV contain real subject/session IDs and PII-derived
+  content — treat them as sensitive as the recordings and keep them out of version control.
+- **No participant paths in source.** `INPUT_FOLDER` ships empty; the script stops rather than
+  guessing.
+- **`--selftest` fabricates its own synthetic data** in a temp directory, so the tool can be
+  verified without touching real recordings.

--- a/scripts/pii_compliance_pipeline.md
+++ b/scripts/pii_compliance_pipeline.md
@@ -67,7 +67,11 @@ ollama pull gemma4
 uv run python scripts/pii_compliance_pipeline.py --selftest
 ```
 
-That runs 127 checks on synthetic data in a temp directory and touches no real files. Then
+That runs 137 checks on synthetic data in a temp directory. It is **hermetic**: every PII
+engine is forced off, the name gazetteer is stubbed and the LLM is disabled, so it makes no
+network calls and its verdict does not depend on which optional packages are installed.
+`--selftest-full` instead exercises the real spaCy/GLiNER/Presidio load paths — useful, but
+it downloads model weights and its result varies with your environment. Then
 point it at some data:
 
 ```bash
@@ -106,7 +110,7 @@ as the shape of the trade, not as guarantees for your data.
 
 | Mode | How | Catches | Queue | Use when |
 |---|---|---|---|---|
-| **Precision-first** | *(defaults)* | ~12 / 42 | ~13 files, ~92% real | Reviewer time is scarce; you want a short list that's almost all real. |
+| **Precision-first** *(default)* | *(no changes)* | ~12 / 42 | ~13 files, ~92% real | Reviewer time is scarce; you want a short list that's almost all real. |
 | **+ open-task judging** | `ENABLE_LLM = True` | **20 / 42** † | ~100 files, ~20% real † | You need free-speech / story-recall tasks checked at all. Adds ~1–2 s per file. |
 | **+ recall nets** | `HIGH_RECALL = True` | more | larger | Thin open responses and weak PII should surface too. |
 | **+ acoustic with speech** | `RECALL_FLAG_ACOUSTIC = True` | more | much larger | A vowel/breath task that transcribed as words is worth a look. |
@@ -353,10 +357,17 @@ every call, and that reload tax dominates runtime.
 
 ## Data safety
 
-- The pipeline only ever **reads** `.pt` files. Masked previews live in the report and are never
-  written back; nothing is auto-redacted.
+- The pipeline only ever **reads** `.pt` files, and reads them with torch's **safe
+  unpickler** (`weights_only=True`), so a malicious or corrupted `.pt` cannot execute code
+  during a scan. `TRUST_INPUT_PICKLES = True` opts out for files you produced yourself.
+  Masked previews live in the report and are never written back; nothing is auto-redacted.
 - **Outputs are sensitive.** The JSON and CSV contain real subject/session IDs and PII-derived
-  content — treat them as sensitive as the recordings and keep them out of version control.
+  content — treat them as sensitive as the recordings. A bare output filename is written
+  **beside the input data**, never into the working directory, so running from a repo
+  checkout cannot drop them into the source tree; all three default names are also in
+  `.gitignore`. Full transcripts are withheld unless `INCLUDE_TRANSCRIPTS = True`: the
+  report carries detected spans and a masked preview, but a clean file's transcript is not
+  copied verbatim into a document that gets circulated.
 - **No participant paths in source.** `INPUT_FOLDER` ships empty; the script stops rather than
   guessing.
 - **`--selftest` fabricates its own synthetic data** in a temp directory, so the tool can be

--- a/scripts/pii_compliance_pipeline.py
+++ b/scripts/pii_compliance_pipeline.py
@@ -90,6 +90,7 @@ data-safety notes. Read the "Modes" section before a first real run.
 
 import argparse
 import csv
+import inspect
 import json
 import re
 import subprocess
@@ -131,7 +132,14 @@ def _importable(module_name, timeout=60):
 
 # ---- What to run ------------------------------------------------------------
 SELFTEST = False               # run the built-in self-test on synthetic data, not a real scan
-COMPLIANCE_ONLY = False        # skip PII detection entirely: task compliance only (much faster)
+COMPLIANCE_ONLY = False
+# .pt files are read with torch's SAFE unpickler (weights_only=True). Flip this only for
+# files you produced yourself and trust: it permits arbitrary code execution on load.
+TRUST_INPUT_PICKLES = False
+# Include each file's full transcript in the JSON report. OFF: reports are circulated to
+# reviewers, and a transcript with no detected PII would otherwise be copied verbatim.
+# Detected spans and a masked preview are always included regardless.
+INCLUDE_TRANSCRIPTS = False        # skip PII detection entirely: task compliance only (much faster)
 RECURSIVE = False              # also scan sub-folders of INPUT_FOLDER
 
 # ---- PII detection engines (each is skipped with a notice if not installed) --
@@ -145,7 +153,7 @@ ENABLE_PRESIDIO = True         # Microsoft Presidio NER
 # DOUBLES the catch rate, at roughly 10x the review queue, and it is slow (~1-2s per
 # file once warm). Off is a deliberate precision choice, not a capability gap.
 # --> NOTES [LLM] at the end of this block for the full tradeoff.
-ENABLE_LLM = True
+ENABLE_LLM = False
 ENABLE_LLM_COMPLIANCE_JUDGE = True   # also judge BORDERLINE transcripts; needs ENABLE_LLM
 
 # ---- Posture: precision vs recall -------------------------------------------
@@ -174,8 +182,8 @@ COMBINATORIAL_REQUIRE_CATEGORY_DIVERSITY = True  # combinatorial risk needs 2 DI
 # ---- Paths. INPUT_FOLDER is the one value you MUST set ----------------------
 # With no input folder here (and none on the command line) the run stops immediately
 # and says so: it does not guess, and it does not scan the working directory.
-INPUT_FOLDER = "/Users/varunthvar1/Desktop/sample_data"   # >>> SET THIS <<< folder of .pt files
-MAX_FILES = 10                 # cap the number of files, or None for all. Handy for a pilot run.
+INPUT_FOLDER = ""                                # >>> SET THIS <<< folder of .pt files
+MAX_FILES = None               # cap the number of files, or None for ALL. Set e.g. 20 to pilot.
 # The task table this pipeline checks every .pt against, shipped NEXT TO this script.
 # Keep the two together. A relative path resolves against the SCRIPT's folder, never
 # the working directory. Missing -> the run STOPS. --> NOTES [TASK REFERENCE]
@@ -288,6 +296,11 @@ TIER_A_COVERAGE_PASS = 1.1     # 1.1 = the coverage guard is OFF. --> NOTES [TIE
 #   is worth against a missed problem -- a per-study decision, not a default. Off
 #   gives a small, dense, high-precision queue; on gives ~2x the recall for ~10x the
 #   queue.
+#   The LLM can lower a score into review but never rescue a HARD fail. That holds for
+#   Tier C too: a structurally degenerate transcript (empty, non-speech only) keeps its
+#   hard fail even when Tier C scored the file, because an empty recording is broken
+#   regardless of what a judge says about it. Only ACOUSTIC tasks suppress that hard
+#   fail, since there a near-empty transcript is the compliant outcome.
 #   ENABLE_LLM_COMPLIANCE_JUDGE asks the model, task-agnostically, whether a
 #   BORDERLINE transcript reads like a completed spoken response. It runs only on
 #   files already in the review band -- never on every file, never on acoustic tasks,
@@ -313,6 +326,11 @@ TIER_A_COVERAGE_PASS = 1.1     # 1.1 = the coverage guard is OFF. --> NOTES [TIE
 #   so flagging acoustic is high-false-positive for almost no recall.
 #   RECALL_FLAG_ALL_OPEN is the no-LLM fallback for "answered the wrong question",
 #   which otherwise needs ENABLE_LLM. More false positives.
+#   High recall widens what reaches REVIEW, never what reaches CONFIRMED. Two things it
+#   deliberately does NOT relax: structured-identifier format validation (a "device
+#   identifier" with no digits is wrong in either posture) and the cross-engine
+#   corroboration requirement for the hard gate. Both would otherwise let a single
+#   hallucinated span auto-confirm as direct PII.
 #
 # [NAMES]  FLAG_ALL_NAMES
 #   Every detected personal name is review-worthy, no matter whose it is or how weak
@@ -464,11 +482,25 @@ NAME_CONTEXT_RE = re.compile(
 
 
 def _zipf(word):
+    """Zipf word frequency, or None when wordfreq is unavailable.
+
+    None is NOT 0.0. 0.0 means "measured, maximally rare", and every caller reads
+    rarity as evidence FOR a PII hit -- so returning 0.0 on a missing dependency
+    silently INVERTS the precision guards instead of relaxing them: a common-word
+    NAME false positive becomes hard-gate eligible, and the soft rare-role qualifier
+    fires on every phrase. Callers must treat None as "unknown" and take their
+    precision-safe branch."""
     try:
         from wordfreq import zipf_frequency
-        return zipf_frequency(word.lower(), "en")
     except Exception:  # noqa: BLE001
-        return 0.0     # no wordfreq -> don't suppress (favor recall)
+        return None
+    return zipf_frequency(word.lower(), "en")
+
+
+def _wordfreq_available():
+    """Whether word-frequency data is installed at all (wordfreq ships in the `pii`
+    extra). Guards that need frequency evidence must not fire without it."""
+    return _zipf("the") is not None
 
 
 def _name_hard_gate_eligible(span_text, start, source_text, methods, engines, score):
@@ -481,7 +513,10 @@ def _name_hard_gate_eligible(span_text, start, source_text, methods, engines, sc
     corroborated = len(engines) >= 2
     preceding = source_text[max(0, start - 30):start]
     has_context = bool(NAME_CONTEXT_RE.search(preceding))
-    common = (not multitoken) and _zipf(span_text) >= NAME_COMMON_WORD_ZIPF
+    # Unknown frequency (no wordfreq) is treated as "common", i.e. the precision-safe
+    # side: a lone single token with no other name signal stays out of the hard gate.
+    z = _zipf(span_text)
+    common = (not multitoken) and (z is None or z >= NAME_COMMON_WORD_ZIPF)
     if common and not (has_context or precise or multitoken):
         return False
     return multitoken or has_context or precise or corroborated or score >= 0.9
@@ -506,9 +541,13 @@ def _valid_structured_identifier(text, category):
 
 
 def postprocess_entities(entities, source_text):
-    """Apply the precision guards to a flat list of engine detections."""
-    if not PRECISION_MODE:
-        return entities
+    """Apply the precision guards to a flat list of engine detections.
+
+    Structured-identifier FORMAT VALIDATION is a correctness check, not a
+    precision/recall tradeoff: a "device identifier" containing no digits is wrong in
+    either posture, and letting it through in high-recall mode promotes a known
+    hallucination class straight to the confirmed/hard-gate tier. It therefore runs
+    always. PRECISION_MODE governs only the confidence-threshold guard below it."""
     out = []
     for e in entities:
         span_text = source_text[e["start"]:e["end"]]
@@ -523,9 +562,11 @@ def postprocess_entities(entities, source_text):
         if cat in ("IDNUM", "CONTACT", "URL") and not _valid_structured_identifier(span_text, cat):
             continue
         # 3) Low-confidence soft detections dropped (pattern/list hits are exempt).
-        method_root = e["method"].split(":")[0].split("+")[0]
-        if e["confidence"] < MIN_ENGINE_CONFIDENCE and method_root not in _PATTERN_METHODS:
-            continue
+        #    This one IS the precision/recall knob, so high-recall keeps them.
+        if PRECISION_MODE:
+            method_root = e["method"].split(":")[0].split("+")[0]
+            if e["confidence"] < MIN_ENGINE_CONFIDENCE and method_root not in _PATTERN_METHODS:
+                continue
         out.append(e)
     return out
 
@@ -731,7 +772,8 @@ _ROLE_INTRO_RE = re.compile(
 def _phrase_min_zipf(phrase):
     """Minimum word-frequency across a role phrase (a rare word anywhere signals
     specificity). Returns None if no word is known to wordfreq."""
-    zs = [z for z in (_zipf(t) for t in re.findall(r"[a-z'-]+", phrase.lower())) if z > 0.0]
+    zs = [z for z in (_zipf(t) for t in re.findall(r"[a-z\'-]+", phrase.lower()))
+          if z is not None and z > 0.0]
     return min(zs) if zs else None
 
 
@@ -744,7 +786,14 @@ def rare_role_scan(text):
     ents = []
     for m in _STRONG_QUALIFIER_RE.finditer(text):
         ents.append(_entity(m.start(), m.end(), "MISC", 0.6, "rare_role"))
+    # The soft qualifier ("professional <x>") is only discriminating WITH frequency
+    # data -- it is what separates "professional figure skater" from "professional
+    # development". Without wordfreq it would fire on every match, so it is skipped:
+    # a missing optional dependency must not manufacture flags.
+    have_freq = _wordfreq_available()
     for m in _SOFT_QUALIFIER_RE.finditer(text):
+        if not have_freq:
+            continue
         z = _phrase_min_zipf(m.group(2))
         if z is None or z <= RARE_ROLE_QUALIFIER_ZIPF_MAX:  # skip 'professional development'
             ents.append(_entity(m.start(), m.end(), "MISC", 0.55, "rare_role"))
@@ -1292,7 +1341,10 @@ def merge_pii(entities, text):
         # URL regex), OR corroborated by >=2 independent engines, OR very high
         # confidence, OR a name via honorific/gazetteer. A lone low-confidence model
         # guess is NOT auto-failed; it still surfaces as needs_review (recall kept).
-        if not (HARD_GATE_REQUIRE_CORROBORATION and PRECISION_MODE):
+        # Deliberately independent of PRECISION_MODE: high recall widens what reaches
+        # REVIEW, never what reaches CONFIRMED. Tying the two together let a single
+        # uncorroborated engine guess auto-confirm as hard-gate PII in recall mode.
+        if not HARD_GATE_REQUIRE_CORROBORATION:
             hard_gate_eligible = is_strong
         elif not is_strong:
             hard_gate_eligible = False
@@ -1534,9 +1586,17 @@ _SCRIPTED_TASK_PATTERNS = (
 
 
 def _norm_task(s):
-    """Alphanumeric-only, lowercased -- so 'Cape-V-Sentences', 'cape_v_sentences' and
-    'cape-V-sentences-(v2)-3' all normalize compatibly for matching."""
-    return re.sub(r"[^a-z0-9]", "", (s or "").lower())
+    """Lowercased, with every run of separators COLLAPSED to a single '-' -- so
+    'Cape-V-Sentences', 'cape_v_sentences' and 'cape-V-sentences-(v2)-3' all normalize
+    compatibly for matching.
+
+    Separators are collapsed, NOT deleted. Deleting them destroys the only boundary
+    between a task number and the next field, so 'list-7-3' and 'list-73-1' both
+    normalize to strings sharing a prefix, and the prefix fallback in
+    _resolve_reference_keys then silently scores a recording against a SIBLING task's
+    reference text -- reporting a compliant participant as having read the wrong
+    script. Keeping the delimiter lets that fallback require a segment boundary."""
+    return re.sub(r"[^a-z0-9]+", "-", (s or "").lower()).strip("-")
 
 
 def task_key_from_filename(filename):
@@ -1603,13 +1663,16 @@ class ComplianceChecker:
         if exact:
             return exact, False
         # Keys that are a prefix of the token -> token is the more specific name.
-        prefixes = [k for k, nk in self._ref_index.items() if nk and nt.startswith(nk)]
+        # The trailing '-' is load-bearing: it forces the match to end on a segment
+        # boundary, so key 'list-7-3' is NOT treated as a prefix of token 'list-73-1'.
+        prefixes = [k for k, nk in self._ref_index.items() if nk and nt.startswith(nk + "-")]
         if prefixes:
             longest = max(len(self._ref_index[k]) for k in prefixes)
             best = [k for k in prefixes if len(self._ref_index[k]) == longest]
             return best, len(best) > 1
         # Token is a prefix of these keys -> genuinely ambiguous between variants.
-        supersets = [k for k, nk in self._ref_index.items() if nk and nk.startswith(nt)]
+        # Same boundary condition, for the same reason, in the other direction.
+        supersets = [k for k, nk in self._ref_index.items() if nk and nk.startswith(nt + "-")]
         return supersets, len(supersets) > 1
 
     # ---- Resolve the task + MODALITY for a file (filename first, then .pt metadata) ----
@@ -1673,16 +1736,26 @@ class ComplianceChecker:
         return ctx
 
     # ---- Transcript quality (gated by modality) ----
-    def check_quality(self, transcript, suppress=False):
+    def check_quality(self, transcript, suppress=False, keep_hard_fail=True):
         """Deterministic transcript-quality signal. When `suppress` is True (acoustic
         tasks, or tasks whose Tier A/C score is the authority), the raw status is still
         reported but it does NOT contribute a compliance score -- so a near-empty
         transcript for a prolonged-vowel/breath task is never counted as a failure.
         Otherwise it is the compliance signal (a degenerate transcript => failure),
-        optionally corroborated by the LLM on borderline files."""
+        optionally corroborated by the LLM on borderline files.
+
+        `keep_hard_fail` separates the two reasons for suppressing. Suppressing the
+        SCORE is right in both cases, but a structurally degenerate transcript (empty,
+        non-speech only) is a broken recording, not a modality artifact, so the HARD
+        FAIL must still survive when the suppression came from a Tier A/C score being
+        authoritative -- otherwise an LLM "completed: true" on an empty transcript
+        silently rescues a hard fail, which the NOTES explicitly promise it cannot do.
+        Only acoustic tasks pass keep_hard_fail=False, because there a near-empty
+        transcript genuinely is the compliant outcome."""
         q = assess_transcript_quality(transcript)
         if suppress:
-            return dict(q, applies=False, score=None, confidence=None, hard_fail=False,
+            return dict(q, applies=False, score=None, confidence=None,
+                        hard_fail=bool(q["hard_fail"] and keep_hard_fail),
                         raw_status=q["status"])
         q = dict(q, applies=True)
         if (ENABLE_LLM_COMPLIANCE_JUDGE and self.llm and self.llm.active
@@ -1920,10 +1993,14 @@ def _compliance_check_score(quality, task_result, step_results):
     # Quality contributes only when it "applies" (score is not None). For acoustic
     # tasks, or tasks whose Tier A/C score is authoritative, quality is suppressed
     # (score None) so a naturally near-empty transcript is not counted as a failure.
-    if quality is not None and quality.get("score") is not None:
-        scores.append(quality["score"])
-        confs.append(quality["confidence"])
+    # The hard fail is read UNCONDITIONALLY, not only when quality contributes a score.
+    # A suppressed quality signal still carries "this transcript is structurally empty",
+    # and that must reach the decision even though it adds no soft score.
+    if quality is not None:
         hard_fail = hard_fail or bool(quality.get("hard_fail"))
+        if quality.get("score") is not None:
+            scores.append(quality["score"])
+            confs.append(quality["confidence"])
     if task_result and task_result.get("score") is not None:
         scores.append(task_result["score"])
         confs.append(task_result.get("confidence") or 0.5)
@@ -2179,8 +2256,13 @@ class Pipeline:
         # Transcript quality is the compliance signal ONLY for open/unknown tasks with no
         # tier score. Acoustic tasks (a near-empty transcript is expected) and tasks whose
         # Tier A/C score is authoritative suppress it, so they are not falsely failed.
-        suppress_quality = (modality == "acoustic") or task_has_score
-        quality = self.compliance.check_quality(transcript, suppress=suppress_quality)
+        acoustic = (modality == "acoustic")
+        suppress_quality = acoustic or task_has_score
+        # keep_hard_fail=False ONLY for acoustic: there a near-empty transcript is the
+        # compliant outcome. When the suppression is merely "Tier A/C scored this file",
+        # a degenerate transcript is still a broken recording and must keep its hard fail.
+        quality = self.compliance.check_quality(transcript, suppress=suppress_quality,
+                                                keep_hard_fail=not acoustic)
         # High-recall: surface likely non-compliance the text-level tiers miss
         # (unexpected speech on acoustic tasks; thin open responses) as REVIEW.
         # Applied even when Tier C DID score the file: the recall net exists to catch what
@@ -2208,7 +2290,12 @@ class Pipeline:
                            "task": task_result, "protocol_steps": step_results},
             "interactions": interactions,
             "composite": composite,
-            "masked_preview": build_masked_preview(transcript, pii) if pii else transcript,
+            # Always the MASKED form -- uniform in both branches, so the field never
+            # silently becomes the raw transcript. With no detected PII there is nothing
+            # to mask, so the preview would BE the transcript; that case is withheld
+            # unless INCLUDE_TRANSCRIPTS says otherwise.
+            "masked_preview": (build_masked_preview(transcript, pii or [])
+                               if (pii or INCLUDE_TRANSCRIPTS) else None),
         }
 
 
@@ -2236,10 +2323,24 @@ class _NullLLM:
 # .pt loading + folder processing
 # ---------------------------------------------------------------------------
 def load_pt(path):
-    """Returns (transcription, task_meta, error). transcription/error mutually exclusive."""
+    """Returns (transcription, task_meta, error). transcription/error mutually exclusive.
+
+    Loaded with weights_only=True (torch >= 2.6's default). This is a triage tool
+    pointed at folders of .pt files produced elsewhere, so unpickling arbitrary objects
+    would mean code execution during a compliance scan. Everything the pipeline reads --
+    the transcription string and string metadata -- loads fine under the safe reader.
+    TRUST_INPUT_PICKLES opts back out explicitly, with a warning, for corpora whose
+    files carry objects the restricted unpickler refuses."""
     try:
-        data = torch.load(path, map_location="cpu", weights_only=False)
+        data = torch.load(path, map_location="cpu",
+                          weights_only=not TRUST_INPUT_PICKLES)
     except Exception as e:  # noqa: BLE001
+        if not TRUST_INPUT_PICKLES:
+            return None, None, (
+                f"failed to load .pt file: {e}. If this file is TRUSTED and the error "
+                f"mentions weights_only / UnpicklingError, set TRUST_INPUT_PICKLES = True "
+                f"in the CONFIG block (this allows arbitrary code execution on load -- "
+                f"only do it for files you produced yourself)")
         return None, None, f"failed to load .pt file: {e}"
     if not isinstance(data, dict) or "transcription" not in data:
         return None, None, "no 'transcription' key found in loaded object"
@@ -2265,6 +2366,7 @@ def process_file(path, pipeline):
 
 def process_folder(folder, pipeline, recursive, max_files):
     files = sorted(folder.glob("**/*.pt" if recursive else "*.pt"))
+    files_available = len(files)
     if max_files:
         files = files[:max_files]
     if not files:
@@ -2290,10 +2392,16 @@ def process_folder(folder, pipeline, recursive, max_files):
             k = key_fn(r)
             out[k] = out.get(k, 0) + 1
         return out
+    # NOTE: there is no "fail" count. composite_score collapses FAIL into REVIEW before
+    # returning, so no record can carry decision == "fail" -- a `fail` key would be
+    # structurally always 0 and would read as "no hard failures" on a corpus full of
+    # them. The pre-collapse severity is reported by hard_gate/pii_confirmed/
+    # compliance_fail below, which are the real signals.
     summary = {
         "pass": sum(1 for r in results if r["decision"] == "pass"),
         "review": sum(1 for r in results if r["decision"] == "review"),
-        "fail": sum(1 for r in results if r["decision"] == "fail"),
+        "hard_gate": sum(1 for r in results if r["composite"]["pii_confirmed"]
+                         or r["composite"]["compliance_fail"]),
         # where the flags come from (these overlap when a file has both)
         "flagged_by_pii": sum(1 for r in results if r["composite"]["flagged_by_pii"]),
         "flagged_by_compliance": sum(1 for r in results if r["composite"]["flagged_by_compliance"]),
@@ -2314,6 +2422,10 @@ def process_folder(folder, pipeline, recursive, max_files):
             if (r["compliance"].get("task_context") or {}).get("ambiguous_match")
             and r.get("task_id")}),
         "errors": len(errors),
+        # A truncated run must say so IN THE ARTIFACT. A JSON read six months later has
+        # no console scrollback, and a partial screen otherwise reads as a complete one.
+        "truncated": bool(max_files and files_available > max_files),
+        "files_available": files_available,
         # THE DELIVERABLE: which files a human actually has to look at. Everything
         # above is a count; this is the list. A file is flagged when its decision is
         # anything other than "pass" -- i.e. PII worth redacting, a compliance
@@ -2400,8 +2512,10 @@ def print_summary(report):
     print("\n--- Summary ---")
     print(f"Files processed: {report['num_files']}")
     print(f"  pass:                  {s['pass']}")
-    print(f"  review:                {s['review']}  (soft gate -> human review)")
-    print(f"  fail:                  {s['fail']}  (hard gate)")
+    print(f"  review:                {s['review']}  (of which hard-gate: {s['hard_gate']})")
+    if s.get("truncated"):
+        print(f"  !! TRUNCATED: only {report['num_files']} of {s['files_available']} .pt "
+              f"file(s) were scanned (MAX_FILES). This is a partial screen.")
     print("  -- flag breakdown (a file can be flagged by both) --")
     print(f"  flagged_by_pii:        {s['flagged_by_pii']}   (of which confirmed hard-gate PII: {s['pii_confirmed']})")
     print(f"  flagged_by_compliance: {s['flagged_by_compliance']}   (of which hard compliance fail: {s['compliance_fail']})")
@@ -2517,8 +2631,32 @@ def load_task_reference(path):
 # ---------------------------------------------------------------------------
 # Self-test (synthetic data only -- never reads real transcripts)
 # ---------------------------------------------------------------------------
-def run_selftest(args):
+_HERMETIC_NAMES = {
+    "john", "smith", "sarah", "connor", "jane", "will", "may", "grant", "mark",
+    "james", "mary", "robert", "patricia", "michael", "linda", "david", "susan",
+}
+
+
+def run_selftest(args, full=False):
+    """Synthetic-data self-test.
+
+    HERMETIC by default: every PII engine is forced off and the name gazetteer is
+    stubbed, so the run makes NO network calls (no nltk.download, no HuggingFace weight
+    pull) and its verdict does not depend on which optional packages happen to be
+    installed. That determinism is what lets it be wrapped as a normal test -- several
+    Part A assertions (e.g. "clean.pt has no PII") only hold with the model engines
+    absent, so with engines on the same command would legitimately pass on one
+    interpreter and fail on another.
+
+    `full=True` (--selftest-full) keeps the engines as configured, exercising the real
+    spaCy/GLiNER/Presidio load paths. That variant downloads model weights and gazetteer
+    data on first run and is deliberately NOT hermetic."""
     print("Running self-test on SYNTHETIC .pt files (no real data touched)...")
+    if full:
+        print("  [full] engines left as configured -- NOT hermetic (may download weights).")
+    else:
+        print("  [hermetic] all PII engines forced off, gazetteer stubbed, no network.")
+        args.enable_spacy = args.enable_gliner = args.enable_presidio = False
     checks = {}
 
     # ---- Part A: ZERO-CONFIG (no protocol spec). Task info comes from the .pt. ----
@@ -2714,11 +2852,17 @@ def run_selftest(args):
     skater = merge_pii(rare_role_scan(skater_txt), skater_txt)
     dev_txt = "we scheduled some professional development this week"
     dev = merge_pii(rare_role_scan(dev_txt), dev_txt)
-    checks["C: 'professional figure skater' -> review-worthy MISC (not confirmed)"] = (
-        len(skater) >= 1 and skater[0].get("review_worthy") is True
-        and skater[0].get("confirmed") is False
-        and composite_score(skater, None, None, q_ok)["decision"] == "review"
-        and composite_score(skater, None, None, q_ok)["flagged_by_pii"] is True)
+    # Frequency-dependent: distinguishing "professional figure skater" from
+    # "professional development" IS the wordfreq lookup, so this can only be asserted
+    # where wordfreq is installed. The negative case below holds either way.
+    if _wordfreq_available():
+        checks["C: 'professional figure skater' -> review-worthy MISC (not confirmed)"] = (
+            len(skater) >= 1 and skater[0].get("review_worthy") is True
+            and skater[0].get("confirmed") is False
+            and composite_score(skater, None, None, q_ok)["decision"] == "review"
+            and composite_score(skater, None, None, q_ok)["flagged_by_pii"] is True)
+    else:
+        print("  [skip] rare-role frequency checks: wordfreq not installed")
     checks["C: 'professional development' -> not flagged (common role word)"] = (len(dev) == 0)
 
     # ---- Demographic quasi-identifiers: self-disclosed gender & race -> REVIEW ----
@@ -3176,6 +3320,69 @@ def run_selftest(args):
     checks["J: --flagged-list writes one flagged path per line"] = (
         lines == [f["file"] for f in flagged] and len(lines) == len(flagged))
 
+    # ---- Part K: regressions for the review findings (#542 review, section 1) ----
+    print("\n[Part K] Regressions for reported defects.")
+
+    # 1.1 -- a Tier C score must not let an empty transcript pass as compliant.
+    q_sup_open = ComplianceChecker({}, _NullLLM()).check_quality("", suppress=True,
+                                                                keep_hard_fail=True)
+    tier_c_ok = {"tier": "C", "score": 0.95, "confidence": 0.9, "completed": True}
+    cx_11 = composite_score([], tier_c_ok, None, q_sup_open)
+    checks["K1.1: an LLM 'completed' verdict cannot rescue an EMPTY transcript"] = (
+        q_sup_open["hard_fail"] is True and cx_11["compliance_fail"] is True
+        and cx_11["decision"] == "review")
+    q_sup_ac = ComplianceChecker({}, _NullLLM()).check_quality("", suppress=True,
+                                                              keep_hard_fail=False)
+    checks["K1.1: ...but an ACOUSTIC empty transcript still never hard-fails"] = (
+        q_sup_ac["hard_fail"] is False
+        and composite_score([], {"tier": "B", "score": None, "confidence": None},
+                            None, q_sup_ac)["compliance_fail"] is False)
+
+    # 1.2 -- a sibling variant must not borrow another task's reference text.
+    cc_k = ComplianceChecker({}, _NullLLM(), task_reference={
+        "harvard-sentences-list-7-3": {"instructions": "Read.", "prompts": ["He ran half way."]},
+        "cape-V-sentences-1": {"instructions": "Read.", "prompts": ["The blue spot."]},
+        "rainbow": {"instructions": "Read.", "prompts": ["When the sunlight strikes"]}})
+    checks["K1.2: 'list-73-1' does NOT match key 'list-7-3' (segment boundary)"] = (
+        cc_k._resolve_reference_keys("Harvard-Sentences-List-73-1") == ([], False))
+    checks["K1.2: 'cape-V-sentences-11' does NOT match 'cape-V-sentences-1'"] = (
+        cc_k._resolve_reference_keys("Cape-V-sentences-11") == ([], False))
+    ctx_k = cc_k.resolve_task_context("sub-1_task-Harvard-Sentences-List-73-1_features.pt", {})
+    checks["K1.2: an unknown sibling reports reference_missing, not a wrong match"] = (
+        ctx_k["modality"] == "scripted" and ctx_k["reference_missing"] is True
+        and ctx_k["reference_texts"] == [])
+    checks["K1.2: genuine prefix matches still resolve (Rainbow-Passage -> rainbow)"] = (
+        cc_k._resolve_reference_keys("Rainbow-Passage") == (["rainbow"], False))
+
+    # 1.3 -- the missing-wordfreq sentinel must be distinguishable from "maximally rare".
+    # (either wordfreq is present and "the" is a real positive frequency, or it is
+    # absent and the sentinel is None -- 0.0, the old sentinel, is neither.)
+    checks["K1.3: _zipf sentinel is None, never 0.0 ('maximally rare')"] = (
+        _zipf("the") is None or _zipf("the") > 0.0)
+
+    # 1.4 -- high recall widens REVIEW, never CONFIRMED.
+    _sv_hr, _sv_pm = HIGH_RECALL, PRECISION_MODE
+    _mod.HIGH_RECALL, _mod.PRECISION_MODE = True, False
+    try:
+        junk = postprocess_entities([_entity(0, 5, "IDNUM", 0.8, "gliner")], "cough here")
+        merged_junk = merge_pii(junk, "cough here")
+        cx_14 = composite_score(merged_junk, None, None, q_ok)
+    finally:
+        _mod.HIGH_RECALL, _mod.PRECISION_MODE = _sv_hr, _sv_pm
+    checks["K1.4: format validation still runs in high-recall (word-only IDNUM dropped)"] = (
+        junk == [])
+    checks["K1.4: high-recall never manufactures confirmed PII"] = (
+        cx_14["pii_confirmed"] is False)
+
+    # 1.10 -- the summary must not carry a structurally-impossible 'fail' counter.
+    checks["K1.10: composite decision is two-way; no record can ever be 'fail'"] = (
+        composite_score([], None, None, q_empty)["decision"] == "review"
+        and composite_score([], None, None, q_ok)["decision"] == "pass")
+
+    # 1.12 -- --flag-all-pii must not be silently inert.
+    checks["K1.12: the stray-recall-flag interlock covers --flag-all-pii"] = (
+        "--flag-all-pii" in inspect.getsource(_apply_runtime_config))
+
     print()
     for label, ok in checks.items():
         print(f"  [{'PASS' if ok else 'FAIL'}] {label}")
@@ -3297,7 +3504,14 @@ def build_args():
                         "Presidio load, no PII scan). Much faster. PII fields are reported as "
                         "skipped rather than clean, and the composite score reflects "
                         "compliance alone.")
-    p.add_argument("--selftest", action="store_true", default=SELFTEST)
+    p.add_argument("--selftest", action="store_true", default=SELFTEST,
+                   help="Hermetic synthetic self-test: engines forced off, gazetteer "
+                        "stubbed, no network, no LLM. Deterministic.")
+    p.add_argument("--selftest-full", dest="selftest_full", action="store_true",
+                   help="Self-test with the PII engines left as configured, exercising "
+                        "the real spaCy/GLiNER/Presidio load paths. NOT hermetic: it may "
+                        "download model weights, and its result depends on which optional "
+                        "packages are installed.")
     return p.parse_args()
 
 
@@ -3333,7 +3547,8 @@ def _apply_runtime_config(args):
         # their own they do nothing. Silently ignoring them would look like "I turned
         # that on and it caught nothing" -- say so instead.
         stray = [f for f, on in (("--flag-acoustic", RECALL_FLAG_ACOUSTIC),
-                                 ("--flag-all-open", RECALL_FLAG_ALL_OPEN)) if on]
+                                 ("--flag-all-open", RECALL_FLAG_ALL_OPEN),
+                                 ("--flag-all-pii", RECALL_FLAG_ALL_PII)) if on]
         if stray:
             print(f"  [note] {', '.join(stray)} has no effect without --high-recall "
                   f"(the recall nets run inside high-recall mode); enabling it now.")
@@ -3387,6 +3602,8 @@ def print_active_modes(args):
 
 def main():
     args = build_args()
+    if getattr(args, "selftest_full", False):
+        args.selftest = True
     if args.selftest:
         # The self-test must stay hermetic, fast and deterministic: synthetic data, no
         # network, no model server. Force the LLM off regardless of the defaults so a
@@ -3394,7 +3611,18 @@ def main():
         args.enable_llm = args.llm_compliance = False
     _apply_runtime_config(args)
     if args.selftest:
-        run_selftest(args)
+        if getattr(args, "selftest_full", False):
+            run_selftest(args, full=True)
+            return
+        # Stub the gazetteer loader: the real one calls nltk.download() on first use,
+        # which is a network call and would make the "hermetic" claim false.
+        mod = sys.modules[__name__]
+        real_gazetteer = mod.load_name_gazetteer
+        mod.load_name_gazetteer = lambda: set(_HERMETIC_NAMES)
+        try:
+            run_selftest(args)
+        finally:
+            mod.load_name_gazetteer = real_gazetteer
         return
     # STOP if there is no input path. Checked BEFORE any status is printed, so a
     # misconfigured run ends with just this message rather than an unrelated notice
@@ -3418,11 +3646,19 @@ def main():
     pipeline = Pipeline(args, protocol, task_reference)
     report = process_folder(args.folder, pipeline, args.recursive, args.max_files)
     print_summary(report)
-    write_json(report, args.output)
+    # Outputs carry participant transcripts and raw PII spans. A bare filename resolves
+    # beside the INPUT DATA, never the working directory -- running the documented command
+    # from a repo checkout would otherwise drop them into the source tree, where a
+    # `git add -A` commits them.
+    def _out(path):
+        p = Path(path)
+        return p if p.parent != Path(".") else args.folder / p.name
+
+    write_json(report, _out(args.output))
     if args.csv:
-        write_csv(report, Path(args.csv))
+        write_csv(report, _out(args.csv))
     if getattr(args, "flagged_list", ""):
-        write_flagged_list(report, Path(args.flagged_list))
+        write_flagged_list(report, _out(args.flagged_list))
 
 
 if __name__ == "__main__":

--- a/scripts/pii_compliance_pipeline.py
+++ b/scripts/pii_compliance_pipeline.py
@@ -1,0 +1,3429 @@
+#!/usr/bin/env python3
+"""
+Local, fully-offline PII Detection + Task Compliance pipeline for ASR
+transcripts stored in .pt files.
+
+STANDALONE, as a PAIR OF FILES that travel together:
+
+    pii_compliance_pipeline.py   this script
+    task_reference.json          the 797-task reference table it checks against
+
+Copy both into the same folder and it runs anywhere -- it imports nothing from
+this repository and reads no config file. The JSON is resolved relative to the
+SCRIPT's folder, not the working directory, so the pair works from any cwd. If
+it is missing the run stops with a message rather than quietly skipping the
+scripted-task checks. Everything else the script can read -- a protocol spec --
+is genuinely optional.
+
+This tool implements the two verification tasks from the poster
+"An AI Pipeline for Ensuring Audio Data Quality" (Ng, Wilke, Johnson,
+Ghosh) --
+
+    (3) PII Detection
+    (4) Task Compliance
+
+-- operationalised with the theory from the companion proposal
+"Unified Framework for PII Detection and Task Compliance Verification
+in Clinical Voice Recordings". Both tasks are treated as one *reference
+problem* under Kripke's rigid-designation framework: for any span, the
+question is not "is this a listed type?" but "does this expression fix a
+unique individual / refer to a required action?".
+
+WHY MORE THAN ONE MODEL (per your request + the poster):
+  * PII engines run IN PARALLEL and are CROSS-VALIDATED: a rigidity
+    rule cascade, GLiNER (HIPAA identifiers), and Presidio (NER). Where
+    engines agree, confidence is boosted; where they disagree, the span
+    is surfaced for human review. Nothing is ever auto-redacted.
+  * A LOCAL LLM (gemma4 via Ollama, one warm model) reasons over the
+    residual/ambiguous PII cases and over open-ended compliance. The
+    confidence it reports on each judgement widens the human-review band
+    exactly as the poster's confidence formula prescribes.
+
+EVERYTHING RUNS LOCALLY. Transcript text is only ever sent to
+localhost (Ollama) or processed in-process (spaCy / GLiNER / Presidio /
+sentence-transformers). No transcript text leaves the machine. The only
+network traffic is the one-time download of model *weights* and
+gazetteers, never your data.
+
+SCOPE: this tool reads TEXT (the "transcription" field of each .pt).
+Poster steps that need raw audio -- (1) Audio & Environment Quality,
+(2) Unconsented Speaker Detection, and Compliance Tier B (acoustic
+features) -- cannot run on text alone and are reported as
+"skipped: requires audio". The text-level tasks (PII, Compliance
+Tier A + Tier C, composite scoring over the available checks) are
+fully implemented.
+
+Each .pt file is loaded as:
+    data = torch.load(path, map_location="cpu", weights_only=False)
+    transcription = data["transcription"]
+
+CONFIGURATION lives in ONE place: the CONFIG block a little further down. Set
+the values there and run the file -- there are no environment variables to
+export and no config file to locate. Command-line arguments override the block
+when you want a one-off change. The only setting you MUST provide is the input
+folder; with no input path the script stops and says so rather than guessing.
+
+Usage (IDE): set INPUT_FOLDER in the CONFIG block below and hit Run.
+Usage (terminal):
+    python pii_compliance_pipeline.py /path/to/pt_folder
+    python pii_compliance_pipeline.py /path/to/pt_folder --protocol my_protocol.json
+    python pii_compliance_pipeline.py /path/to/pt_folder --flagged-list flagged.txt
+    python pii_compliance_pipeline.py --selftest
+
+OUTPUT: a JSON report, an optional CSV summary, and -- the point of the run --
+the list of flagged file names, printed and available as summary.flagged_files
+in the JSON (or its own text file via --flagged-list).
+
+DEPENDENCIES: only ``torch`` is required (to read the .pt files). Every
+detection engine is optional and degrades gracefully with a printed notice if
+it is absent -- run with none of them and you still get the rule cascade plus
+task compliance. In this repository they come from the extras:
+    uv sync --extra pii --extra nlp        # presidio + spacy, nltk
+    uv run python -m spacy download en_core_web_lg
+    uv run pip install gliner wordfreq     # optional: HIPAA engine, word frequencies
+The local LLM (off by default) additionally needs Ollama on localhost.
+
+FULL DOCUMENTATION: scripts/pii_compliance_pipeline.md (beside this file) -- how each engine and tier
+works, the precision/recall modes and what they cost, the known blind spots, and
+data-safety notes. Read the "Modes" section before a first real run.
+"""
+
+import argparse
+import csv
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+import torch
+
+
+def _importable(module_name, timeout=60):
+    """Check whether `import module_name` succeeds -- in a SUBPROCESS.
+
+    Some optional engines (e.g. gliner / sentence-transformers when they pull a
+    TensorFlow build compiled for unavailable CPU instructions) abort the whole
+    process at the C level on import; a normal try/except cannot catch a SIGABRT.
+    Probing in a throwaway subprocess isolates that crash so the pipeline keeps
+    running with the engine simply skipped."""
+    try:
+        r = subprocess.run([sys.executable, "-c", f"import {module_name}"],
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                           timeout=timeout)
+        return r.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+# =============================================================================
+# MODES -- flip these on or off, then hit Run. Nothing else needed.
+#
+# This block and SETTINGS below are the whole configuration: no environment
+# variables, no config file, no command line required. (Every mode is also a
+# CLI flag if you ever want a one-off override from a terminal, but running the
+# file straight from an IDE uses exactly what is written here.)
+#
+# The active modes are printed at the start of every run, so you can always see
+# what was on without re-reading this block.
+# =============================================================================
+
+# ---- What to run ------------------------------------------------------------
+SELFTEST = False               # run the built-in self-test on synthetic data, not a real scan
+COMPLIANCE_ONLY = False        # skip PII detection entirely: task compliance only (much faster)
+RECURSIVE = False              # also scan sub-folders of INPUT_FOLDER
+
+# ---- PII detection engines (each is skipped with a notice if not installed) --
+ENABLE_SPACY = True            # spaCy NER
+ENABLE_GLINER = True           # GLiNER -- the HIPAA-identifier engine
+ENABLE_PRESIDIO = True         # Microsoft Presidio NER
+
+# ---- Local LLM (needs Ollama running -- see OLLAMA_* in SETTINGS) -----------
+# The only thing that can judge open-ended (Tier C) compliance: "did this free-speech
+# answer actually address the prompt?" is a semantic question no rule reaches. Roughly
+# DOUBLES the catch rate, at roughly 10x the review queue, and it is slow (~1-2s per
+# file once warm). Off is a deliberate precision choice, not a capability gap.
+# --> NOTES [LLM] at the end of this block for the full tradeoff.
+ENABLE_LLM = True
+ENABLE_LLM_COMPLIANCE_JUDGE = True   # also judge BORDERLINE transcripts; needs ENABLE_LLM
+
+# ---- Posture: precision vs recall -------------------------------------------
+PRECISION_MODE = True          # false-positive guards. --> NOTES [PRECISION]
+HIGH_RECALL = False            # screening mode: catch more, review more. Forces PRECISION_MODE off.
+# The next three only do anything while HIGH_RECALL is on (setting any of them
+# switches it on for you, with a printed note). --> NOTES [RECALL]
+RECALL_FLAG_ALL_PII = False    # flag even lone common-word NAME guesses (Will / May / Grant)
+RECALL_FLAG_ALL_OPEN = False   # route EVERY open free-speech task to review
+RECALL_FLAG_ACOUSTIC = False   # route acoustic tasks with unexpected speech to review
+
+# ---- Always-flag identifiers ------------------------------------------------
+FLAG_ALL_NAMES = True          # every detected name goes to the redaction queue. --> NOTES [NAMES]
+DEMOGRAPHIC_PII = True         # detect self-disclosed gender / race-ethnicity. --> NOTES [DEMOGRAPHIC]
+
+# ---- Hard-gate behaviour (what may FAIL a file rather than route to review) --
+HARD_GATE_MISSING_REQUIRED_STEP = True           # a missing REQUIRED protocol step is a real failure
+HARD_GATE_REQUIRE_CORROBORATION = True           # a lone weak strong-PII guess never auto-fails
+COMBINATORIAL_REQUIRE_CATEGORY_DIVERSITY = True  # combinatorial risk needs 2 DIFFERENT categories
+
+
+# =============================================================================
+# SETTINGS -- paths, models and thresholds. Same deal: edit and run.
+# =============================================================================
+
+# ---- Paths. INPUT_FOLDER is the one value you MUST set ----------------------
+# With no input folder here (and none on the command line) the run stops immediately
+# and says so: it does not guess, and it does not scan the working directory.
+INPUT_FOLDER = "/Users/varunthvar1/Desktop/sample_data"   # >>> SET THIS <<< folder of .pt files
+MAX_FILES = 10                 # cap the number of files, or None for all. Handy for a pilot run.
+# The task table this pipeline checks every .pt against, shipped NEXT TO this script.
+# Keep the two together. A relative path resolves against the SCRIPT's folder, never
+# the working directory. Missing -> the run STOPS. --> NOTES [TASK REFERENCE]
+TASK_REFERENCE = "task_reference.json"
+# OPTIONAL. None = zero-config: task info is read from each .pt's own metadata. Set a
+# JSON path only for interview-style protocol-step checking (consent sequences etc.).
+PROTOCOL_SPEC = None                             # e.g. "protocol_spec.example.json", or None
+
+# ---- Outputs ----------------------------------------------------------------
+OUTPUT_JSON = "pii_compliance_report.json"       # full JSON report
+OUTPUT_CSV = "pii_compliance_summary.csv"        # flat CSV summary, or "" to skip
+# Just the flagged file paths, one per line -- the plain-text list of what needs review.
+# "" means don't write it; the list is printed either way and is in the JSON report
+# under summary.flagged_files.
+OUTPUT_FLAGGED_LIST = ""                         # e.g. "flagged_files.txt"
+
+# ---- Engine models and thresholds -------------------------------------------
+SPACY_MODEL = "en_core_web_lg"
+GLINER_MODEL = "urchade/gliner_multi_pii-v1"
+GLINER_THRESHOLD = 0.6         # raise to cut GLiNER false positives (was 0.4)
+# GLiNER caps input at ~384 tokens and SILENTLY TRUNCATES longer text, dropping any PII
+# past the cap, so long transcripts are windowed through it instead. Keep max words
+# safely under the cap; overlap so entities on a chunk boundary are not split.
+GLINER_MAX_WORDS = 320
+GLINER_OVERLAP_WORDS = 40
+
+# ---- Local LLM connection ---------------------------------------------------
+OLLAMA_HOST = "http://localhost:11434"
+# Any tag Ollama can serve, e.g. "gemma4:12b", "phi4", "llama3.1". Pull it first:
+#   ollama pull gemma4
+OLLAMA_MODEL = "gemma4"
+LLM_TIMEOUT_SECONDS = 180
+# Below this reported confidence the model's yes/no is treated as UNDECIDED rather than
+# as an answer: the file routes to review instead of being scored pass or hard-fail.
+LLM_CONFIDENT_AT = 0.5
+
+# ---- Precision thresholds ---------------------------------------------------
+MIN_ENGINE_CONFIDENCE = 0.5          # drop low-confidence model detections (pattern hits exempt)
+STRONG_PII_HARD_GATE_CONFIDENCE = 0.85   # a lone strong-PII guess this confident may hard-fail
+# A single-token NAME that is also a common English word (zipf >= this) with no real name
+# signal is treated as an NER false positive: recorded, but it does not flag the file.
+# Lower => stricter (fewer name flags).
+NAME_COMMON_WORD_ZIPF = 3.9
+
+# ---- Rigidity cascade thresholds (PII, from the prior proposal) --------------
+COMBINATORIAL_WINDOW_TOKENS = 15
+COMBINATORIAL_THRESHOLD = 0.5
+INDIVIDUAL_FLAG_THRESHOLD = 0.4
+RARE_WORD_ZIPF_THRESHOLD = 2.7
+RARE_ROLE_QUALIFIER_ZIPF_MAX = 3.9   # soft-qualifier role fires only if it contains an uncommon word
+RARE_ROLE_INTRO_ZIPF_MAX = 3.6       # 'I am a <role>' fires only for uncommon occupations
+
+# ---- Which PII labels may HARD-FAIL a file ----------------------------------
+# Canonical labels (AGE/NAME/DATE/TIME/ORG/IDNUM/LOC/PROFESSION/CONTACT/URL/MISC) whose
+# CONFIRMED presence hard-fails. Default = the DIRECT identifiers only. Add "NAME" to
+# make names fail too; use set() to never fail on PII. --> NOTES [HARD GATE]
+HARD_GATE_PII_LABELS = {"IDNUM", "CONTACT", "URL"}
+# An age STRICTLY GREATER than this is flagged for review. HIPAA Safe Harbor treats all
+# ages over 89 as identifiers, so use 89 for strict HIPAA; 90 matches "any age over 90".
+AGE_REVIEW_OVER_YEARS = 90
+
+# ---- High-recall tuning (only bites while HIGH_RECALL is on) ----------------
+# An ACOUSTIC task with MORE content words than this routes to REVIEW. Raise it if
+# legitimate reps ("pa-ta-ka", counting) trip it. -1 routes EVERY acoustic task to
+# review -- the only way to reach acoustic misses, at the cost of the entire acoustic
+# half of the corpus in queue.
+RECALL_ACOUSTIC_MAX_CONTENT_WORDS = 4
+RECALL_OPEN_MIN_CONTENT_WORDS = 12   # an OPEN task thinner than this routes to REVIEW
+
+# ---- Composite scoring (poster Section 5) -----------------------------------
+# Q = sum(w_i * c_i * s_i);  C = weighted_mean(c_i) * (1 - LAMBDA * std(c_i))
+CHECK_WEIGHTS = {"pii": 0.5, "compliance": 0.5}
+CONFIDENCE_LAMBDA = 0.5
+Q_PASS_CUTOFF = 0.9
+Q_FAIL_CUTOFF = 0.5
+
+# ---- Transcript quality (compliance signal that needs NO task metadata) -----
+# A degenerate transcript is a genuine compliance failure whatever the task was:
+# empty / non-speech markers only / filler vocalizations only. Near-degenerate goes
+# to review. --> NOTES [QUALITY]
+COMPLIANCE_HARD_FAIL_MIN_CONTENT_WORDS = 1   # < this many content words -> hard FAIL
+COMPLIANCE_REVIEW_MIN_CONTENT_WORDS = 3      # < this many (but >= hard-fail) -> REVIEW
+COMPLIANCE_MAX_FILLER_RATIO = 0.6            # filler words / all words above this -> REVIEW
+COMPLIANCE_SHORT_RESPONSE_WORDS = 8          # filler ratio only judged for responses this short
+
+# ---- Tier A (scripted read) thresholds --------------------------------------
+# Calibrated to ASR, not to a clean text diff. --> NOTES [TIER A]
+#     WER <= TIER_A_WER_REVIEW              -> score 1.0..0.9   -> PASS   (read it; ASR noise)
+#     TIER_A_WER_REVIEW < WER <= ..._FAIL   -> score 0.9..0.5   -> REVIEW (doubtful read)
+#     WER >  TIER_A_WER_FAIL                -> score 0.5..0.0   -> FAIL   (wrong text / no read)
+TIER_A_WER_REVIEW = 0.50
+TIER_A_WER_FAIL = 0.80
+TIER_A_MIN_WORD_ERRORS = 4     # never flag a read with fewer word errors, whatever the ratio
+TIER_A_COVERAGE_PASS = 1.1     # 1.1 = the coverage guard is OFF. --> NOTES [TIER A]
+
+
+# =============================================================================
+# NOTES -- why the defaults are what they are. Reference only; nothing to edit.
+# =============================================================================
+#
+# [LLM]  ENABLE_LLM
+#   ONE model, kept warm for the whole run. Ollama holds a limited set resident, so
+#   cycling calls across several large models forces a disk reload on nearly every
+#   call; that reload tax, not generation, dominates runtime. A single warm model is
+#   several times faster, and multi-model voting never justified its cost here.
+#   Measured on the study corpus the LLM roughly DOUBLES the catch rate (12 -> 20 of
+#   42 real problems). It also flags ~79 compliant open-task recordings to do it,
+#   taking the review queue from 11 files to 100 and the share of the queue that is
+#   real from ~92% to ~20%. Which way that trades depends on what a reviewer's time
+#   is worth against a missed problem -- a per-study decision, not a default. Off
+#   gives a small, dense, high-precision queue; on gives ~2x the recall for ~10x the
+#   queue.
+#   ENABLE_LLM_COMPLIANCE_JUDGE asks the model, task-agnostically, whether a
+#   BORDERLINE transcript reads like a completed spoken response. It runs only on
+#   files already in the review band -- never on every file, never on acoustic tasks,
+#   never where a Tier A/C score is authoritative -- and can lower a score into review
+#   but never rescue a hard fail. It runs THROUGH the same model, so it is inert
+#   unless ENABLE_LLM is on. Left on so that enabling the LLM gets the whole LLM
+#   configuration rather than silently omitting the borderline judge.
+#
+# [PRECISION]  PRECISION_MODE
+#   Turns on all the false-positive guards. Everything a guard removes from the
+#   auto-FAIL path is still surfaced as needs_review -- true positives are never
+#   dropped, only re-routed away from hard rejection. HIGH_RECALL forces this off, so
+#   low-confidence detections survive to be flagged.
+#
+# [RECALL]  HIGH_RECALL and the RECALL_* modes
+#   Posture: catch as many problems as possible and route them to human REVIEW (never
+#   a hard fail), accepting more false positives. Turn on when a MISSED problem costs
+#   more than an extra review. Every recall knob only ADDS review flags; none of them
+#   can auto-reject a file.
+#   RECALL_FLAG_ACOUSTIC is off by default because acoustic non-compliance (too few
+#   reps, no attempt) yields a near-empty transcript indistinguishable from a
+#   compliant one, while compliant DDK/counting tasks often DO transcribe as words --
+#   so flagging acoustic is high-false-positive for almost no recall.
+#   RECALL_FLAG_ALL_OPEN is the no-LLM fallback for "answered the wrong question",
+#   which otherwise needs ENABLE_LLM. More false positives.
+#
+# [NAMES]  FLAG_ALL_NAMES
+#   Every detected personal name is review-worthy, no matter whose it is or how weak
+#   the signal -- a spoken name always belongs in the human redaction queue. This
+#   deliberately overrides the "lone common word tagged NAME" precision guard, so NER
+#   false positives (Will / May / Grant / Mark) WILL flag files. Names still route to
+#   REVIEW, never an auto-fail: NAME stays out of HARD_GATE_PII_LABELS.
+#
+# [DEMOGRAPHIC]  DEMOGRAPHIC_PII
+#   Self-disclosed gender / gender-identity and race / ethnicity are sensitive,
+#   protected attributes; combined with other detail they help re-identify a
+#   participant. Mentions surface to REVIEW as MISC quasi-identifiers, never an
+#   auto-FAIL -- a human/ethics reviewer makes the call. Kept HIGH-PRECISION: only
+#   SELF- or person-anchored mentions fire ("I'm Black", "as a trans man", "my
+#   ethnicity is ..."), never bare nouns, pronouns or incidental words ("black
+#   coffee", "Chinese food", "the man over there").
+#   The same machinery covers unusually SPECIFIC roles ("professional figure skater",
+#   which ethics flagged in the pediatric study as "a bit too much info") via
+#   RARE_ROLE_*: identifying without being a listed PII type.
+#
+# [HARD GATE]  HARD_GATE_PII_LABELS
+#   The decision is three-way (Pass / Needs Review / Fail), then FAIL is collapsed
+#   into REVIEW at the very end so nothing is ever auto-rejected. Most detected PII
+#   means "send to the redaction queue", NOT "reject the file": nothing is
+#   auto-redacted, and in voice data participants naturally speak names, dates and
+#   places, which are redactable rather than reject-worthy. Only CONFIRMED DIRECT
+#   identifiers (SSN / MRN / email / phone / URL) are serious enough to hard-fail. A
+#   spoken NAME is deliberately excluded.
+#
+# [QUALITY]  COMPLIANCE_* word counts
+#   The Task-Compliance step needs to know a task actually happened. When a .pt
+#   carries only a transcript, the strongest ground-truth-free signal is whether the
+#   transcript is a real spoken response at all: empty, non-speech markers only, or
+#   filler-only means nothing was said, whatever the task. A transcript with real
+#   content is treated as a valid attempt -- it cannot be failed on text alone
+#   without a reference or rubric, which is what Tier A / Tier C add.
+#
+# [TIER A]  TIER_A_*
+#   Tier A asks ONE question: "did the participant read the script we gave them?" --
+#   not "how good is the ASR?". A raw score = 1 - WER fed into the generic Q cutoffs
+#   sends everything above WER 0.1 to review, far too tight: on clinical read-aloud
+#   speech a 0.1-0.4 WER is the NORMAL cost of dysphonia, accent, room noise and ASR
+#   error on someone who read the script perfectly well. Someone who read the WRONG
+#   text lands much higher (0.6-1.0+).
+#   TIER_A_MIN_WORD_ERRORS exists because WER is a ratio and punishes short
+#   references hardest: three misheard words in a 5-word CAPE-V sentence is WER 0.6,
+#   while the same three errors in the 64-word rainbow passage is WER 0.05. The short
+#   sentence is not three times less compliant.
+#   TIER_A_COVERAGE_PASS is OFF by default (1.1 is unreachable) because it is an
+#   assumption about the ANNOTATORS, not about ASR. It only helps if your reviewers
+#   treat extra speech around a correct read as compliant. In the study corpus they do
+#   NOT: two recordings containing every reference word plus 5-7 extra were both
+#   labelled `partial`, and the guard turned both into misses while rescuing no false
+#   positives. Measure before enabling -- set ~0.90 and re-run the evaluator.
+#
+# [TASK REFERENCE]  TASK_REFERENCE
+#   Each .pt filename encodes its task in a BIDS-style `task-<Name>` field, e.g.
+#   sub-XXXX_ses-YYYY_task-Word-color-Stroop_features.pt -> "word-color-stroop".
+#   The JSON maps every task to its instructions + read-aloud prompts, which is how
+#   the pipeline learns each file's MODALITY -- and the modality decides how, or
+#   whether, compliance can be judged from text at all:
+#     * scripted (read a sentence/passage) -> Tier A: word error rate vs the prompt.
+#     * open     (free speech, naming)     -> Tier C LLM judge, else "speech expected".
+#     * acoustic (vowel, DDK, breath, cough, glides, phonation, loudness)
+#                                          -> Tier B: NOT text-assessable. A near-empty
+#                                             transcript here is EXPECTED, never a failure.
+#   A missing file stops the run rather than silently disabling every scripted check.
+# =============================================================================
+
+
+# ---------------------------------------------------------------------------
+# Rigidity spectrum (proposal Section 2.2 / 5) + canonical guideline labels
+# ---------------------------------------------------------------------------
+STRONG_RIGID = {"NAME", "IDNUM", "CONTACT", "URL"}
+CONTEXTUAL_RIGID = {"ORG", "LOC_SPECIFIC", "DATE_SPECIFIC"}
+WEAK_RIGID = {"AGE", "TIME", "DATE_PARTIAL", "PROFESSION", "LOC_GENERIC"}
+MISC = {"MISC"}
+
+CATEGORY_WEIGHTS = {
+    **{c: 1.0 for c in STRONG_RIGID},
+    **{c: 0.6 for c in CONTEXTUAL_RIGID},
+    **{c: 0.25 for c in WEAK_RIGID},
+    "MISC": 0.3,
+    "COMBINATORIAL": 0.6,
+}
+
+# Map the tool's fine-grained categories onto the annotation-guidelines label
+# set (AGE, NAME, DATE, TIME, ORG, IDNUM, LOC, PROFESSION, CONTACT, URL, MISC)
+# so output is compatible with the label-studio config in the guidelines.
+CANONICAL_LABEL = {
+    "NAME": "NAME", "IDNUM": "IDNUM", "CONTACT": "CONTACT", "URL": "URL",
+    "ORG": "ORG", "LOC_SPECIFIC": "LOC", "LOC_GENERIC": "LOC",
+    "DATE_SPECIFIC": "DATE", "DATE_PARTIAL": "DATE", "AGE": "AGE", "TIME": "TIME",
+    "PROFESSION": "PROFESSION", "MISC": "MISC", "COMBINATORIAL": "MISC",
+}
+
+
+def rigidity_tier(category: str) -> str:
+    if category in STRONG_RIGID:
+        return "strongly_rigid"
+    if category in CONTEXTUAL_RIGID:
+        return "contextually_rigid"
+    if category in WEAK_RIGID:
+        return "weakly_rigid"
+    if category == "COMBINATORIAL":
+        return "combinatorial"
+    return "misc"
+
+
+def _entity(start, end, category, confidence, method, **extra):
+    e = {"start": start, "end": end, "category": category,
+         "confidence": confidence, "method": method}
+    e.update(extra)
+    return e
+
+
+# ---------------------------------------------------------------------------
+# Precision guards -- reduce false positives without dropping true positives.
+# ---------------------------------------------------------------------------
+# High-precision methods whose hits we trust even below MIN_ENGINE_CONFIDENCE
+# (they matched an explicit pattern/list, not a soft model score).
+_PATTERN_METHODS = {"regex", "honorific", "gazetteer", "keyword", "demographic"}
+_DIGIT_RE = re.compile(r"\d")
+
+# Holidays / named time-periods. Per the annotation guidelines these are DATES,
+# NOT places/orgs/names -- so if any engine tags one as NAME/LOC/ORG we reclassify
+# it to a (weak) DATE rather than letting it read as a strong/contextual identifier.
+# This is what stops "Easter" surfacing as a LOCATION or ORGANIZATION.
+HOLIDAYS = {
+    "christmas", "christmas eve", "easter", "good friday", "thanksgiving",
+    "halloween", "new year", "new year's", "new years", "new year's eve",
+    "hanukkah", "chanukah", "passover", "yom kippur", "rosh hashanah",
+    "ramadan", "eid", "diwali", "holi", "lent", "advent", "boxing day",
+    "independence day", "memorial day", "labor day", "labour day",
+    "veterans day", "columbus day", "juneteenth", "mardi gras", "carnival",
+    "valentine's day", "valentines day", "st patrick's day", "cinco de mayo",
+}
+
+
+# Cues that a nearby capitalized token really is a person's name (high precision
+# for ASR speech: "my name is ...", "I'm ...", "this is ...", honorifics, etc.).
+NAME_CONTEXT_RE = re.compile(
+    r"\b(?:name\s+is|name'?s|my\s+name|named|call(?:ed)?\s+me|i\s*am|i'?m|"
+    r"this\s+is|it'?s|mr|mrs|ms|miss|dr|prof(?:essor)?|sir|madam|dame|rev|"
+    r"father|speaking\s+with|speaking\s+to|interview(?:ing)?\s+with|"
+    r"patient|participant|meet)\b",
+    re.IGNORECASE,
+)
+
+
+def _zipf(word):
+    try:
+        from wordfreq import zipf_frequency
+        return zipf_frequency(word.lower(), "en")
+    except Exception:  # noqa: BLE001
+        return 0.0     # no wordfreq -> don't suppress (favor recall)
+
+
+def _name_hard_gate_eligible(span_text, start, source_text, methods, engines, score):
+    """A NAME hard-fails a file only with a real name signal. A lone single-token
+    common word tagged as a name by an NER model (Will / May / Grant / Mark ...) is
+    the classic false positive -- it drops to needs_review instead of failing."""
+    tokens = span_text.split()
+    multitoken = len(tokens) >= 2
+    precise = bool(methods & {"honorific", "gazetteer"})
+    corroborated = len(engines) >= 2
+    preceding = source_text[max(0, start - 30):start]
+    has_context = bool(NAME_CONTEXT_RE.search(preceding))
+    common = (not multitoken) and _zipf(span_text) >= NAME_COMMON_WORD_ZIPF
+    if common and not (has_context or precise or multitoken):
+        return False
+    return multitoken or has_context or precise or corroborated or score >= 0.9
+
+
+def _valid_structured_identifier(text, category):
+    """Structured identifiers must actually look structured. A word with no
+    digits / '@' / URL shape is almost always a model hallucination -- e.g. an
+    ASR'd cough token flagged as a 'device identifier'. Real SSNs, MRNs, phone
+    numbers, emails, and URLs always satisfy these."""
+    t = (text or "").strip()
+    if not t:
+        return False
+    if category == "URL":
+        return bool(re.search(r"(https?://|www\.|\.[a-z]{2,})", t, re.IGNORECASE))
+    if category == "CONTACT":                      # email / phone / fax / IP
+        return ("@" in t) or len(_DIGIT_RE.findall(t)) >= 7 or \
+            bool(re.fullmatch(r"(?:\d{1,3}\.){3}\d{1,3}", t))
+    if category == "IDNUM":                         # ids carry digits
+        return _DIGIT_RE.search(t) is not None
+    return True
+
+
+def postprocess_entities(entities, source_text):
+    """Apply the precision guards to a flat list of engine detections."""
+    if not PRECISION_MODE:
+        return entities
+    out = []
+    for e in entities:
+        span_text = source_text[e["start"]:e["end"]]
+        cat = e["category"]
+        # 1) Holiday/named-period reclassification (guidelines: these are DATES).
+        low = span_text.lower().strip().strip(".,'’")
+        if low in HOLIDAYS and cat in ("NAME", "ORG", "LOC_SPECIFIC", "LOC_GENERIC", "MISC"):
+            e = dict(e, category="DATE_PARTIAL", confidence=min(e["confidence"], 0.6),
+                     method=e["method"] + "+holiday-reclass")
+            cat = "DATE_PARTIAL"
+        # 2) Structured-identifier format validation (kills word-only "identifiers").
+        if cat in ("IDNUM", "CONTACT", "URL") and not _valid_structured_identifier(span_text, cat):
+            continue
+        # 3) Low-confidence soft detections dropped (pattern/list hits are exempt).
+        method_root = e["method"].split(":")[0].split("+")[0]
+        if e["confidence"] < MIN_ENGINE_CONFIDENCE and method_root not in _PATTERN_METHODS:
+            continue
+        out.append(e)
+    return out
+
+
+# ===========================================================================
+# PART A -- PII DETECTION ENGINES (run in parallel, cross-validated)
+# ===========================================================================
+
+# --- Gazetteers (Stage 1 of the rigidity cascade) --------------------------
+def load_name_gazetteer():
+    """~8000 common given names (NLTK 'names' corpus); downloaded once."""
+    import nltk
+    try:
+        from nltk.corpus import names
+        names.words()
+    except LookupError:
+        nltk.download("names", quiet=True)
+        from nltk.corpus import names
+    return {n.lower() for n in names.words()}
+
+
+US_STATES = {
+    "alabama", "alaska", "arizona", "arkansas", "california", "colorado", "connecticut",
+    "delaware", "florida", "georgia", "hawaii", "idaho", "illinois", "indiana", "iowa",
+    "kansas", "kentucky", "louisiana", "maine", "maryland", "massachusetts", "michigan",
+    "minnesota", "mississippi", "missouri", "montana", "nebraska", "nevada",
+    "new hampshire", "new jersey", "new mexico", "new york", "north carolina",
+    "north dakota", "ohio", "oklahoma", "oregon", "pennsylvania", "rhode island",
+    "south carolina", "south dakota", "tennessee", "texas", "utah", "vermont",
+    "virginia", "washington", "west virginia", "wisconsin", "wyoming",
+}
+MAJOR_CITIES = {
+    "new york", "los angeles", "chicago", "houston", "phoenix", "philadelphia",
+    "san antonio", "san diego", "dallas", "san jose", "austin", "boston", "seattle",
+    "denver", "washington", "nashville", "detroit", "portland", "las vegas",
+    "baltimore", "atlanta", "miami", "toronto", "vancouver", "montreal", "london",
+    "paris", "berlin", "madrid", "rome", "amsterdam", "dublin", "cairo", "lagos",
+    "nairobi", "johannesburg", "mumbai", "delhi", "bangalore", "beijing", "shanghai",
+    "hong kong", "tokyo", "seoul", "singapore", "bangkok", "manila", "jakarta",
+    "sydney", "melbourne", "auckland", "mexico city", "sao paulo", "buenos aires",
+    "lima", "bogota", "moscow", "istanbul", "damascus", "baghdad", "tehran",
+}
+
+
+def load_place_gazetteer():
+    places = set()
+    try:
+        import pycountry
+        places = {c.name.lower() for c in pycountry.countries}
+    except Exception:  # noqa: BLE001
+        pass
+    return places | US_STATES | MAJOR_CITIES
+
+
+ORG_SUFFIX_RE = re.compile(
+    r"\b([A-Z][\w&.,'-]*(?:\s+[A-Z][\w&.,'-]*){0,4}\s+"
+    r"(?:Hospital|University|Clinic|Center|Centre|Foundation|Institute|"
+    r"Inc\.?|LLC|Corp\.?|Ltd\.?|Co\.))\b"
+)
+CALENDAR_WORDS = {
+    "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+    "january", "february", "march", "april", "may", "june", "july", "august",
+    "september", "october", "november", "december",
+    "spring", "summer", "autumn", "fall", "winter",
+}
+
+
+def gazetteer_scan(text, name_set, place_set):
+    entities = []
+    for m in re.finditer(r"\b[A-Z][a-zA-Z'-]+(?:\s+[A-Z][a-zA-Z'-]+){0,2}\b", text):
+        phrase = m.group(0)
+        words = phrase.split()
+        if phrase.lower() in place_set:
+            entities.append(_entity(m.start(), m.end(), "LOC_SPECIFIC", 0.9, "gazetteer"))
+            continue
+        if len(words) >= 2 and any(
+            w.lower() in name_set and w.lower() not in CALENDAR_WORDS for w in words
+        ):
+            entities.append(_entity(m.start(), m.end(), "NAME", 0.85, "gazetteer"))
+    for m in ORG_SUFFIX_RE.finditer(text):
+        entities.append(_entity(m.start(1), m.end(1), "ORG", 0.8, "gazetteer"))
+    return entities
+
+
+# --- Stage 1 regex over structured identifiers -----------------------------
+REGEX_PATTERNS = [
+    ("CONTACT", 0.95, re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b")),                                   # email
+    ("CONTACT", 0.90, re.compile(r"(?<!\d)(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}(?!\d)")),  # phone
+    ("IDNUM",   0.95, re.compile(r"\b\d{3}-\d{2}-\d{4}\b")),                                           # SSN
+    ("URL",     0.95, re.compile(r"\b(?:https?://|www\.)[^\s,]+", re.IGNORECASE)),
+    ("CONTACT", 0.90, re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")),                                     # IPv4
+    ("IDNUM",   0.85, re.compile(
+        r"\b(?:MRN|medical record(?:\s+number)?|account number|patient id|"
+        r"certificate number|license number|policy number|member id|health plan number)"
+        r"\s*[:#]?\s*([A-Za-z0-9-]{4,})\b", re.IGNORECASE)),
+    ("DATE_SPECIFIC", 0.90, re.compile(r"\b\d{1,2}/\d{1,2}/\d{2,4}\b")),
+    ("DATE_SPECIFIC", 0.90, re.compile(r"\b\d{4}-\d{2}-\d{2}\b")),
+    ("AGE",           0.85, re.compile(r"\b\d{1,3}[\s-]year[\s-]old\b", re.IGNORECASE)),
+]
+HONORIFIC_RE = re.compile(
+    r"\b(?:Mr|Mrs|Ms|Miss|Dr|Prof|Rev|Fr|Sr|Sir|Dame)\.?\s+"
+    r"([A-Z][a-zA-Z'-]+(?:\s+[A-Z][a-zA-Z'-]+)?)"
+)
+PROFESSION_KEYWORDS = {
+    "doctor", "nurse", "surgeon", "physician", "therapist", "psychologist",
+    "psychiatrist", "teacher", "professor", "engineer", "lawyer", "attorney",
+    "technician", "officer", "manager", "director", "researcher", "scientist",
+    "student", "resident", "pharmacist", "counselor", "social worker", "paramedic",
+    "lieutenant", "captain", "sergeant", "president",
+}
+
+
+def regex_scan(text):
+    entities = []
+    for category, confidence, pattern in REGEX_PATTERNS:
+        for m in pattern.finditer(text):
+            span = m.span(1) if m.groups() else m.span()
+            entities.append(_entity(span[0], span[1], category, confidence, "regex"))
+    return entities
+
+
+# --- Stage 2 weak signals (spaCy NER, honorific, profession, rare word) ----
+_SPACY_LABEL_MAP = {"PERSON": "NAME", "ORG": "ORG", "TIME": "TIME"}
+
+
+def ner_scan(nlp, text, place_set):
+    entities = []
+    for ent in nlp(text).ents:
+        if ent.label_ in ("GPE", "LOC"):
+            cat = "LOC_SPECIFIC" if ent.text.lower() in place_set else "LOC_GENERIC"
+            entities.append(_entity(ent.start_char, ent.end_char, cat, 0.75, "ner"))
+        elif ent.label_ == "DATE":
+            cat = "DATE_SPECIFIC" if re.search(r"\b(19|20)\d{2}\b", ent.text) else "DATE_PARTIAL"
+            entities.append(_entity(ent.start_char, ent.end_char, cat, 0.7, "ner"))
+        elif ent.label_ in _SPACY_LABEL_MAP:
+            entities.append(_entity(ent.start_char, ent.end_char,
+                                    _SPACY_LABEL_MAP[ent.label_], 0.75, "ner"))
+    return entities
+
+
+def honorific_scan(text):
+    return [_entity(m.start(1), m.end(1), "NAME", 0.7, "honorific")
+            for m in HONORIFIC_RE.finditer(text)]
+
+
+_MULTIWORD_PROFESSIONS = sorted((p for p in PROFESSION_KEYWORDS if " " in p),
+                                key=len, reverse=True)
+
+
+def profession_scan(text):
+    """Flag profession keywords. Checks every single word individually (so an
+    adjacent word never swallows the keyword) plus known multi-word professions."""
+    entities = []
+    taken = []  # spans already claimed by a multi-word match
+    for phrase in _MULTIWORD_PROFESSIONS:
+        for m in re.finditer(rf"\b{re.escape(phrase)}\b", text, re.IGNORECASE):
+            entities.append(_entity(m.start(), m.end(), "PROFESSION", 0.6, "keyword"))
+            taken.append((m.start(), m.end()))
+    for m in re.finditer(r"\b[a-zA-Z]+\b", text):
+        if m.group(0).lower() in PROFESSION_KEYWORDS:
+            if any(s <= m.start() < e for s, e in taken):
+                continue
+            entities.append(_entity(m.start(), m.end(), "PROFESSION", 0.6, "keyword"))
+    return entities
+
+
+def rareword_scan(text, zipf_threshold):
+    try:
+        from wordfreq import zipf_frequency
+    except Exception:  # noqa: BLE001
+        return []
+    entities = []
+    for m in re.finditer(r"\b[A-Z][a-zA-Z'-]{3,}\b", text):
+        word = m.group(0)
+        preceding = text[: m.start()].rstrip()
+        if preceding == "" or preceding[-1] in ".!?":  # skip sentence-initial caps
+            continue
+        if zipf_frequency(word.lower(), "en") <= zipf_threshold:
+            entities.append(_entity(m.start(), m.end(), "MISC", 0.5, "rareword"))
+    return entities
+
+
+# A role/activity phrase of 1-2 words that does not run past a stopword (so
+# "figure skater and I ..." captures just "figure skater").
+_ROLE_STOP = (r"(?:and|or|but|who|that|which|because|so|when|while|the|a|an|to|of|"
+              r"in|on|for|is|was|are|were|be|i|my|me|he|she|they|we|you|it|this)")
+_ROLE_WORDS = (r"[a-z][a-z'-]+(?:\s+(?!" + _ROLE_STOP + r"\b)[a-z][a-z'-]+){0,1}")
+# STRONG qualifiers are identifying on their own ("olympic <x>"). SOFT qualifiers
+# ("professional <x>") flag only when the role phrase contains an uncommon word --
+# so "professional figure skater" fires but "professional development" does not.
+_STRONG_QUALIFIER_RE = re.compile(
+    r"\b(olympic|paralympic|championship|champion|world[-\s]?class|elite|decorated|"
+    r"renowned|award[-\s]?winning)\s+(" + _ROLE_WORDS + r")\b", re.IGNORECASE)
+_SOFT_QUALIFIER_RE = re.compile(
+    r"\b(professional|semi[-\s]?professional|competitive|national|international|"
+    r"former|retired|amateur)\s+(" + _ROLE_WORDS + r")\b", re.IGNORECASE)
+# A self-described occupation ("I am a <x>", "I work as a <x>").
+_ROLE_INTRO_RE = re.compile(
+    r"\b(?:i'm|i\s+am|i\s+was|i\s+used\s+to\s+be|worked\s+as|work\s+as|employed\s+as)\s+"
+    r"(?:an?\s+|the\s+)?(" + _ROLE_WORDS + r")\b", re.IGNORECASE)
+
+
+def _phrase_min_zipf(phrase):
+    """Minimum word-frequency across a role phrase (a rare word anywhere signals
+    specificity). Returns None if no word is known to wordfreq."""
+    zs = [z for z in (_zipf(t) for t in re.findall(r"[a-z'-]+", phrase.lower())) if z > 0.0]
+    return min(zs) if zs else None
+
+
+def rare_role_scan(text):
+    """Nuanced quasi-identifiers: unusually specific roles/activities/statuses that can
+    re-identify a person on their own (annotation-guidelines MISC). Example that
+    motivated this: a participant mentioning being a "professional figure skater".
+    These are surfaced to REVIEW (never an auto-fail); the LLM and a human
+    reviewer make the final call. Kept high-precision to avoid flagging common jobs."""
+    ents = []
+    for m in _STRONG_QUALIFIER_RE.finditer(text):
+        ents.append(_entity(m.start(), m.end(), "MISC", 0.6, "rare_role"))
+    for m in _SOFT_QUALIFIER_RE.finditer(text):
+        z = _phrase_min_zipf(m.group(2))
+        if z is None or z <= RARE_ROLE_QUALIFIER_ZIPF_MAX:  # skip 'professional development'
+            ents.append(_entity(m.start(), m.end(), "MISC", 0.55, "rare_role"))
+    for m in _ROLE_INTRO_RE.finditer(text):
+        z = _phrase_min_zipf(m.group(1))
+        if z is not None and z <= RARE_ROLE_INTRO_ZIPF_MAX:  # only uncommon occupations
+            ents.append(_entity(m.start(1), m.end(1), "MISC", 0.5, "rare_role"))
+    return ents
+
+
+# ---------------------------------------------------------------------------
+# Demographic quasi-identifiers: self-disclosed gender & race/ethnicity.
+# High precision by design -- everything requires a SELF/person anchor so bare
+# nouns, pronouns and incidental words ("black coffee", "Chinese food") never fire.
+# All hits are MISC with method "demographic:<race|gender>" -> merge_pii marks them
+# review_worthy (like rare_role); they never hard-FAIL a file.
+# ---------------------------------------------------------------------------
+_PERSON_NOUN = (r"man|woman|male|female|guy|girl|boy|lady|gentleman|person|"
+                r"individual|folk|folks|kid|child")
+# Race / ethnicity terms distinctive enough to flag when self/person-anchored. Bare
+# nationalities (Chinese, Mexican, ...) are intentionally excluded -- they fire far too
+# often on food/places -- and are caught only via the explicit "my ethnicity is <X>".
+_RACE_TERMS = (
+    r"black|white|caucasian|african[-\s]?american|afro[-\s]?caribbean|"
+    r"asian(?:[-\s]?american)?|south[-\s]?asian|east[-\s]?asian|southeast[-\s]?asian|desi|"
+    r"hispanic|latin[oax]|latine|"
+    r"native[-\s]?american|american[-\s]?indian|indigenous|alaska[-\s]?native|"
+    r"pacific[-\s]?islander|native[-\s]?hawaiian|"
+    r"middle[-\s]?eastern|arab|"
+    r"biracial|multiracial|mixed[-\s]?race|brown"
+)
+# Gender-identity terms (sensitive/protected); distinctive enough to flag on sight.
+_GENDER_IDENTITY_TERMS = (
+    r"transgender|transsexual|trans[-\s]?(?:man|woman|male|female|masc\w*|fem\w*)|"
+    r"cis[-\s]?gender(?:ed)?|cisgender(?:ed)?|"
+    r"non[-\s]?binary|nonbinary|gender[-\s]?queer|genderqueer|gender[-\s]?fluid|genderfluid|"
+    r"agender|bigender|two[-\s]?spirit|inter[-\s]?sex|intersex|"
+    r"gender[-\s]?non[-\s]?conforming|gender[-\s]?dysphoria|gender[-\s]?identity|"
+    r"mtf|ftm|afab|amab"
+)
+# Binary sex/gender words -- flagged ONLY when self-disclosed (a first/third-person
+# copular anchor or "as a"/"my gender is"), never as a bare noun or pronoun.
+_BINARY_GENDER = r"man|woman|male|female|guy|girl|boy|lady|gentleman|nonbinary|non[-\s]?binary"
+_ANY_GENDER = r"(?:" + _GENDER_IDENTITY_TERMS + r"|" + _BINARY_GENDER + r")"
+# In the strongest self-ID contexts only ("I am ___", "they identify as ___") also accept
+# bare trans/cis (lookahead keeps it out of trans-atlantic / cis-regulatory).
+_ANY_GENDER_SELF = r"(?:" + _GENDER_IDENTITY_TERMS + r"|" + _BINARY_GENDER + r"|(?:trans|cis)(?![-\w]))"
+# Subject pronoun + copula ("I'm", "I am", "she is", "they were", ...).
+_SUBJ = r"(?:i|we|he|she|they)(?:\s*'m|\s*'re|\s*'s|\s+am|\s+are|\s+is|\s+was|\s+were)"
+
+_RACE_SELF_RE = re.compile(
+    r"\b" + _SUBJ + r"\s+(?:an?\s+)?((?:" + _RACE_TERMS + r")(?:\s+(?:" + _PERSON_NOUN + r"))?)\b",
+    re.IGNORECASE)
+_RACE_ADJ_RE = re.compile(
+    r"\b((?:" + _RACE_TERMS + r")\s+(?:" + _PERSON_NOUN + r"))\b", re.IGNORECASE)
+_RACE_EXPLICIT_RE = re.compile(
+    r"\bmy\s+(?:race|ethnicity|ethnic\s+background|racial\s+background|heritage|ancestry)\s+"
+    r"(?:is|are|was|were|being|:)?\s*([a-z][\w'-]+(?:\s+[a-z][\w'-]+)?)", re.IGNORECASE)
+_POC_RE = re.compile(r"\b((?:person|people|woman|man|women|men)\s+of\s+colou?r)\b", re.IGNORECASE)
+_GENDER_IDENTITY_RE = re.compile(r"\b(" + _GENDER_IDENTITY_TERMS + r")\b", re.IGNORECASE)
+_GENDER_SELF_RE = re.compile(
+    r"\b(?:" + _SUBJ + r"|(?:i|we|he|she|they)\s+identif(?:y|ies)\s+as)\s+"
+    r"(?:an?\s+)?(" + _ANY_GENDER_SELF + r")\b", re.IGNORECASE)
+_GENDER_ASA_RE = re.compile(
+    r"\bas\s+an?\s+(" + _ANY_GENDER + r"(?:\s+(?:" + _PERSON_NOUN + r"))?)\b", re.IGNORECASE)
+_GENDER_EXPLICIT_RE = re.compile(
+    r"\bmy\s+(?:gender(?:\s+identity)?|sex|pronouns?)\s+(?:is|are|was|were|being|:)?\s*"
+    r"([a-z][\w'-]+)", re.IGNORECASE)
+
+_RACE_RES = (_RACE_SELF_RE, _RACE_ADJ_RE, _RACE_EXPLICIT_RE, _POC_RE)
+_GENDER_RES = (_GENDER_IDENTITY_RE, _GENDER_SELF_RE, _GENDER_ASA_RE, _GENDER_EXPLICIT_RE)
+
+
+def demographic_scan(text):
+    """Nuanced demographic quasi-identifiers: SELF-disclosed race/ethnicity and gender/
+    gender-identity. These are sensitive, protected attributes that (with other detail)
+    re-identify a participant, so every hit is surfaced to REVIEW as MISC (never a hard
+    FAIL). Precision comes from requiring a self/person anchor, so bare nouns, pronouns
+    and incidental words ('black coffee', 'Chinese food') do not fire."""
+    if not DEMOGRAPHIC_PII:
+        return []
+    ents, seen = [], set()
+
+    def _add(a, b, subtype, conf):
+        if b <= a or (a, b) in seen:
+            return
+        seen.add((a, b))
+        ents.append(_entity(a, b, "MISC", conf, "demographic:" + subtype))
+
+    for rx in _RACE_RES:
+        strong = rx in (_RACE_EXPLICIT_RE,)
+        for m in rx.finditer(text):
+            _add(m.start(1), m.end(1), "race", 0.6 if strong else 0.55)
+    for rx in _GENDER_RES:
+        strong = rx in (_GENDER_IDENTITY_RE, _GENDER_EXPLICIT_RE)
+        for m in rx.finditer(text):
+            _add(m.start(1), m.end(1), "gender", 0.6 if strong else 0.55)
+    return ents
+
+
+# ---------------------------------------------------------------------------
+# Very high age (> AGE_REVIEW_OVER_YEARS) -- an always-flag quasi-identifier.
+# HIPAA Safe Harbor treats ages over 89 as identifiers: at the top of the age
+# distribution the population thins out so much that the age alone can single a
+# participant out. The general AGE regex above only catches "95-year-old" and is
+# too weak to flag a file on its own, so this dedicated scan handles the phrasings
+# ASR actually produces -- "95 years old", "aged 102", "my age is 94", spelled-out
+# numbers ("ninety-five", "a hundred and two"), and "in her nineties" -- and marks
+# the hit `age_over_threshold` so merge_pii always routes it to REVIEW.
+# ---------------------------------------------------------------------------
+_AGE_UNITS = {"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+              "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11,
+              "twelve": 12, "thirteen": 13, "fourteen": 14, "fifteen": 15,
+              "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19}
+_AGE_TENS = {"twenty": 20, "thirty": 30, "forty": 40, "fifty": 50,
+             "sixty": 60, "seventy": 70, "eighty": 80, "ninety": 90}
+_UNIT_RE = "|".join(_AGE_UNITS)
+_TENS_RE = "|".join(_AGE_TENS)
+# A spelled-out number up to ~199: "a/one hundred [and] [tens] [units]" | "ninety-five" | "ninety"
+_AGE_WORD_NUM = (rf"(?:(?:one|a)\s+hundred(?:\s+and)?(?:\s+(?:{_TENS_RE}))?(?:[-\s](?:{_UNIT_RE}))?"
+                 rf"|(?:{_TENS_RE})(?:[-\s](?:{_UNIT_RE}))?)")
+_AGE_VALUE = rf"(\d{{1,3}}|{_AGE_WORD_NUM})"
+# Each pattern anchors the number to an explicit AGE meaning, so bare numbers
+# ("I'm 100 percent sure", "100 dollars") never register as an age.
+_AGE_CONTEXT_RES = (
+    re.compile(rf"\b{_AGE_VALUE}\s*-?\s*years?[\s-]*old\b", re.IGNORECASE),
+    re.compile(rf"\b{_AGE_VALUE}\s*-?\s*y[\s.]?o\.?\b", re.IGNORECASE),
+    re.compile(rf"\bage[d]?\s*(?:is|of|:)?\s*{_AGE_VALUE}\b", re.IGNORECASE),
+    re.compile(rf"\b(?:turned|turning|turns)\s+{_AGE_VALUE}\b", re.IGNORECASE),
+)
+# Decade/status phrasings that imply >90 without naming a number.
+_AGE_OVER_PHRASE_RE = re.compile(
+    r"\b(?:in\s+(?:his|her|their|my|the)\s+(?:nineties|hundreds)"
+    r"|centenarian|centenarians|nonagenarian|nonagenarians"
+    r"|over\s+(?:ninety|90|the\s+age\s+of\s+(?:ninety|90)))\b", re.IGNORECASE)
+
+
+def _age_word_to_int(phrase):
+    """Convert a spelled-out age ('ninety-five', 'a hundred and two') to an int,
+    or None if it isn't one. Digits are handled by the caller."""
+    words = re.findall(r"[a-z]+", phrase.lower())
+    if not words:
+        return None
+    total = 0
+    if "hundred" in words:
+        total = 100
+        words = words[words.index("hundred") + 1:]
+    for w in words:
+        if w in _AGE_TENS:
+            total += _AGE_TENS[w]
+        elif w in _AGE_UNITS:
+            total += _AGE_UNITS[w]
+        elif w in ("and", "a", "one") and total >= 100:
+            continue
+    return total or None
+
+
+def age_scan(text, over_years=None):
+    """Flag ages STRICTLY GREATER than `over_years` (default AGE_REVIEW_OVER_YEARS).
+    Only the flaggable (very high) ages are emitted, so ordinary ages keep behaving
+    exactly as before. Every hit carries age_over_threshold=True, which makes
+    merge_pii mark it review_worthy regardless of the precision guards."""
+    limit = AGE_REVIEW_OVER_YEARS if over_years is None else over_years
+    ents, seen = [], set()
+
+    def _add(a, b, conf, value=None):
+        if b <= a or (a, b) in seen:
+            return
+        seen.add((a, b))
+        ents.append(_entity(a, b, "AGE", conf, "regex:age_over",
+                            age_over_threshold=True, age_value=value))
+
+    for rx in _AGE_CONTEXT_RES:
+        for m in rx.finditer(text):
+            raw = m.group(1)
+            value = int(raw) if raw.isdigit() else _age_word_to_int(raw)
+            # Ignore implausible ages (typos / non-age numbers that slipped through).
+            if value is None or value > 125:
+                continue
+            if value > limit:
+                _add(m.start(), m.end(), 0.9, value)
+    for m in _AGE_OVER_PHRASE_RE.finditer(text):
+        _add(m.start(), m.end(), 0.8, None)
+    return ents
+
+
+# --- Engine: GLiNER (poster's HIPAA-identifier detector) -------------------
+# Label set mirrors the poster's "GLINER TARGETS: HIPAA IDENTIFIERS" panel.
+GLINER_LABELS = [
+    "person name", "date", "phone number", "fax number", "email address",
+    "social security number", "medical record number", "health plan number",
+    "account number", "certificate or license number", "vehicle identifier",
+    "device identifier", "url", "ip address", "biometric identifier",
+    "geographic location", "organization", "profession", "age",
+]
+_GLINER_TO_CATEGORY = {
+    "person name": "NAME", "date": "DATE_SPECIFIC", "phone number": "CONTACT",
+    "fax number": "CONTACT", "email address": "CONTACT",
+    "social security number": "IDNUM", "medical record number": "IDNUM",
+    "health plan number": "IDNUM", "account number": "IDNUM",
+    "certificate or license number": "IDNUM", "vehicle identifier": "IDNUM",
+    "device identifier": "IDNUM", "url": "URL", "ip address": "CONTACT",
+    "biometric identifier": "IDNUM", "geographic location": "LOC_SPECIFIC",
+    "organization": "ORG", "profession": "PROFESSION", "age": "AGE",
+}
+
+
+def _gliner_chunks(text, max_words, overlap_words):
+    """Yield (chunk_text, char_offset) windows of <= max_words words, with
+    overlap, so GLiNER never has to truncate and boundary entities are covered."""
+    words = list(re.finditer(r"\S+", text))
+    n = len(words)
+    if n == 0:
+        return
+    step = max(1, max_words - overlap_words)
+    i = 0
+    while i < n:
+        chunk = words[i:i + max_words]
+        c_start = chunk[0].start()
+        c_end = chunk[-1].end()
+        yield text[c_start:c_end], c_start
+        if i + max_words >= n:
+            break
+        i += step
+
+
+def gliner_scan(gliner_model, text, threshold=GLINER_THRESHOLD,
+                max_words=GLINER_MAX_WORDS, overlap_words=GLINER_OVERLAP_WORDS):
+    if gliner_model is None:
+        return []
+    entities = []
+    for chunk, offset in _gliner_chunks(text, max_words, overlap_words):
+        try:
+            preds = gliner_model.predict_entities(chunk, GLINER_LABELS, threshold=threshold)
+        except Exception:  # noqa: BLE001
+            continue
+        for p in preds:
+            cat = _GLINER_TO_CATEGORY.get(p["label"], "MISC")
+            entities.append(_entity(p["start"] + offset, p["end"] + offset, cat,
+                                    float(p.get("score", 0.6)), "gliner"))
+    return entities
+
+
+# --- Engine: Presidio (poster's NER detector) ------------------------------
+_PRESIDIO_TO_CATEGORY = {
+    "PERSON": "NAME", "PHONE_NUMBER": "CONTACT", "EMAIL_ADDRESS": "CONTACT",
+    "US_SSN": "IDNUM", "US_DRIVER_LICENSE": "IDNUM", "US_PASSPORT": "IDNUM",
+    "MEDICAL_LICENSE": "IDNUM", "CREDIT_CARD": "IDNUM", "IBAN_CODE": "IDNUM",
+    "US_BANK_NUMBER": "IDNUM", "URL": "URL", "IP_ADDRESS": "CONTACT",
+    "LOCATION": "LOC_SPECIFIC", "DATE_TIME": "DATE_SPECIFIC", "NRP": "MISC",
+    "ORGANIZATION": "ORG",
+}
+
+
+def presidio_scan(analyzer, text):
+    if analyzer is None:
+        return []
+    try:
+        results = analyzer.analyze(text=text, language="en")
+    except Exception:  # noqa: BLE001
+        return []
+    entities = []
+    for r in results:
+        cat = _PRESIDIO_TO_CATEGORY.get(r.entity_type, "MISC")
+        entities.append(_entity(r.start, r.end, cat, float(r.score), "presidio"))
+    return entities
+
+
+# --- Stage 3 combinatorial rigidity (sliding window) -----------------------
+def combinatorial_scan(text, weak_and_misc_entities, window_tokens, threshold):
+    tokens = list(re.finditer(r"\S+", text))
+    if not tokens or not weak_and_misc_entities:
+        return []
+    flags = []
+    n = len(tokens)
+    for i in range(n):
+        w_start = tokens[i].start()
+        w_end = tokens[min(i + window_tokens, n) - 1].end()
+        contributing = [e for e in weak_and_misc_entities
+                        if e["start"] >= w_start and e["end"] <= w_end]
+        score = sum(CATEGORY_WEIGHTS.get(e["category"], 0.3) * e["confidence"]
+                    for e in contributing)
+        diverse = len({e["category"] for e in contributing}) >= 2
+        if COMBINATORIAL_REQUIRE_CATEGORY_DIVERSITY and not diverse:
+            continue  # two of the same weak signal (e.g. two professions) don't combine
+        if score >= threshold and len(contributing) >= 2:
+            flags.append({
+                "start": min(e["start"] for e in contributing),
+                "end": max(e["end"] for e in contributing),
+                "category": "COMBINATORIAL", "confidence": min(1.0, score),
+                "method": "combinatorial", "contributing": contributing,
+            })
+    flags.sort(key=lambda e: e["start"])
+    merged = []
+    for f in flags:
+        if merged and f["start"] <= merged[-1]["end"]:
+            merged[-1]["end"] = max(merged[-1]["end"], f["end"])
+            merged[-1]["confidence"] = max(merged[-1]["confidence"], f["confidence"])
+            ids = {id(c) for c in merged[-1]["contributing"]}
+            merged[-1]["contributing"].extend(c for c in f["contributing"] if id(c) not in ids)
+        else:
+            merged.append(f)
+    return merged
+
+
+# ===========================================================================
+# PART B -- LOCAL LLM ENSEMBLE (more than one model; votes are aggregated)
+# ===========================================================================
+PII_SYSTEM_PROMPT = (
+    "You are screening a clinical-research transcript for identification risk, "
+    "using Kripke's theory of rigid designation: for any span the question is not only "
+    "'is this a listed identifier type?' but also 'does this expression fix a unique "
+    "individual, on its own or combined with other details?'. Be conservative -- "
+    "flag anything that could plausibly contribute to identification. This includes "
+    "nuanced quasi-identifiers that are not classic PII: an unusually specific "
+    "occupation, achievement, or activity (e.g. 'professional figure skater', "
+    "'Olympic swimmer', 'the only heart-transplant patient at my clinic') can single "
+    "someone out even with no name -- flag these as MISC. Also flag self-disclosed "
+    "SENSITIVE DEMOGRAPHICS -- a speaker's gender / gender identity (e.g. 'I identify "
+    "as nonbinary', 'as a trans man') and race / ethnicity (e.g. \"I'm Black\", 'my "
+    "ethnicity is ...') -- as MISC, since these are protected attributes that aid "
+    "re-identification; but do NOT flag incidental uses ('black coffee', 'Chinese "
+    "food'). A false negative is far worse than a false positive."
+)
+COMPLIANCE_SYSTEM_PROMPT = (
+    "You are auditing whether a researcher completed a required protocol/task step "
+    "in a clinical-research transcript. A step can be completed without using its "
+    "exact wording (e.g. consent obtained via 'is it okay if I record this?'). "
+    "Judge whether expressions in the transcript REFER TO the required action, not "
+    "whether they reproduce it verbatim. Be conservative and explain your reasoning."
+)
+
+
+class LocalLLM:
+    """One local Ollama model, queried for the judgements no rule can make.
+
+    Deliberately a SINGLE model rather than a voting ensemble. Ollama keeps a limited
+    set of models resident, so rotating calls across several large ones forces a disk
+    reload on nearly every call; that reload tax, not generation, dominates runtime.
+    One warm model is several times faster, and the confidence it reports carries the
+    uncertainty that cross-model disagreement used to stand in for."""
+
+    def __init__(self, host, model, timeout):
+        self.host = host
+        self.model = model
+        self.timeout = timeout
+        self.available = self._check()
+
+    def _check(self):
+        """Confirm the model is actually served before the run starts, so a missing
+        pull surfaces immediately instead of as silently absent LLM judgements."""
+        try:
+            req = urllib.request.Request(f"{self.host}/api/tags")
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                installed = {m["name"] for m in json.loads(resp.read()).get("models", [])}
+        except Exception as e:  # noqa: BLE001
+            print(f"  [LLM] Ollama not reachable at {self.host} ({e}); LLM disabled.")
+            return False
+        # Accept "gemma4" against an installed "gemma4:latest" and vice versa.
+        base = self.model.split(":")[0]
+        if self.model in installed or any(m.split(":")[0] == base for m in installed):
+            print(f"  [LLM] active, model: {self.model}")
+            return True
+        print(f"  [LLM] model {self.model!r} is not installed; LLM disabled. "
+              f"Pull it with `ollama pull {base}`.")
+        return False
+
+    @property
+    def active(self):
+        return self.available
+
+    def _ask(self, system, prompt):
+        """One JSON-mode call. Returns the parsed object, or None on any failure --
+        unreachable server, timeout, or a reply that isn't the JSON we asked for."""
+        payload = json.dumps({"model": self.model, "prompt": prompt, "system": system,
+                              "format": "json", "stream": False}).encode()
+        req = urllib.request.Request(f"{self.host}/api/generate", data=payload,
+                                     headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                return json.loads(json.loads(resp.read())["response"])
+        except Exception:  # noqa: BLE001
+            return None
+
+    # ---- PII: span detection ----
+    def pii_spans(self, text):
+        if not self.active:
+            return []
+        data = self._ask(PII_SYSTEM_PROMPT, (
+            "Passage:\n" + text + "\n\n"
+            'Return JSON {"flags":[{"text":"...","start":int,"end":int,'
+            '"category":"NAME|IDNUM|CONTACT|URL|ORG|LOC|DATE|TIME|AGE|PROFESSION|MISC",'
+            '"reasoning":"...","confidence":0-1}]}. start/end are char offsets into the passage.'
+        ))
+        out = []
+        for f in (data or {}).get("flags", []):
+            try:
+                out.append(_entity(int(f["start"]), int(f["end"]),
+                                   f.get("category", "MISC").upper(),
+                                   float(f.get("confidence", 0.5)),
+                                   f"llm:{self.model}", reasoning=f.get("reasoning", "")))
+            except (KeyError, ValueError, TypeError):
+                continue
+        return out
+
+    # ---- PII: does the COMBINATION of spans identify someone? ----
+    def pii_combinatorial_vote(self, text, spans):
+        if not spans or not self.active:
+            return None
+        listing = "\n".join(f'- {s["categories"][0]}: "{text[s["start"]:s["end"]]}"'
+                            for s in spans)
+        d = self._ask(PII_SYSTEM_PROMPT, (
+            "These spans were flagged in a transcript:\n" + listing + "\n\n"
+            "Taken together, do they fix a unique individual within the plausible "
+            "population of a clinical study? Return JSON "
+            '{"identifies_unique_individual":true|false,"reasoning":"..."}'
+        ))
+        if d is None:
+            return None
+        return {"model": self.model,
+                "identifies_unique_individual": bool(d.get("identifies_unique_individual")),
+                "reasoning": d.get("reasoning", "")}
+
+    # ---- Compliance: was a required protocol step completed? ----
+    def compliance_vote(self, transcript, step):
+        d = self._ask(COMPLIANCE_SYSTEM_PROMPT, (
+            "Transcript:\n" + transcript + "\n\n"
+            f'Required step: "{step["step_description"]}"\n'
+            f'Required speaker: {step.get("required_speaker", "either")}\n'
+            'Did the transcript show this step being completed? Return JSON '
+            '{"completed":true|false,"evidence":"quote or \'none\'","confidence":0-1,"reasoning":"..."}'
+        )) if self.active else None
+        return self._judgement(d, extra=("evidence",))
+
+    # ---- Compliance: open-ended task judge (poster Tier C) ----
+    def task_judge_vote(self, transcript, task):
+        rubric = task.get("rubric") or task.get("prompt") or task.get("description", "")
+        d = self._ask(COMPLIANCE_SYSTEM_PROMPT, (
+            "Transcript of a participant's spoken response:\n" + transcript + "\n\n"
+            f'Task the participant was asked to complete: "{rubric}"\n'
+            'Did the speaker complete the task? Return JSON '
+            '{"completed":true|false,"confidence":0-1,"reasoning":"..."}'
+        )) if self.active else None
+        return self._judgement(d)
+
+    # ---- Compliance: task-agnostic completion judge (no reference/rubric) ----
+    def transcript_completion_vote(self, transcript):
+        """Used when the .pt carries no task metadata: ask whether the transcript reads
+        like a real, completed, coherent spoken response rather than silence, a cut-off
+        fragment, or non-responsive noise. Corroborates the deterministic quality check
+        on borderline files only."""
+        d = self._ask(COMPLIANCE_SYSTEM_PROMPT, (
+            "Transcript of a single spoken response from a clinical voice study:\n"
+            + transcript + "\n\n"
+            "Ignoring what the specific task was, does this read like a COMPLETE, "
+            "coherent spoken response (someone actually spoke and finished a thought), "
+            "as opposed to silence, a cut-off fragment, or non-responsive noise? "
+            'Return JSON {"completed":true|false,"confidence":0-1,"reasoning":"..."}'
+        )) if self.active else None
+        return self._judgement(d)
+
+    def _judgement(self, d, extra=()):
+        """Normalise one completed/confidence reply into the compliance-score shape."""
+        if d is None:
+            return None
+        try:
+            confidence = min(1.0, max(0.0, float(d.get("confidence", 0.5))))
+        except (TypeError, ValueError):
+            confidence = 0.5      # unparseable confidence -> maximally undecided
+        completed = bool(d.get("completed"))
+        out = {"model": self.model, "completed": completed,
+               "confidence": round(confidence, 3),
+               "score": llm_judgement_score(completed, confidence),
+               "reasoning": d.get("reasoning", ""),
+               # The model is unsure enough that a human should decide.
+               "uncertain": confidence < 0.5}
+        for k in extra:
+            out[k] = d.get(k, "")
+        return out
+
+
+def llm_judgement_score(completed, confidence):
+    """Put one LLM yes/no + confidence onto the same 0-1 axis as every other
+    compliance check, banded so it lands on the composite cutoffs exactly like
+    Tier A does:
+
+        confident "completed"      -> 0.9 .. 1.0   PASS
+        UNSURE, either way         -> 0.5 .. 0.9   REVIEW
+        confident "not completed"  -> 0.0 .. 0.5   FAIL (-> review)
+
+    The middle band is the point. A model that says "no" but is not confident about
+    it has not found a failure -- it has failed to decide, which is a human's job.
+    Letting low confidence slide into the fail band would report a guess as a hard
+    compliance failure. With one model this reported confidence carries the
+    uncertainty that a spread of votes across several models used to express, and
+    it does so honestly rather than as a function of how many models are installed.
+    """
+    confidence = min(1.0, max(0.0, confidence))
+    # Signed evidence: +confident yes .. 0 undecided .. -confident no.
+    e = confidence if completed else -confidence
+    t = LLM_CONFIDENT_AT
+    if e >= t:                                            # confident yes -> PASS band
+        return round(Q_PASS_CUTOFF + (1.0 - Q_PASS_CUTOFF) * (e - t) / max(1e-9, 1.0 - t), 3)
+    if e <= -t:                                           # confident no  -> FAIL band
+        return round((Q_FAIL_CUTOFF - 0.001) * (e + 1.0) / max(1e-9, 1.0 - t), 3)
+    span = Q_PASS_CUTOFF - Q_FAIL_CUTOFF - 0.001          # undecided    -> REVIEW band
+    return round(Q_FAIL_CUTOFF + span * (e + t) / (2 * t), 3)
+
+
+# ===========================================================================
+# PART C -- PII merge / cross-validation across engines
+# ===========================================================================
+def merge_pii(entities, text):
+    """Cluster overlapping detections from all engines; agreement across
+    distinct engines/models boosts confidence, single-engine hits are kept
+    but flagged for review (poster: 'Disagreements surface to reviewers')."""
+    entities = sorted(entities, key=lambda e: e["start"])
+    clusters = []
+    for e in entities:
+        placed = False
+        for c in clusters:
+            if any(max(e["start"], m["start"]) < min(e["end"], m["end"]) for m in c):
+                c.append(e)
+                placed = True
+                break
+        if not placed:
+            clusters.append([e])
+
+    merged = []
+    for c in clusters:
+        start = min(m["start"] for m in c)
+        end = max(m["end"] for m in c)
+        categories = sorted({m["category"] for m in c})
+        base = max(CATEGORY_WEIGHTS.get(m["category"], 0.3) * m["confidence"] for m in c)
+        engines = sorted({m["method"].split(":")[0].split("+")[0] for m in c})
+        methods = {m["method"].split(":")[0].split("+")[0] for m in c}
+        # agreement bonus: more independent engines -> higher confidence
+        agreement_bonus = min(0.15, 0.05 * (len(engines) - 1))
+        best = max(c, key=lambda m: CATEGORY_WEIGHTS.get(m["category"], 0.3) * m["confidence"])
+        score = round(min(1.0, base + agreement_bonus), 3)
+        is_strong = best["category"] in STRONG_RIGID
+
+        # Hard-gate eligibility: a strong-PII hit auto-FAILS a file only when it is
+        # trustworthy on its own -- a high-precision pattern match (SSN/email/phone/
+        # URL regex), OR corroborated by >=2 independent engines, OR very high
+        # confidence, OR a name via honorific/gazetteer. A lone low-confidence model
+        # guess is NOT auto-failed; it still surfaces as needs_review (recall kept).
+        if not (HARD_GATE_REQUIRE_CORROBORATION and PRECISION_MODE):
+            hard_gate_eligible = is_strong
+        elif not is_strong:
+            hard_gate_eligible = False
+        elif best["category"] == "NAME":
+            hard_gate_eligible = _name_hard_gate_eligible(
+                text[start:end], start, text, methods, engines, score)
+        else:
+            # IDNUM / CONTACT / URL: already format-validated in postprocess; trust a
+            # pattern match, cross-engine agreement, or very high confidence.
+            hard_gate_eligible = (
+                len(engines) >= 2
+                or score >= STRONG_PII_HARD_GATE_CONFIDENCE
+                or "regex" in methods
+            )
+        canonical = sorted({CANONICAL_LABEL.get(x, "MISC") for x in categories})
+        cross_validated = len(engines) >= 2
+        confirmed = hard_gate_eligible and bool(set(canonical) & HARD_GATE_PII_LABELS)
+        # review_worthy is the file-flagging bar: a file is flagged for PII only if it
+        # has at least one review_worthy span. This is the main lever against
+        # over-flagging -- a lone single-engine weak guess, or a common word tagged
+        # NAME with no real name signal (even if two engines share the false positive),
+        # is recorded below but does NOT flag the file.
+        best_cat = best["category"]
+        # FLAG_ALL_NAMES: every detected name is review-worthy, whoever it belongs to
+        # and however weak the signal (no auto-fail -- NAME stays out of the hard gate).
+        name_signal = best_cat == "NAME" and (FLAG_ALL_NAMES or hard_gate_eligible)
+        # An age above AGE_REVIEW_OVER_YEARS always flags, despite AGE's weak weight.
+        elderly_age = any(m.get("age_over_threshold") for m in c)
+        contextual_or_id = best_cat in ((STRONG_RIGID | CONTEXTUAL_RIGID) - {"NAME"})
+        quasi_identifier = best_cat == "MISC" and bool({"rare_role", "demographic"} & methods)
+        if best_cat == "COMBINATORIAL":
+            review_worthy = True
+        elif confirmed or name_signal or quasi_identifier or elderly_age:
+            review_worthy = True             # identifier, real-name signal, or nuanced quasi-id
+        elif contextual_or_id:
+            review_worthy = cross_validated  # ORG/LOC/DATE/ID: only if engines agree
+        else:
+            review_worthy = False            # AGE/TIME/PROFESSION/plain-MISC alone: informational
+        # High-recall screening: flag ANY real detection for human review. Only the
+        # classic lone common-word NAME false positive (no name signal) stays quiet,
+        # unless RECALL_FLAG_ALL_PII forces even those. Minimizes false negatives.
+        if HIGH_RECALL:
+            lone_common_name = (best_cat == "NAME" and not hard_gate_eligible)
+            if RECALL_FLAG_ALL_PII or not lone_common_name:
+                review_worthy = True
+        merged.append({
+            "start": start, "end": end, "text": text[start:end],
+            "categories": categories,
+            "canonical_labels": canonical,
+            "rigidity_tier": rigidity_tier(best["category"]),
+            "score": score,
+            "engines": engines,
+            "cross_validated": cross_validated,
+            "hard_gate_eligible": hard_gate_eligible,
+            "confirmed": confirmed,
+            "review_worthy": review_worthy,
+            "needs_review": review_worthy,
+            "detections": c,
+        })
+    return merged
+
+
+def build_masked_preview(text, entities):
+    """Reviewer-convenience preview only. Never written back to the .pt --
+    nothing is auto-redacted (poster)."""
+    preview = text
+    for ent in sorted(entities, key=lambda e: e["start"], reverse=True):
+        tag = f"[{ent['canonical_labels'][0]}]"
+        preview = preview[: ent["start"]] + tag + preview[ent["end"]:]
+    return preview
+
+
+# ===========================================================================
+# PART D -- TASK COMPLIANCE
+# ===========================================================================
+_WORD_RE = re.compile(r"[a-z0-9']+")
+
+
+def _normalize_words(text):
+    return _WORD_RE.findall(text.lower())
+
+
+def _align_counts(ref, hyp):
+    """Levenshtein alignment of two word lists, broken down by EDIT TYPE.
+
+    Returns (substitutions, deletions, insertions, hits). The plain edit distance
+    (= sub + del + ins) is all WER needs, but Tier A needs the breakdown: deletions
+    and substitutions mean reference words that were NOT said, while insertions are
+    only extra words on top. Conflating them is what makes a compliant read with a
+    false start look like an off-script read."""
+    n, m = len(ref), len(hyp)
+    # Each cell carries (cost, sub, del, ins, hit) for the best path reaching it.
+    row = [(j, 0, 0, j, 0) for j in range(m + 1)]
+    for i in range(1, n + 1):
+        prev, row = row, [(i, 0, i, 0, 0)] + [None] * m
+        ref_w = ref[i - 1]
+        for j in range(1, m + 1):
+            c, s, d, ins, h = prev[j - 1]
+            diag = (c, s, d, ins, h + 1) if ref_w == hyp[j - 1] else (c + 1, s + 1, d, ins, h)
+            c, s, d, ins, h = prev[j]
+            drop = (c + 1, s, d + 1, ins, h)          # reference word not said
+            c, s, d, ins, h = row[j - 1]
+            add = (c + 1, s, d, ins + 1, h)           # extra word not in the reference
+            row[j] = min(diag, drop, add, key=lambda t: t[0])
+    return row[m][1], row[m][2], row[m][3], row[m][4]
+
+
+def alignment_stats(reference, hypothesis):
+    """Tier A measurements for one reference prompt against one transcript.
+
+    ``wer``      -- classic word error rate, (sub + del + ins) / len(reference).
+    ``coverage`` -- fraction of reference words actually matched, 1 - (sub + del)/len(ref).
+                    Insertion-blind: extra speech cannot lower it, so it answers
+                    "was the script read?" where WER answers "how cleanly?".
+    """
+    ref = _normalize_words(reference)
+    hyp = _normalize_words(hypothesis)
+    if not ref:
+        return {"wer": 0.0 if not hyp else 1.0, "coverage": 1.0, "errors": len(hyp),
+                "substitutions": 0, "deletions": 0, "insertions": len(hyp),
+                "hits": 0, "ref_words": 0, "hyp_words": len(hyp)}
+    sub, dele, ins, hits = _align_counts(ref, hyp)
+    return {"wer": (sub + dele + ins) / len(ref),
+            "coverage": hits / len(ref),
+            "errors": sub + dele + ins,
+            "substitutions": sub, "deletions": dele, "insertions": ins,
+            "hits": hits, "ref_words": len(ref), "hyp_words": len(hyp)}
+
+
+def word_error_rate(reference, hypothesis):
+    """Levenshtein-based WER (poster Tier A). No external dependency."""
+    return alignment_stats(reference, hypothesis)["wer"]
+
+
+def tier_a_score(wer):
+    """Map a word error rate onto a compliance score in [0,1] using the Tier A
+    thresholds, so the generic composite cutoffs (Q_PASS_CUTOFF / Q_FAIL_CUTOFF)
+    land on the WER values that actually mean pass / review / fail for read speech.
+    Piecewise linear and monotonically decreasing, with each band kept strictly
+    inside its cutoff so a boundary WER never lands on the wrong side."""
+    wer = max(0.0, wer)
+    if wer <= TIER_A_WER_REVIEW:
+        frac = wer / TIER_A_WER_REVIEW if TIER_A_WER_REVIEW > 0 else 1.0
+        return round(1.0 - (1.0 - Q_PASS_CUTOFF) * frac, 3)          # 1.0 .. 0.9  -> PASS
+    if wer <= TIER_A_WER_FAIL:
+        span = max(1e-9, TIER_A_WER_FAIL - TIER_A_WER_REVIEW)
+        frac = (wer - TIER_A_WER_REVIEW) / span
+        return round(Q_PASS_CUTOFF - (Q_PASS_CUTOFF - Q_FAIL_CUTOFF - 0.001) * frac, 3)
+    span = max(1e-9, 1.0 - TIER_A_WER_FAIL)                          # 0.9 .. 0.5  -> REVIEW
+    frac = min(1.0, (wer - TIER_A_WER_FAIL) / span)
+    return round(max(0.0, (Q_FAIL_CUTOFF - 0.001) * (1.0 - frac)), 3)  # 0.5 .. 0.0 -> FAIL
+
+
+# Non-lexical vocalizations an ASR system emits for hesitation/backchannel. These
+# carry no task content; a transcript made only of them means nothing was said.
+# (Deliberately excludes real words like "yeah"/"okay"/"no" -- those are content.)
+FILLER_TOKENS = {
+    "uh", "um", "umm", "uhh", "uhm", "er", "err", "erm", "ah", "ahh", "hmm", "hm",
+    "mm", "mmm", "mhm", "mmhm", "mhmm", "mmhmm", "uhhuh", "uh-huh", "huh", "eh",
+    "hmmm", "mmk", "shh", "ugh", "oof", "ooh", "aah",
+}
+# Bracketed / angle-bracketed ASR non-speech annotations: [noise], (coughing),
+# <unk>, [inaudible], {laughter}, etc. Stripped before counting words.
+_NONSPEECH_MARKER_RE = re.compile(r"[\[\(<\{][^\]\)>\}]*[\]\)>\}]")
+
+
+def assess_transcript_quality(transcript):
+    """Task-compliance signal that needs NO task metadata or reference text.
+
+    Returns a dict with a compliance-style score in [0,1] and a hard_fail flag.
+    A degenerate transcript (empty / non-speech only / filler only) is a genuine
+    compliance failure: whatever the task was, no valid spoken response exists to
+    have completed it. Near-degenerate transcripts route to review."""
+    raw = transcript or ""
+    stripped = raw.strip()
+    no_markers = _NONSPEECH_MARKER_RE.sub(" ", stripped)
+    words = re.findall(r"[A-Za-z0-9']+", no_markers.lower())
+    n_words = len(words)
+    # content = tokens that carry task meaning (filler vocalizations removed).
+    content = [w for w in words if w not in FILLER_TOKENS]
+    n_content = len(content)
+    filler_ratio = (n_words - n_content) / n_words if n_words else 0.0
+
+    def result(status, score, confidence, hard_fail):
+        return {"method": "transcript_quality", "status": status,
+                "score": round(score, 3), "confidence": confidence,
+                "hard_fail": hard_fail, "completed": (not hard_fail) and score >= Q_PASS_CUTOFF,
+                "n_words": n_words, "n_content_words": n_content,
+                "filler_ratio": round(filler_ratio, 3)}
+
+    if not stripped or n_words == 0:
+        return result("empty", 0.0, 0.99, True)
+    if n_content == 0:
+        # Only non-speech markers and/or filler vocalizations survived.
+        return result("non_speech_only", 0.0, 0.97, True)
+    if n_content < COMPLIANCE_HARD_FAIL_MIN_CONTENT_WORDS:
+        return result("no_content", 0.0, 0.95, True)
+    if n_content < COMPLIANCE_REVIEW_MIN_CONTENT_WORDS:
+        return result("too_short", 0.6, 0.7, False)
+    if n_content < COMPLIANCE_SHORT_RESPONSE_WORDS and filler_ratio > COMPLIANCE_MAX_FILLER_RATIO:
+        return result("mostly_filler", 0.6, 0.7, False)
+    return result("ok", 1.0, 0.8, False)
+
+
+def _recall_compliance_override(transcript, modality, quality):
+    """HIGH_RECALL only. Route to REVIEW (never a hard fail) the non-compliance the
+    text-level tiers structurally miss: unexpected speech on an ACOUSTIC task, and
+    thin / likely-incomplete OPEN free-speech. Returns a review-band quality dict
+    (score 0.6, between Q_FAIL_CUTOFF and Q_PASS_CUTOFF) so composite_score flags
+    compliance for review; otherwise returns the original `quality` unchanged."""
+    q = assess_transcript_quality(transcript)
+    ncw = q.get("n_content_words", 0)
+    if (modality == "acoustic" and RECALL_FLAG_ACOUSTIC
+            and ncw > RECALL_ACOUSTIC_MAX_CONTENT_WORDS):
+        return dict(q, applies=True, status="acoustic_unexpected_speech",
+                    score=0.6, confidence=0.6, hard_fail=False,
+                    method="recall:acoustic_extra_speech")
+    if modality == "open" and (RECALL_FLAG_ALL_OPEN or ncw < RECALL_OPEN_MIN_CONTENT_WORDS):
+        return dict(q, applies=True, status="open_needs_review",
+                    score=0.6, confidence=0.55, hard_fail=False,
+                    method="recall:open_review")
+    return quality
+
+
+# ---------------------------------------------------------------------------
+# Task identity + modality, read from the .pt FILENAME (BIDS `task-<Name>` field)
+# ---------------------------------------------------------------------------
+# A task's modality decides whether/how compliance can be judged from text alone.
+# Classified by substring patterns on the normalized task token so it is robust to
+# the many per-subtype variants (diadochokinesis-PA, cape-V-sentences-3, ...).
+_ACOUSTIC_TASK_PATTERNS = (
+    "diadochokinesis", "prolongedvowel", "maximumphonation", "phonation", "loudness",
+    "glide", "hightolow", "lowtohigh", "respiration", "cough", "breath",
+    "longsounds", "sillysounds", "noisysounds",
+)
+_SCRIPTED_TASK_PATTERNS = (
+    "capevsentences", "rainbow", "caterpillar", "harvardsentence", "passage", "sentence",
+)
+
+
+def _norm_task(s):
+    """Alphanumeric-only, lowercased -- so 'Cape-V-Sentences', 'cape_v_sentences' and
+    'cape-V-sentences-(v2)-3' all normalize compatibly for matching."""
+    return re.sub(r"[^a-z0-9]", "", (s or "").lower())
+
+
+def task_key_from_filename(filename):
+    """Extract the BIDS-style task token from a .pt filename, e.g.
+    'sub-1_ses-2_task-Word-color-Stroop_features.pt' -> 'Word-color-Stroop'."""
+    if not filename:
+        return None
+    stem = Path(filename).name
+    stem = stem[:-3] if stem.endswith(".pt") else stem
+    m = re.search(r"task-([^_]+)", stem)
+    return m.group(1) if m else None
+
+
+def classify_modality(task_token):
+    """acoustic (non-verbal) / scripted (read a reference) / open (free speech)."""
+    n = _norm_task(task_token)
+    if not n:
+        return None
+    if any(p in n for p in _ACOUSTIC_TASK_PATTERNS):
+        return "acoustic"
+    if any(p in n for p in _SCRIPTED_TASK_PATTERNS):
+        return "scripted"
+    return "open"
+
+
+def _clean_prompt(p):
+    """Strip the recording boilerplate that trails some reference prompts, e.g.
+    'The blue spot is on the key again. When you are ready, press "record".'"""
+    p = re.sub(r"when you are ready.*$", "", p or "", flags=re.IGNORECASE)
+    return p.strip().strip("“”\"'").strip()
+
+
+class ComplianceChecker:
+    def __init__(self, protocol, llm, task_reference=None):
+        self.tasks = (protocol or {}).get("tasks", {})
+        self.steps = (protocol or {}).get("protocol_steps", [])
+        self.llm = llm
+        self.task_reference = task_reference or {}
+        # normalized-key index for tolerant filename matching (handles subtype variants)
+        self._ref_index = {k: _norm_task(k) for k in self.task_reference}
+
+    def _resolve_reference_keys(self, token):
+        """Pick the reference key(s) for a task token, MOST SPECIFIC FIRST.
+
+        Returns (keys, ambiguous). Plain bidirectional prefix matching is wrong here:
+        it pulls in SIBLING VARIANTS, because one task's normalized name is often a
+        prefix of a different task's ('diadochokinesisPA' is a prefix of
+        'diadochokinesisPataka'; 'picturedescription' of 'picturedescriptionoption2').
+        That silently mixes another task's prompt/instruction into this file's
+        compliance test. So:
+
+          1. an EXACT normalized match wins outright -- nothing else is considered;
+          2. otherwise prefer the LONGEST key that is a prefix of the token (the most
+             specific reference that still describes this task, e.g. token
+             'Rainbow-Passage' -> key 'rainbow');
+          3. only if the token is itself a prefix of several keys (i.e. the filename is
+             LESS specific than the reference, so we genuinely cannot tell which
+             variant it was) do we return all of them, flagged `ambiguous`.
+        """
+        nt = _norm_task(token)
+        if not nt:
+            return [], False
+        exact = [k for k, nk in self._ref_index.items() if nk == nt]
+        if exact:
+            return exact, False
+        # Keys that are a prefix of the token -> token is the more specific name.
+        prefixes = [k for k, nk in self._ref_index.items() if nk and nt.startswith(nk)]
+        if prefixes:
+            longest = max(len(self._ref_index[k]) for k in prefixes)
+            best = [k for k in prefixes if len(self._ref_index[k]) == longest]
+            return best, len(best) > 1
+        # Token is a prefix of these keys -> genuinely ambiguous between variants.
+        supersets = [k for k, nk in self._ref_index.items() if nk and nk.startswith(nt)]
+        return supersets, len(supersets) > 1
+
+    # ---- Resolve the task + MODALITY for a file (filename first, then .pt metadata) ----
+    def resolve_task_context(self, filename, task_meta):
+        """Identify the task from the .pt filename's `task-<Name>` field, look up its
+        reference prompts/instructions, and classify its modality. This is what lets
+        the pipeline judge compliance correctly per task type. Returns None if the task
+        is unknown (compliance then falls back to transcript quality)."""
+        ctx = {"task_id": None, "modality": None, "tier": None, "reference_texts": [],
+               "instruction": None, "matched_keys": [], "source": None,
+               "ambiguous_match": False, "reference_missing": False}
+        token = task_key_from_filename(filename)
+        if token:
+            ctx["task_id"] = token
+            ctx["source"] = "filename"
+            ctx["modality"] = classify_modality(token)
+            matches, ambiguous = self._resolve_reference_keys(token)
+            ctx["matched_keys"] = matches
+            ctx["ambiguous_match"] = ambiguous
+            for k in matches:
+                entry = self.task_reference.get(k, {})
+                for p in entry.get("prompts", []):
+                    cleaned = _clean_prompt(p)
+                    if cleaned:
+                        ctx["reference_texts"].append(cleaned)
+                if not ctx["instruction"] and entry.get("instructions"):
+                    ctx["instruction"] = entry["instructions"].strip()
+        # A scripted task whose reference text is missing from the task reference can
+        # still be scored if the .pt itself carries one -- use it rather than silently
+        # giving up on the word-error-rate check.
+        if (ctx["modality"] == "scripted" and not ctx["reference_texts"]
+                and task_meta and task_meta.get("reference_text")):
+            ctx["reference_texts"] = [task_meta["reference_text"]]
+            ctx["source"] = (ctx["source"] or "") + "+metadata_reference"
+        # Fallback: a .pt that carries its own task metadata (reference_text / prompt / tier).
+        if ctx["modality"] is None and task_meta:
+            if task_meta.get("reference_text"):
+                ctx.update(modality="scripted", source="metadata",
+                           reference_texts=[task_meta["reference_text"]],
+                           task_id=ctx["task_id"] or task_meta.get("task_id"))
+            elif task_meta.get("tier"):
+                t = task_meta["tier"].upper()
+                ctx.update(modality={"A": "scripted", "B": "acoustic"}.get(t, "open"),
+                           source="metadata", instruction=task_meta.get("prompt"),
+                           task_id=ctx["task_id"] or task_meta.get("task_id"))
+            elif task_meta.get("prompt"):
+                ctx.update(modality="open", source="metadata",
+                           instruction=task_meta.get("prompt"),
+                           task_id=ctx["task_id"] or task_meta.get("task_id"))
+        if ctx["modality"] is None:
+            return None
+        ctx["tier"] = {"acoustic": "B", "scripted": "A", "open": "C"}[ctx["modality"]]
+        # A SCRIPTED task with no reference text cannot be word-error-rate checked, so
+        # its compliance falls back to the transcript-quality floor only -- which cannot
+        # detect reading the WRONG text. Record it so the gap is visible in the report
+        # instead of looking like a clean pass. Fix by adding the task's prompts to the
+        # built-in table (PART H) or a --task-reference JSON, or by shipping a
+        # reference_text inside the .pt.
+        if ctx["modality"] == "scripted" and not ctx["reference_texts"]:
+            ctx["reference_missing"] = True
+        return ctx
+
+    # ---- Transcript quality (gated by modality) ----
+    def check_quality(self, transcript, suppress=False):
+        """Deterministic transcript-quality signal. When `suppress` is True (acoustic
+        tasks, or tasks whose Tier A/C score is the authority), the raw status is still
+        reported but it does NOT contribute a compliance score -- so a near-empty
+        transcript for a prolonged-vowel/breath task is never counted as a failure.
+        Otherwise it is the compliance signal (a degenerate transcript => failure),
+        optionally corroborated by the LLM on borderline files."""
+        q = assess_transcript_quality(transcript)
+        if suppress:
+            return dict(q, applies=False, score=None, confidence=None, hard_fail=False,
+                        raw_status=q["status"])
+        q = dict(q, applies=True)
+        if (ENABLE_LLM_COMPLIANCE_JUDGE and self.llm and self.llm.active
+                and not q["hard_fail"] and q["status"] != "ok"):
+            vote = self.llm.transcript_completion_vote(transcript)
+            if vote:
+                q["llm_completion"] = {k: vote[k] for k in
+                                       ("model", "completed", "confidence", "uncertain")}
+                if not vote["completed"] and vote["confidence"] >= 0.7:
+                    q = dict(q, status="llm_incomplete", score=0.3,
+                             confidence=vote["confidence"], hard_fail=True)
+                elif vote["completed"] and vote["confidence"] >= 0.7:
+                    q = dict(q, status="llm_ok", score=1.0,
+                             confidence=vote["confidence"], completed=True)
+        return q
+
+    # ---- Route a task to its tier and score it (poster Tiers A / B / C) ----
+    def assess_task(self, transcript, ctx):
+        if not ctx:
+            return None
+        modality = ctx["modality"]
+        if modality == "acoustic":
+            result = {"tier": "B", "method": "acoustic", "score": None,
+                      "confidence": None, "completed": None,
+                      "status": "skipped: acoustic/non-verbal task (requires audio)"}
+        elif modality == "scripted" and ctx["reference_texts"]:
+            result = self._tier_a(transcript, ctx["reference_texts"])
+        elif modality == "open":
+            result = self._tier_c(transcript, ctx)
+            if result is None:
+                return None  # no LLM -> transcript quality carries the open-task signal
+        else:
+            return None      # scripted w/o reference text -> quality carries it
+        result["task_id"] = ctx.get("task_id")
+        result["modality"] = modality
+        result["required"] = True
+        return result
+
+    # ---- Tier A: scripted read, best-matching reference prompt ----
+    def _tier_a(self, transcript, reference_texts):
+        """Did the participant read the script? Scored from the BEST-matching reference
+        prompt (lowest WER, ties broken by highest coverage), then passed through the
+        Tier A thresholds and two precision guards. Both guards can only move a file
+        towards PASS -- neither can create a flag -- so they trade no recall away."""
+        cands = [alignment_stats(r, transcript) for r in reference_texts if r]
+        if not cands:
+            best = {"wer": 1.0, "coverage": 0.0, "errors": 0, "substitutions": 0,
+                    "deletions": 0, "insertions": 0, "hits": 0, "ref_words": 0,
+                    "hyp_words": 0}
+        else:
+            best = min(cands, key=lambda a: (a["wer"], -a["coverage"]))
+        score = tier_a_score(best["wer"])
+        guard = None
+        # Guard 1 -- absolute error floor. One or two misheard words in a short CAPE-V /
+        # Harvard sentence is ASR noise, not a failure to read it, however bad the ratio.
+        if score < Q_PASS_CUTOFF and best["errors"] < TIER_A_MIN_WORD_ERRORS:
+            score, guard = Q_PASS_CUTOFF, "below_min_word_errors"
+        # Guard 2 -- reference covered. Nearly every reference word was actually said and
+        # the errors are dominated by EXTRA words (false start, restart, an aside to the
+        # researcher). The script was demonstrably read; WER is just inflated by insertions.
+        elif (score < Q_PASS_CUTOFF and best["coverage"] >= TIER_A_COVERAGE_PASS
+                and best["insertions"] > best["substitutions"] + best["deletions"]):
+            score, guard = Q_PASS_CUTOFF, "reference_covered"
+        return {"tier": "A", "method": "wer_min_over_prompts",
+                "wer": round(best["wer"], 3), "coverage": round(best["coverage"], 3),
+                "word_errors": best["errors"], "substitutions": best["substitutions"],
+                "deletions": best["deletions"], "insertions": best["insertions"],
+                "ref_words": best["ref_words"], "hyp_words": best["hyp_words"],
+                "precision_guard": guard,
+                "score": score, "confidence": 0.9, "completed": score >= Q_PASS_CUTOFF,
+                "num_reference_prompts": len(reference_texts)}
+
+    # ---- Tier C: open-ended, local LLM judge (None if no LLM) ----
+    def _tier_c(self, transcript, ctx):
+        if not (self.llm and self.llm.active):
+            return None
+        task = {"rubric": ctx.get("instruction") or "",
+                "prompt": ctx["reference_texts"][0] if ctx["reference_texts"] else ""}
+        vote = self.llm.task_judge_vote(transcript, task)
+        if vote is None:
+            return None
+        return {"tier": "C", "method": "llm_judge", "score": vote["score"],
+                "confidence": vote["confidence"], "completed": vote["completed"],
+                "model": vote["model"], "uncertain": vote["uncertain"],
+                "reasoning": vote.get("reasoning", "")}
+
+    # ---- Protocol-step verification (proposal Section 4.1: keyword/phrase
+    #      gazetteer -> sequence check; + the LLM on residual/ambiguous steps) ----
+    def check_protocol_steps(self, transcript):
+        if not self.steps:
+            return None
+        step_results = []
+        for step in self.steps:
+            # Stage 1 - keyword/phrase gazetteer
+            hit, method, conf, evidence = self._keyword_match(transcript, step)
+            # LLM on residual / ambiguous steps
+            llm_vote = None
+            if not hit and self.llm and self.llm.active:
+                llm_vote = self.llm.compliance_vote(transcript, step)
+                if llm_vote and llm_vote["completed"]:
+                    hit, method, conf = True, "llm", llm_vote["confidence"]
+                    evidence = _first_evidence(llm_vote)
+            if hit:
+                status = "protocol_step_completed"
+            elif llm_vote and llm_vote.get("uncertain"):
+                # The model said "not completed" but was not confident about it -- the
+                # step is arguably present. (This is the single-model stand-in for what
+                # used to be cross-model disagreement.)
+                status = "protocol_step_attempted"
+            elif step.get("required", True):
+                status = "protocol_step_absent"
+            else:
+                status = "protocol_step_optional_absent"
+            step_results.append({
+                "step_id": step["step_id"], "status": status, "method": method,
+                "confidence": round(conf, 3), "evidence": evidence,
+                "sequence_position": step.get("sequence_position", "any"),
+                "required": step.get("required", True),
+                "pii_expected": step.get("pii_expected", False),
+                "consent_marker": bool(step.get("consent_marker", False)),
+                "llm_vote": llm_vote,
+            })
+        # Stage 3 - sequence verification
+        _flag_sequence_deviations(step_results)
+        return step_results
+
+    def _keyword_match(self, transcript, step):
+        low = transcript.lower()
+        for phrase in step.get("canonical_phrases", []):
+            if phrase.lower() in low:
+                i = low.find(phrase.lower())
+                return True, "keyword", 0.9, transcript[i:i + len(phrase)]
+        return False, "none", 0.0, None
+
+
+def _first_evidence(vote):
+    """The quote the model pointed at, if it gave a usable one."""
+    ev = (vote or {}).get("evidence") or ""
+    return ev if vote and vote.get("completed") and ev.lower() != "none" else None
+
+
+def _flag_sequence_deviations(step_results):
+    """Mark completed steps that appear out of prescribed order (proposal Stage 3)."""
+    ordered = [(r["sequence_position"], r) for r in step_results
+               if r["status"] == "protocol_step_completed"
+               and isinstance(r["sequence_position"], int)]
+    last = 0
+    for pos, r in ordered:
+        if pos < last:
+            r["status"] = "protocol_deviation"
+            r["deviation"] = "out_of_sequence"
+        last = max(last, pos)
+
+
+# ===========================================================================
+# PART E -- INTERACTION ANNOTATIONS (mutual reinforcement, proposal 2.3 / 3.3)
+# ===========================================================================
+def interaction_annotations(pii_entities, step_results, transcript):
+    if not step_results:
+        return []
+    interactions = []
+    for step in step_results:
+        if step["status"] not in ("protocol_step_completed", "protocol_deviation"):
+            # compliance_gap_pii_adjacent: absent step but PII nearby => maybe off-script
+            if step["status"] == "protocol_step_absent" and pii_entities:
+                interactions.append({
+                    "type": "compliance_gap_pii_adjacent", "step_id": step["step_id"],
+                    "note": "Required step not found, but PII present in transcript; "
+                            "step may have occurred informally/off-script. Priority review.",
+                    "priority": "high",
+                })
+            continue
+        # Locate the evidence span for the completed step (best effort)
+        ev = step.get("evidence")
+        if not ev:
+            continue
+        pos = transcript.find(ev)
+        if pos < 0:
+            continue
+        ev_start, ev_end = pos, pos + len(ev)
+        within = [e for e in pii_entities
+                  if e["start"] >= ev_start - 40 and e["end"] <= ev_end + 40]
+        for e in within:
+            if step.get("pii_expected"):
+                itype = "identity_confirmation" if step.get("consent_marker") or \
+                    "identity" in step["step_id"] else "pii_within_protocol_step"
+                note = "PII used within a step where identifying info is expected (benign)."
+                priority = "low"
+            else:
+                itype = "pii_within_protocol_step"
+                note = ("PII appears within a step that should be anonymised -- review "
+                        "whether disclosure was inadvertent.")
+                priority = "high"
+            interactions.append({
+                "type": itype, "step_id": step["step_id"],
+                "pii_text": e["text"], "pii_labels": e["canonical_labels"],
+                "note": note, "priority": priority,
+            })
+    return interactions
+
+
+# ===========================================================================
+# PART F -- COMPOSITE SCORING (poster Section 5)
+# ===========================================================================
+def _pii_signals(pii_entities):
+    """Returns (s, c, pii_confirmed, pii_review).
+
+    pii_confirmed = a CONFIRMED strong identifier whose canonical label is in
+    HARD_GATE_PII_LABELS (the poster's 'certain PII' hard gate -> FAIL).
+    pii_review    = at least one review_worthy span (meaningful PII -> REVIEW).
+    A lone single-engine weak guess is neither: it is recorded but does not flag
+    the file. s/c feed the composite metric; PII never zeroes s on its own unless
+    it is a confirmed hard-gate hit."""
+    if not pii_entities:
+        return 1.0, 0.9, False, False
+    pii_confirmed = any(e.get("confirmed") for e in pii_entities)
+    pii_review = any(e.get("review_worthy") for e in pii_entities)
+    if pii_confirmed:
+        return 0.0, 0.95, True, True
+    if pii_review:
+        # meaningful but unconfirmed -> uncertain score (routes to REVIEW).
+        return 0.6, 0.5, False, True
+    # only lone/weak detections present: not review-worthy on their own.
+    return 0.9, 0.6, False, False
+
+
+def _compliance_check_score(quality, task_result, step_results):
+    """Returns (s, c, missing_required, hard_fail).
+
+    Combines the always-on transcript-quality signal (works with no task metadata)
+    with Tier A/C task results and protocol steps when those exist. The soft score
+    is the MIN of the available sub-scores (a real failure in any dimension is not
+    masked by a good score elsewhere). hard_fail is the OR of the hard signals."""
+    scores, confs, missing_required, hard_fail = [], [], False, False
+    # Quality contributes only when it "applies" (score is not None). For acoustic
+    # tasks, or tasks whose Tier A/C score is authoritative, quality is suppressed
+    # (score None) so a naturally near-empty transcript is not counted as a failure.
+    if quality is not None and quality.get("score") is not None:
+        scores.append(quality["score"])
+        confs.append(quality["confidence"])
+        hard_fail = hard_fail or bool(quality.get("hard_fail"))
+    if task_result and task_result.get("score") is not None:
+        scores.append(task_result["score"])
+        confs.append(task_result.get("confidence") or 0.5)
+    if step_results:
+        required = [s for s in step_results if s["required"]]
+        if required:
+            completed = sum(1 for s in required
+                            if s["status"] in ("protocol_step_completed", "protocol_deviation"))
+            scores.append(completed / len(required))
+            confs.append(sum(s["confidence"] for s in required) / len(required))
+            if completed < len(required):
+                missing_required = True
+    if not scores:
+        return None, None, False, False
+    return (round(min(scores), 3),
+            round(sum(confs) / len(confs), 3), missing_required, hard_fail)
+
+
+def composite_score(pii_entities, task_result, step_results, quality=None):
+    """Q = sum(w*c*s) / sum(w*c);  C = weighted_mean(c) * (1 - lambda*std(c)).
+
+    Three-way decision (poster: Pass / Needs Review / Fail):
+      1. FAIL   - a hard gate fired: CONFIRMED hard-gate PII, a required protocol
+                  step absent, a degenerate transcript (task not performed), or a
+                  compliance score below the fail cutoff.
+      2. REVIEW - flagged but recoverable: meaningful-but-unconfirmed PII (redact),
+                  a combinatorial re-identification cluster, or a middling
+                  compliance/quality score.
+      3. PASS   - no PII worth a reviewer's time and a valid, complete response.
+
+    The three-way logic above is computed first, then FAIL is COLLAPSED into
+    REVIEW at the very end, so the returned ``decision`` is two-way (pass / review)
+    -- nothing is auto-rejected. The pre-collapse severity is still exposed via the
+    ``pii_confirmed`` and ``compliance_fail`` flags in the returned dict.
+    """
+    checks = {}
+    # pii_entities is None (not []) when PII detection was SKIPPED entirely
+    # (--compliance-only). Then PII contributes no check at all, so Q reflects
+    # compliance alone rather than being diluted by a vacuous "clean" PII score.
+    pii_skipped = pii_entities is None
+    if pii_skipped:
+        s_pii = c_pii = None
+        pii_confirmed = pii_review = False
+    else:
+        s_pii, c_pii, pii_confirmed, pii_review = _pii_signals(pii_entities)
+        checks["pii"] = {"s": s_pii, "c": c_pii}
+    s_comp, c_comp, missing_required, quality_hard_fail = \
+        _compliance_check_score(quality, task_result, step_results)
+    if s_comp is not None:
+        checks["compliance"] = {"s": s_comp, "c": c_comp}
+
+    num = den = 0.0
+    weighted_confs, weights = [], []
+    for name, v in checks.items():
+        w = CHECK_WEIGHTS.get(name, 0.5)
+        num += w * v["c"] * v["s"]
+        den += w * v["c"]
+        weighted_confs.append(v["c"])
+        weights.append(w)
+    Q = round(num / den, 3) if den else None
+
+    # There may be NO checks at all: under --compliance-only an acoustic task has its
+    # quality signal suppressed, Tier B skipped and no protocol steps, so nothing is
+    # assessable from text. Q and C are then None (unknown), not 0 (bad).
+    if weights:
+        mean_c = sum(w * c for w, c in zip(weights, weighted_confs)) / sum(weights)
+        if len(weighted_confs) > 1:
+            avg = sum(weighted_confs) / len(weighted_confs)
+            std = (sum((c - avg) ** 2 for c in weighted_confs) / len(weighted_confs)) ** 0.5
+        else:
+            std = 0.0
+        C = round(mean_c * (1 - CONFIDENCE_LAMBDA * std), 3)
+    else:
+        C = None
+
+    missing_step = HARD_GATE_MISSING_REQUIRED_STEP and missing_required
+    compliance_score_fail = s_comp is not None and s_comp < Q_FAIL_CUTOFF
+    compliance_hard = bool(missing_step or quality_hard_fail or compliance_score_fail)
+    compliance_review = s_comp is not None and Q_FAIL_CUTOFF <= s_comp < Q_PASS_CUTOFF
+
+    flagged_by_pii = pii_confirmed or pii_review
+    flagged_by_compliance = compliance_hard or compliance_review
+
+    if pii_confirmed or compliance_hard:
+        decision = "fail"
+    elif pii_review or compliance_review:
+        decision = "review"
+    else:
+        decision = "pass"
+
+    # Final collapse: fold FAIL into REVIEW so the headline verdict is two-way --
+    # Pass or Review only (nothing is auto-rejected). The underlying severity is
+    # still available via pii_confirmed / compliance_fail in the returned dict.
+    if decision == "fail":
+        decision = "review"
+
+    return {"Q": Q, "C": C, "decision": decision, "checks": checks,
+            "pii_skipped": pii_skipped,
+            "flagged_by_pii": bool(flagged_by_pii),
+            "flagged_by_compliance": bool(flagged_by_compliance),
+            # the "serious" (hard-gate) subset of each reason
+            "pii_confirmed": bool(pii_confirmed),
+            "compliance_fail": bool(compliance_hard)}
+
+
+# ===========================================================================
+# PART G -- PIPELINE ORCHESTRATION
+# ===========================================================================
+# .pt metadata keys the pipeline will look for to figure out the task, so no
+# external protocol spec is required (poster input = "Audio + task metadata").
+TASK_NAME_KEYS = ["task_id", "task", "task_name", "prompt_id"]
+REFERENCE_KEYS = ["reference_text", "reference", "target_text", "prompt_text",
+                  "script", "expected_text"]
+PROMPT_KEYS = ["prompt", "task_prompt", "instruction", "rubric",
+               "task_description", "description"]
+TIER_KEYS = ["tier", "compliance_tier"]
+
+
+def extract_task_meta(data):
+    """Pull whatever task info the .pt carries. All fields optional."""
+    def first(keys):
+        for k in keys:
+            v = data.get(k)
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+        return None
+    tier = first(TIER_KEYS)
+    return {
+        "task_id": first(TASK_NAME_KEYS),
+        "reference_text": first(REFERENCE_KEYS),
+        "prompt": first(PROMPT_KEYS),
+        "tier": tier.upper() if tier else None,
+    }
+
+
+class Pipeline:
+    def __init__(self, args, protocol, task_reference=None):
+        self.args = args
+        self.protocol = protocol
+        self.task_reference = task_reference or {}
+        self._load_engines()
+        self.llm = LocalLLM(args.ollama_host, args.ollama_model, LLM_TIMEOUT_SECONDS) \
+            if args.enable_llm else _NullLLM()
+        self.compliance = ComplianceChecker(protocol, self.llm, self.task_reference)
+
+    def _load_engines(self):
+        self.nlp = None
+        self.name_set = self.place_set = None
+        self.gliner = None
+        self.presidio = None
+        # --compliance-only: none of the PII engines are needed. Skipping the loads is
+        # where nearly all the time is saved (spaCy/GLiNER/Presidio startup + per-file
+        # inference); task compliance is pure rules + optional LLM.
+        if getattr(self.args, "compliance_only", False):
+            print("Compliance-only mode: skipping all PII engines.")
+            return
+
+        if self.args.enable_spacy and _importable("spacy"):
+            try:
+                import spacy
+                print(f"Loading spaCy '{self.args.spacy_model}' (rigidity-cascade NER)...")
+                self.nlp = spacy.load(self.args.spacy_model)
+            except Exception as e:  # noqa: BLE001
+                print(f"  [spaCy] unavailable ({e}); NER stage skipped.")
+        elif self.args.enable_spacy:
+            print("  [spaCy] not importable on this interpreter; NER stage skipped.")
+        try:
+            print("Loading name/place gazetteers...")
+            self.name_set = load_name_gazetteer()
+            self.place_set = load_place_gazetteer()
+        except Exception as e:  # noqa: BLE001
+            print(f"  [gazetteer] unavailable ({e}); using empty sets.")
+            self.name_set, self.place_set = set(), load_place_gazetteer()
+
+        if self.args.enable_gliner and _importable("gliner"):
+            try:
+                from gliner import GLiNER
+                print(f"Loading GLiNER '{self.args.gliner_model}' (HIPAA identifiers)...")
+                self.gliner = GLiNER.from_pretrained(self.args.gliner_model)
+            except Exception as e:  # noqa: BLE001
+                print(f"  [GLiNER] unavailable ({e}); GLiNER engine skipped.")
+        elif self.args.enable_gliner:
+            print("  [GLiNER] not importable on this interpreter (skipped).")
+
+        if self.args.enable_presidio and _importable("presidio_analyzer"):
+            try:
+                from presidio_analyzer import AnalyzerEngine
+                print("Loading Presidio analyzer (NER engine)...")
+                self.presidio = AnalyzerEngine()
+            except Exception as e:  # noqa: BLE001
+                print(f"  [Presidio] unavailable ({e}); Presidio engine skipped.")
+        elif self.args.enable_presidio:
+            print("  [Presidio] not importable on this interpreter (skipped).")
+
+    # ---- PII: all engines in parallel, then cross-validate ----
+    def detect_pii(self, text):
+        if not text.strip():
+            return [], None
+        rule = regex_scan(text) + gazetteer_scan(text, self.name_set, self.place_set)
+        rule += honorific_scan(text) + profession_scan(text) + rareword_scan(text, RARE_WORD_ZIPF_THRESHOLD)
+        rule += rare_role_scan(text) + demographic_scan(text) + age_scan(text)
+        if self.nlp is not None:
+            rule += ner_scan(self.nlp, text, self.place_set)
+
+        all_engine = rule + gliner_scan(self.gliner, text, getattr(self.args, "gliner_threshold", GLINER_THRESHOLD)) \
+            + presidio_scan(self.presidio, text)
+        if self.llm.active:
+            all_engine += self.llm.pii_spans(text)
+        # Precision guards: drop format-invalid ids, reclassify holidays, cut
+        # low-confidence soft hits -- applied uniformly across every engine.
+        all_engine = postprocess_entities(all_engine, text)
+
+        weak_misc = [e for e in all_engine if e["category"] in WEAK_RIGID | MISC]
+        combinatorial = combinatorial_scan(text, weak_misc,
+                                            COMBINATORIAL_WINDOW_TOKENS, COMBINATORIAL_THRESHOLD)
+        individually_flagged = [e for e in all_engine
+                                if CATEGORY_WEIGHTS.get(e["category"], 0.3) * e["confidence"]
+                                >= INDIVIDUAL_FLAG_THRESHOLD]
+        # Nuanced quasi-identifiers (rare specific roles, self-disclosed gender/race) are
+        # low-weight MISC and would miss the individual-flag bar, so include them
+        # explicitly -- they carry a deliberate review signal (merge_pii marks them
+        # review_worthy).
+        quasi_identifiers = [e for e in all_engine
+                             if e["method"] == "rare_role"
+                             or e["method"].split(":")[0] == "demographic"]
+        # Same for a very high age (> AGE_REVIEW_OVER_YEARS): AGE is a weak category,
+        # so it would never clear the individual-flag bar -- include it explicitly.
+        elderly_ages = [e for e in all_engine if e.get("age_over_threshold")]
+
+        llm_note = f"{sum(1 for e in all_engine if e['method'].startswith('llm'))} " \
+                   f"span(s) from the LLM" if self.llm.active else None
+
+        merged = merge_pii(individually_flagged + combinatorial + quasi_identifiers
+                           + elderly_ages, text)
+
+        llm_combo = None
+        if self.llm.active and merged:
+            llm_combo = self.llm.pii_combinatorial_vote(text, merged)
+        return merged, {"llm_span_note": llm_note, "llm_combinatorial_vote": llm_combo}
+
+    def analyze(self, transcript, task_meta, filename=None):
+        # --compliance-only: skip PII detection outright (no engines, no scan). pii
+        # stays None so composite_score omits the PII check instead of scoring it clean.
+        if getattr(self.args, "compliance_only", False):
+            pii, pii_llm = None, None
+        else:
+            pii, pii_llm = self.detect_pii(transcript)
+        # Identify the task (from the filename) and route compliance by its modality.
+        task_ctx = self.compliance.resolve_task_context(filename, task_meta)
+        task_result = self.compliance.assess_task(transcript, task_ctx)
+        task_has_score = bool(task_result and task_result.get("score") is not None)
+        modality = task_ctx["modality"] if task_ctx else None
+        # Transcript quality is the compliance signal ONLY for open/unknown tasks with no
+        # tier score. Acoustic tasks (a near-empty transcript is expected) and tasks whose
+        # Tier A/C score is authoritative suppress it, so they are not falsely failed.
+        suppress_quality = (modality == "acoustic") or task_has_score
+        quality = self.compliance.check_quality(transcript, suppress=suppress_quality)
+        # High-recall: surface likely non-compliance the text-level tiers miss
+        # (unexpected speech on acoustic tasks; thin open responses) as REVIEW.
+        # Applied even when Tier C DID score the file: the recall net exists to catch what
+        # the tiers structurally miss, and the LLM judge is the thing most likely to have
+        # been wrong. _compliance_check_score takes the MIN, so this can only add a flag.
+        if HIGH_RECALL and modality in ("acoustic", "open"):
+            quality = _recall_compliance_override(transcript, modality, quality)
+        step_results = self.compliance.check_protocol_steps(transcript)
+        interactions = interaction_annotations(pii or [], step_results, transcript)
+        composite = composite_score(pii, task_result, step_results, quality)
+        # pii is None only under --compliance-only; report the skip explicitly rather
+        # than emitting zero counts that would read as "scanned and found nothing".
+        pii_block = ({"skipped": True, "entities": [], "num_entities": None,
+                      "cross_validated": None, "review_worthy": None,
+                      "confirmed": None, "llm": None}
+                     if pii is None else
+                     {"skipped": False, "entities": pii, "num_entities": len(pii),
+                      "cross_validated": sum(1 for e in pii if e["cross_validated"]),
+                      "review_worthy": sum(1 for e in pii if e.get("review_worthy")),
+                      "confirmed": sum(1 for e in pii if e.get("confirmed")),
+                      "llm": pii_llm})
+        return {
+            "pii": pii_block,
+            "compliance": {"task_context": task_ctx, "quality": quality,
+                           "task": task_result, "protocol_steps": step_results},
+            "interactions": interactions,
+            "composite": composite,
+            "masked_preview": build_masked_preview(transcript, pii) if pii else transcript,
+        }
+
+
+class _NullLLM:
+    """Stand-in when the LLM is off, so callers never branch on None."""
+    active = False
+
+    def pii_spans(self, text):
+        return []
+
+    def pii_combinatorial_vote(self, *a):
+        return None
+
+    def compliance_vote(self, *a):
+        return None
+
+    def task_judge_vote(self, *a):
+        return None
+
+    def transcript_completion_vote(self, *a):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# .pt loading + folder processing
+# ---------------------------------------------------------------------------
+def load_pt(path):
+    """Returns (transcription, task_meta, error). transcription/error mutually exclusive."""
+    try:
+        data = torch.load(path, map_location="cpu", weights_only=False)
+    except Exception as e:  # noqa: BLE001
+        return None, None, f"failed to load .pt file: {e}"
+    if not isinstance(data, dict) or "transcription" not in data:
+        return None, None, "no 'transcription' key found in loaded object"
+    transcription = data["transcription"]
+    if transcription is None:
+        return None, None, "'transcription' key is None"
+    if not isinstance(transcription, str):
+        transcription = str(transcription)
+    return transcription, extract_task_meta(data), None
+
+
+def process_file(path, pipeline):
+    transcription, task_meta, error = load_pt(path)
+    if error:
+        return {"file": str(path), "error": error}
+    result = pipeline.analyze(transcription, task_meta, filename=Path(path).name)
+    task_ctx = result["compliance"].get("task_context") or {}
+    return {"file": str(path),
+            "task_id": task_ctx.get("task_id") or task_meta.get("task_id"),
+            "modality": task_ctx.get("modality"),
+            "decision": result["composite"]["decision"], **result}
+
+
+def process_folder(folder, pipeline, recursive, max_files):
+    files = sorted(folder.glob("**/*.pt" if recursive else "*.pt"))
+    if max_files:
+        files = files[:max_files]
+    if not files:
+        print(f"No .pt files found in {folder} (recursive={recursive})")
+
+    results, errors = [], []
+    for i, path in enumerate(files, 1):
+        rec = process_file(path, pipeline)
+        if "error" in rec:
+            errors.append(rec)
+            print(f"[{i}/{len(files)}] {path.name}: ERROR - {rec['error']}")
+        else:
+            results.append(rec)
+            comp = rec["composite"]
+            print(f"[{i}/{len(files)}] {path.name}: {rec['decision'].upper()} "
+                  f"(Q={comp['Q']}, C={comp['C']}, "
+                  f"{'PII skipped' if rec['pii'].get('skipped') else str(rec['pii']['review_worthy']) + '/' + str(rec['pii']['num_entities']) + ' PII review-worthy'}, "
+                  f"task={rec.get('task_id')}, modality={rec.get('modality')})")
+
+    def tally(key_fn):
+        out = {}
+        for r in results:
+            k = key_fn(r)
+            out[k] = out.get(k, 0) + 1
+        return out
+    summary = {
+        "pass": sum(1 for r in results if r["decision"] == "pass"),
+        "review": sum(1 for r in results if r["decision"] == "review"),
+        "fail": sum(1 for r in results if r["decision"] == "fail"),
+        # where the flags come from (these overlap when a file has both)
+        "flagged_by_pii": sum(1 for r in results if r["composite"]["flagged_by_pii"]),
+        "flagged_by_compliance": sum(1 for r in results if r["composite"]["flagged_by_compliance"]),
+        "pii_confirmed": sum(1 for r in results if r["composite"]["pii_confirmed"]),
+        "compliance_fail": sum(1 for r in results if r["composite"]["compliance_fail"]),
+        "modality_breakdown": tally(lambda r: r.get("modality") or "unknown"),
+        "unresolved_tasks": sorted({r.get("task_id") for r in results
+                                    if r.get("modality") is None and r.get("task_id")}),
+        # Scripted tasks with no reference text get NO word-error-rate check (so reading
+        # the wrong text cannot be detected). Surfaced here because it looks like a
+        # clean pass otherwise. Fix: add the task's prompts via --task-reference.
+        "scripted_without_reference": sorted({
+            r.get("task_id") for r in results
+            if (r["compliance"].get("task_context") or {}).get("reference_missing")
+            and r.get("task_id")}),
+        "ambiguous_task_matches": sorted({
+            r.get("task_id") for r in results
+            if (r["compliance"].get("task_context") or {}).get("ambiguous_match")
+            and r.get("task_id")}),
+        "errors": len(errors),
+        # THE DELIVERABLE: which files a human actually has to look at. Everything
+        # above is a count; this is the list. A file is flagged when its decision is
+        # anything other than "pass" -- i.e. PII worth redacting, a compliance
+        # problem, or both. (`decision` is two-way by the time it gets here: FAIL is
+        # collapsed into REVIEW, since nothing is ever auto-rejected. The severity
+        # behind each entry is in `reasons` / the per-file record.)
+        "flagged_files": [
+            {"file": str(r["file"]), "name": Path(r["file"]).name,
+             "task_id": r.get("task_id"), "modality": r.get("modality"),
+             "reasons": _flag_reasons(r)}
+            for r in results if r["decision"] != "pass"],
+    }
+    return {"folder": str(folder), "num_files": len(files),
+            "summary": summary, "files": results, "errors": errors}
+
+
+def _flag_reasons(rec):
+    """Short human-readable tags for WHY a file was flagged, most serious first."""
+    cx = rec["composite"]
+    reasons = []
+    if cx["pii_confirmed"]:
+        reasons.append("pii:confirmed")
+    elif cx["flagged_by_pii"]:
+        reasons.append("pii:review")
+    if cx["compliance_fail"]:
+        reasons.append("compliance:fail")
+    elif cx["flagged_by_compliance"]:
+        reasons.append("compliance:review")
+    return reasons
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+def write_json(report, path):
+    Path(path).write_text(json.dumps(report, indent=2, default=str))
+    print(f"Wrote JSON report to {path}")
+
+
+def write_csv(report, path):
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["file", "task_id", "modality", "tier", "decision",
+                    "flagged_by_pii", "flagged_by_compliance", "pii_confirmed",
+                    "compliance_fail", "quality_status", "Q", "C", "num_pii",
+                    "pii_review_worthy", "pii_cross_validated", "num_interactions",
+                    "pii_labels", "compliance_summary"])
+        for r in report["files"]:
+            labels = "skipped" if r["pii"].get("skipped") else ";".join(sorted({l for e in r["pii"]["entities"]
+                                      for l in e["canonical_labels"]}))
+            comp = r["compliance"]
+            cx = r["composite"]
+            quality = comp.get("quality") or {}
+            task = comp.get("task") or {}
+            csummary = [f"quality:{quality.get('status')}"]
+            if comp["task"]:
+                csummary.append(f"task:{task.get('completed')}")
+                if task.get("wer") is not None:
+                    csummary.append(f"wer:{task.get('wer')}")
+                # Tier A triage detail: coverage says whether the script was read at all,
+                # word_errors gives the absolute (length-independent) size of the mismatch.
+                if task.get("coverage") is not None:
+                    csummary.append(f"coverage:{task.get('coverage')}")
+                    csummary.append(f"errs:{task.get('word_errors')}/{task.get('ref_words')}w")
+                if task.get("precision_guard"):
+                    csummary.append(f"guard:{task['precision_guard']}")
+            if comp["protocol_steps"]:
+                statuses = [s["status"] for s in comp["protocol_steps"]]
+                csummary.append(f"steps:{sum(1 for s in statuses if 'completed' in s)}/{len(statuses)}")
+            w.writerow([r["file"], r.get("task_id"), r.get("modality"), task.get("tier"),
+                        r["decision"], cx["flagged_by_pii"], cx["flagged_by_compliance"],
+                        cx["pii_confirmed"], cx["compliance_fail"],
+                        quality.get("status"), cx["Q"], cx["C"],
+                        r["pii"]["num_entities"], r["pii"].get("review_worthy"),
+                        r["pii"]["cross_validated"], len(r["interactions"]),
+                        labels, " ".join(csummary)])
+        for r in report["errors"]:
+            w.writerow([r["file"]] + [""] * 16 + [r["error"]])
+    print(f"Wrote CSV summary to {path}")
+
+
+def print_summary(report):
+    s = report["summary"]
+    print("\n--- Summary ---")
+    print(f"Files processed: {report['num_files']}")
+    print(f"  pass:                  {s['pass']}")
+    print(f"  review:                {s['review']}  (soft gate -> human review)")
+    print(f"  fail:                  {s['fail']}  (hard gate)")
+    print("  -- flag breakdown (a file can be flagged by both) --")
+    print(f"  flagged_by_pii:        {s['flagged_by_pii']}   (of which confirmed hard-gate PII: {s['pii_confirmed']})")
+    print(f"  flagged_by_compliance: {s['flagged_by_compliance']}   (of which hard compliance fail: {s['compliance_fail']})")
+    if s.get("modality_breakdown"):
+        parts = ", ".join(f"{k}={v}" for k, v in sorted(s["modality_breakdown"].items()))
+        print(f"  -- task modality --  {parts}")
+    if s.get("unresolved_tasks"):
+        print(f"  -- tasks not in reference (compliance via quality only): {s['unresolved_tasks']}")
+    if s.get("scripted_without_reference"):
+        print(f"\n  !! {len(s['scripted_without_reference'])} SCRIPTED task(s) have NO reference "
+              f"text, so no word-error-rate check ran for them -- reading the WRONG text "
+              f"cannot be detected. Add their prompts via --task-reference:")
+        for t in s["scripted_without_reference"][:10]:
+            print(f"       {t}")
+        if len(s["scripted_without_reference"]) > 10:
+            print(f"       ... and {len(s['scripted_without_reference']) - 10} more")
+    if s.get("ambiguous_task_matches"):
+        print(f"  !! ambiguous task->reference matches (prompt may be from a sibling "
+              f"variant): {s['ambiguous_task_matches']}")
+    print(f"  errors:                {s['errors']}")
+    print_flagged_files(report)
+
+
+def print_flagged_files(report, limit=25):
+    """Print the pipeline's actual output: the names of the files to review.
+
+    Bounded so a large corpus does not bury the summary -- the complete list is
+    always in the JSON report under summary.flagged_files, and --flagged-list
+    writes it to its own plain-text file."""
+    flagged = report["summary"].get("flagged_files") or []
+    print(f"\n--- Flagged files ({len(flagged)}) ---")
+    if not flagged:
+        print("  none -- every file passed.")
+        return
+    width = max(len(f["name"]) for f in flagged[:limit])
+    for f in flagged[:limit]:
+        print(f"  {f['name']:<{width}}  {', '.join(f['reasons']) or 'flagged'}")
+    if len(flagged) > limit:
+        print(f"  ... and {len(flagged) - limit} more "
+              f"(full list: summary.flagged_files in the JSON report, or --flagged-list)")
+
+
+def write_flagged_list(report, path):
+    """Write just the flagged file paths, one per line -- the plain-text handoff to
+    whatever does the redaction/review next (xargs, a work queue, a spreadsheet)."""
+    flagged = report["summary"].get("flagged_files") or []
+    Path(path).write_text("".join(f["file"] + "\n" for f in flagged))
+    print(f"Wrote {len(flagged)} flagged file path(s) to {path}")
+
+
+# ---------------------------------------------------------------------------
+# Protocol spec
+# ---------------------------------------------------------------------------
+def load_protocol(path):
+    if not path:
+        return {}
+    p = Path(path)
+    if not p.is_file():
+        print(f"  [protocol] '{path}' not found; compliance runs task-only/empty.")
+        return {}
+    try:
+        return json.loads(p.read_text())
+    except Exception as e:  # noqa: BLE001
+        print(f"  [protocol] failed to parse '{path}' ({e}); continuing without it.")
+        return {}
+
+
+def resolve_task_reference_path(path):
+    """Absolute path of the task reference JSON. A relative path resolves NEXT TO THIS
+    SCRIPT, not against the working directory -- task_reference.json is a companion of
+    the script, so it must be found however the script is invoked."""
+    p = Path(path)
+    return p if p.is_absolute() else Path(__file__).resolve().parent / p
+
+
+def load_task_reference(path):
+    """Load the task -> {instructions, prompts} table that drives filename-based task
+    compliance.
+
+    This is the companion file the pipeline checks each .pt against: the `task-<Name>`
+    field of a filename is looked up here to learn the task's modality and, for a
+    scripted task, the reference text the participant was supposed to read.
+
+    A configured path that is missing or unparseable STOPS the run. It is not treated
+    as "no reference": without this table every scripted task silently loses its Tier A
+    word-error-rate check, so reading the WRONG script stops being detectable and the
+    files sail through as clean passes. That failure is invisible in the output, so it
+    is refused up front instead. To run deliberately without it, set TASK_REFERENCE = ""
+    (or pass --no-task-reference) -- compliance then falls back to transcript quality."""
+    if not path:
+        print("  [task-reference] disabled -- filename-based task compliance is OFF; "
+              "compliance falls back to transcript quality only.")
+        return {}
+    p = resolve_task_reference_path(path)
+    if not p.is_file():
+        raise SystemExit(
+            f"Task reference not found -- stopping.\n"
+            f"  looked for: {p}\n"
+            f"'{Path(p).name}' is the companion file this script checks each .pt against; "
+            f"keep it in the same folder as the script.\n"
+            f"Set TASK_REFERENCE in the CONFIG block (top of this file) to point elsewhere, "
+            f"or set it to \"\" to run without filename-based task compliance.")
+    try:
+        ref = json.loads(p.read_text())
+    except Exception as e:  # noqa: BLE001
+        raise SystemExit(f"Task reference {p} could not be parsed -- stopping.\n  {e}")
+    if not isinstance(ref, dict) or not ref:
+        raise SystemExit(f"Task reference {p} is empty or is not a JSON object -- stopping.")
+    print(f"  [task-reference] loaded {len(ref)} task definitions from {p.name}")
+    return ref
+
+
+# ---------------------------------------------------------------------------
+# Self-test (synthetic data only -- never reads real transcripts)
+# ---------------------------------------------------------------------------
+def run_selftest(args):
+    print("Running self-test on SYNTHETIC .pt files (no real data touched)...")
+    checks = {}
+
+    # ---- Part A: ZERO-CONFIG (no protocol spec). Task info comes from the .pt. ----
+    print("\n[Part A] Zero-config run -- task metadata read from each .pt, no spec.")
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        torch.save({"transcription": "My name is John Smith, SSN 123-45-6789, "
+                                     "email john.smith@example.com."}, tmp / "strong_pii.pt")
+        torch.save({"transcription": "The weather was pleasant and the tea was warm."},
+                   tmp / "clean.pt")
+        torch.save({"transcription": "The 84-year-old retired engineer admitted last "
+                                     "Tuesday described his symptoms to the nurse in Ward 3."},
+                   tmp / "combinatorial.pt")
+        # scripted task: reference text travels WITH the file -> Tier A, no spec needed
+        torch.save({"transcription": "the cat sat on a mat", "task": "read_sentence",
+                    "reference_text": "the cat sat on the mat"}, tmp / "scripted_task.pt")
+        # open-ended task: only a prompt travels with the file -> Tier C
+        torch.save({"transcription": "My name is Jane and my favorite show is The Office.",
+                    "task": "favorite_show",
+                    "prompt": "State your name and your favorite show."}, tmp / "open_task.pt")
+        # DEGENERATE transcripts -> genuine compliance FAILURES, no metadata needed.
+        torch.save({"transcription": ""}, tmp / "empty.pt")
+        torch.save({"transcription": "uh um uh... [inaudible]"}, tmp / "nonspeech.pt")
+        torch.save({"transcription": "yeah"}, tmp / "tooshort.pt")
+
+        args.protocol = None
+        pipeline = Pipeline(args, {})
+        report = process_folder(tmp, pipeline, False, None)
+        print_summary(report)
+        by = {Path(r["file"]).name: r for r in report["files"]}
+        checks.update({
+            "A: strong_pii.pt -> REVIEW, PII-confirmed (real SSN + email)":
+                by["strong_pii.pt"]["decision"] == "review"
+                and by["strong_pii.pt"]["composite"]["flagged_by_pii"]
+                and by["strong_pii.pt"]["composite"]["pii_confirmed"],
+            "A: clean.pt -> pass, no PII, valid transcript":
+                by["clean.pt"]["pii"]["num_entities"] == 0
+                and by["clean.pt"]["decision"] == "pass",
+            "A: weak-only combinatorial file -> REVIEW, not confirmed, not failed":
+                by["combinatorial.pt"]["decision"] == "review"
+                and not by["combinatorial.pt"]["composite"]["pii_confirmed"],
+            "A: combinatorial.pt -> PII flagged":
+                by["combinatorial.pt"]["pii"]["num_entities"] > 0,
+            "A: empty.pt -> REVIEW, hard compliance fail (task not performed)":
+                by["empty.pt"]["decision"] == "review"
+                and by["empty.pt"]["composite"]["flagged_by_compliance"]
+                and by["empty.pt"]["composite"]["compliance_fail"]
+                and not by["empty.pt"]["composite"]["flagged_by_pii"],
+            "A: non-speech-only transcript -> REVIEW, hard compliance fail":
+                by["nonspeech.pt"]["decision"] == "review"
+                and by["nonspeech.pt"]["composite"]["compliance_fail"],
+            "A: too-short response -> REVIEW by compliance (not a hard fail)":
+                by["tooshort.pt"]["decision"] == "review"
+                and by["tooshort.pt"]["composite"]["flagged_by_compliance"]
+                and not by["tooshort.pt"]["composite"]["compliance_fail"],
+            "A: scripted_task.pt -> Tier A from .pt metadata (no spec)":
+                (by["scripted_task.pt"]["compliance"]["task"] or {}).get("tier") == "A",
+            "A: scripted_task.pt -> WER ~0.17 (one sub in 6 words)":
+                abs((by["scripted_task.pt"]["compliance"]["task"] or {}).get("wer", -1)
+                    - (1 / 6)) < 0.01,
+            "A: open_task.pt -> routed to Tier C (open modality); quality carries it w/o LLM":
+                (by["open_task.pt"]["compliance"]["task_context"] or {}).get("tier") == "C"
+                and (by["open_task.pt"]["compliance"]["task_context"] or {}).get("modality") == "open",
+            "A: no protocol steps run without a spec":
+                by["clean.pt"]["compliance"]["protocol_steps"] is None,
+            "A: every file now gets a transcript-quality signal":
+                all(r["compliance"]["quality"] is not None for r in report["files"]),
+        })
+
+    # ---- Part B: OPTIONAL spec enables interview-style protocol-step checking. ----
+    print("\n[Part B] With an optional protocol spec -> protocol-step checking.")
+    protocol = {
+        "protocol_steps": [
+            {"step_id": "consent", "step_description": "Obtain verbal consent before beginning.",
+             "required_speaker": "researcher", "sequence_position": 1, "required": True,
+             "canonical_phrases": ["is it okay if I record this", "do you consent"],
+             "pii_expected": False, "consent_marker": True},
+            {"step_id": "confirm_identity", "step_description": "Confirm participant identity.",
+             "required_speaker": "researcher", "sequence_position": 2, "required": True,
+             "canonical_phrases": ["can you confirm your name", "state your date of birth"],
+             "pii_expected": True},
+        ],
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        torch.save({"transcription": "Before we start, is it okay if I record this? "
+                                     "Great. Can you confirm your name for me?"},
+                   tmp / "interview.pt")
+        pipeline = Pipeline(args, protocol)
+        report = process_folder(tmp, pipeline, False, None)
+        steps = report["files"][0]["compliance"]["protocol_steps"]
+        checks["B: consent step completed from canonical phrase"] = \
+            any(s["step_id"] == "consent" and "completed" in s["status"] for s in (steps or []))
+
+    # ---- Part C: precision guards (deterministic, engine-independent). ----
+    print("\n[Part C] Precision guards -- false-positive reduction.")
+    # Structured-identifier validation: a word-only "identifier" is dropped.
+    txt = "cough Easter 123-45-6789"
+    ents = [_entity(0, 5, "IDNUM", 0.8, "gliner"),          # 'cough' -> invalid id, drop
+            _entity(6, 12, "LOC_SPECIFIC", 0.8, "gliner"),  # 'Easter' -> reclassify to DATE
+            _entity(13, 24, "IDNUM", 0.95, "regex")]        # real SSN -> keep
+    post = postprocess_entities(ents, txt)
+    kept = {(txt[e["start"]:e["end"]], e["category"]) for e in post}
+    checks["C: word-only 'cough' IDNUM dropped"] = ("cough", "IDNUM") not in kept
+    checks["C: 'Easter' reclassified away from LOCATION -> DATE"] = \
+        ("Easter", "DATE_PARTIAL") in kept and ("Easter", "LOC_SPECIFIC") not in kept
+    checks["C: valid SSN kept as IDNUM"] = ("123-45-6789", "IDNUM") in kept
+    checks["C: validator basics"] = (
+        not _valid_structured_identifier("cough", "IDNUM")
+        and _valid_structured_identifier("123-45-6789", "IDNUM")
+        and _valid_structured_identifier("a@b.com", "CONTACT")
+        and not _valid_structured_identifier("hello", "CONTACT"))
+    # GLiNER windowing: long text is chunked (no silent truncation) with correct offsets.
+    long_text = " ".join(f"w{i}" for i in range(1000))          # 1000 words >> 384 cap
+    chunks = list(_gliner_chunks(long_text, GLINER_MAX_WORDS, GLINER_OVERLAP_WORDS))
+    checks["C: long text is split into multiple GLiNER chunks"] = len(chunks) >= 3
+    checks["C: every chunk is within the token cap"] = \
+        all(len(c.split()) <= GLINER_MAX_WORDS for c, _ in chunks)
+    checks["C: chunk offsets map back to the original text exactly"] = \
+        all(long_text[off:off + len(c)] == c for c, off in chunks)
+    checks["C: chunks cover the whole transcript (start..end)"] = \
+        chunks[0][1] == 0 and (chunks[-1][1] + len(chunks[-1][0])) == len(long_text)
+    # Decision is 3-way (pass/review/fail); reason split into PII vs compliance.
+    ssn = merge_pii([_entity(0, 11, "IDNUM", 0.95, "regex")], "123-45-6789")
+    ssn_cx = composite_score(ssn, None, None)
+    checks["C: real SSN -> REVIEW, by PII, confirmed"] = (
+        ssn_cx["decision"] == "review" and ssn_cx["flagged_by_pii"]
+        and ssn_cx["pii_confirmed"] and not ssn_cx["flagged_by_compliance"])
+    # A failed scripted task -> FAIL, flagged by compliance only.
+    bad_task = {"tier": "A", "score": 0.1, "confidence": 0.9, "completed": False, "required": True}
+    ct = composite_score([], bad_task, None)
+    checks["C: failed task -> REVIEW, by COMPLIANCE only"] = (
+        ct["decision"] == "review" and ct["flagged_by_compliance"]
+        and ct["compliance_fail"] and not ct["flagged_by_pii"])
+
+    # ---- Transcript-quality compliance (works with NO task metadata) ----
+    q_empty = assess_transcript_quality("")
+    q_nonspeech = assess_transcript_quality("uh um [noise] (coughing)")
+    q_short = assess_transcript_quality("yeah okay")
+    q_ok = assess_transcript_quality("the cat sat on the mat quietly this afternoon")
+    checks["C: empty transcript -> hard_fail quality"] = \
+        q_empty["status"] == "empty" and q_empty["hard_fail"] and q_empty["score"] == 0.0
+    checks["C: non-speech/filler-only -> hard_fail quality"] = \
+        q_nonspeech["status"] == "non_speech_only" and q_nonspeech["hard_fail"]
+    checks["C: short response -> review-band quality (not hard fail)"] = \
+        (not q_short["hard_fail"]) and Q_FAIL_CUTOFF <= q_short["score"] < Q_PASS_CUTOFF
+    checks["C: substantive transcript -> ok quality, passes"] = \
+        q_ok["status"] == "ok" and (not q_ok["hard_fail"]) and q_ok["score"] >= Q_PASS_CUTOFF
+    checks["C: empty transcript -> composite REVIEW, hard compliance fail"] = (
+        composite_score([], None, None, q_empty)["decision"] == "review"
+        and composite_score([], None, None, q_empty)["compliance_fail"])
+    checks["C: ok transcript, no PII -> composite PASS"] = \
+        composite_score([], None, None, q_ok)["decision"] == "pass"
+
+    # NAME precision -- the main false-positive lever.
+    # (a) A lone common word tagged NAME by NER models, no name context: even when
+    #     TWO engines share the false positive it must NOT flag the file.
+    will = merge_pii([_entity(0, 4, "NAME", 0.8, "ner"),
+                      _entity(0, 4, "NAME", 0.75, "gliner")], "Will you sit down now")
+    # (b) The same word WITH a name-introduction cue => a real name.
+    will_ctx = merge_pii([_entity(11, 15, "NAME", 0.8, "ner")], "my name is Will and I agree")
+    # (c) A multi-token name => real.
+    full = merge_pii([_entity(6, 18, "NAME", 0.8, "gliner")], "I met Sarah Connor yesterday.")
+    # FLAG_ALL_NAMES (default): even a lone common word tagged NAME with no name signal
+    # is now REVIEW-worthy -- every name is flagged. It is still never *confirmed*
+    # (no hard-gate eligibility), so it can never auto-fail a file.
+    checks["C: common-word NAME -> REVIEW (all names flagged), still not confirmed"] = (
+        (not will[0]["hard_gate_eligible"]) and will[0]["review_worthy"] is True
+        and composite_score(will, None, None, q_ok)["pii_confirmed"] is False
+        and composite_score(will, None, None, q_ok)["decision"] == "review")
+    # A real name (cue, or multi-token) is REVIEW by default (redaction queue), NOT
+    # a hard fail -- names are redactable PII, not reject-worthy.
+    checks["C: NAME with 'my name is' cue -> REVIEW, review-worthy, not confirmed"] = (
+        will_ctx[0]["hard_gate_eligible"] and will_ctx[0]["review_worthy"]
+        and composite_score(will_ctx, None, None, q_ok)["pii_confirmed"] is False
+        and composite_score(will_ctx, None, None, q_ok)["decision"] == "review")
+    checks["C: multi-token NAME -> REVIEW, review-worthy, not confirmed"] = (
+        full[0]["hard_gate_eligible"] and full[0]["review_worthy"]
+        and composite_score(full, None, None, q_ok)["pii_confirmed"] is False
+        and composite_score(full, None, None, q_ok)["decision"] == "review")
+    # Tightening: ADD NAME back to the gate -> the same real name now hard-FAILS.
+    _mod = sys.modules[__name__]
+    saved_labels = _mod.HARD_GATE_PII_LABELS
+    _mod.HARD_GATE_PII_LABELS = {"NAME", "IDNUM", "CONTACT", "URL"}
+    full2 = merge_pii([_entity(6, 18, "NAME", 0.8, "gliner")], "I met Sarah Connor yesterday.")
+    gated = composite_score(full2, None, None, q_ok)
+    checks["C: adding NAME to gate -> REVIEW, confirmed"] = (
+        gated["decision"] == "review" and gated["pii_confirmed"] is True)
+    _mod.HARD_GATE_PII_LABELS = saved_labels
+
+    # ---- Nuanced quasi-identifier: rare specific role/activity -> REVIEW ----
+    skater_txt = "I am a professional figure skater and I train daily"
+    skater = merge_pii(rare_role_scan(skater_txt), skater_txt)
+    dev_txt = "we scheduled some professional development this week"
+    dev = merge_pii(rare_role_scan(dev_txt), dev_txt)
+    checks["C: 'professional figure skater' -> review-worthy MISC (not confirmed)"] = (
+        len(skater) >= 1 and skater[0].get("review_worthy") is True
+        and skater[0].get("confirmed") is False
+        and composite_score(skater, None, None, q_ok)["decision"] == "review"
+        and composite_score(skater, None, None, q_ok)["flagged_by_pii"] is True)
+    checks["C: 'professional development' -> not flagged (common role word)"] = (len(dev) == 0)
+
+    # ---- Demographic quasi-identifiers: self-disclosed gender & race -> REVIEW ----
+    race_txt = "I grew up in a small town and I am Black"
+    race = merge_pii(demographic_scan(race_txt), race_txt)
+    gender_txt = "to answer your question I identify as nonbinary"
+    gender = merge_pii(demographic_scan(gender_txt), gender_txt)
+    eth_txt = "my ethnicity is Korean and I moved here in 2001"
+    eth = merge_pii(demographic_scan(eth_txt), eth_txt)
+    neg_txt = "I drank black coffee and we ate Chinese food last night"
+    neg = merge_pii(demographic_scan(neg_txt), neg_txt)
+    rainbow_txt = ("when the sunlight strikes raindrops in the air they act as a "
+                   "prism and form a rainbow the white light is divided")
+    rainbow_demo = demographic_scan(rainbow_txt)
+    checks["C: 'I am Black' -> review-worthy MISC race (not confirmed), composite REVIEW"] = (
+        len(race) >= 1 and race[0].get("review_worthy") is True
+        and race[0].get("confirmed") is False and race[0]["canonical_labels"] == ["MISC"]
+        and composite_score(race, None, None, q_ok)["decision"] == "review"
+        and composite_score(race, None, None, q_ok)["flagged_by_pii"] is True)
+    checks["C: 'identify as nonbinary' -> review-worthy MISC gender"] = (
+        len(gender) >= 1 and gender[0].get("review_worthy") is True
+        and "demographic" in gender[0]["engines"])
+    checks["C: 'my ethnicity is Korean' -> review-worthy MISC"] = (
+        len(eth) >= 1 and eth[0].get("review_worthy") is True)
+    checks["C: demographic PII never hard-fails (MISC not in HARD_GATE_PII_LABELS)"] = (
+        all(e.get("confirmed") is False for e in race + gender + eth)
+        and composite_score(race, None, None, q_ok)["decision"] != "fail")
+    checks["C: 'black coffee' / 'Chinese food' -> NOT flagged (no self anchor)"] = (len(neg) == 0)
+    checks["C: scripted 'white light' passage -> no demographic false positive"] = (len(rainbow_demo) == 0)
+
+    # ---- Filename -> task -> tier routing (engine-independent) ----
+    ref = {"rainbow": {"instructions": "Please read the passage out loud.",
+                       "prompts": ["When the sunlight strikes raindrops in the air, "
+                                   "they act as a prism and form a rainbow."]},
+           "maximum-phonation-time": {"instructions": "Hold 'ah' as long as you can.", "prompts": []},
+           "free-speech-1": {"instructions": "Answer the question.",
+                             "prompts": ["Why are you interested in this study?"]}}
+    cc = ComplianceChecker({}, _NullLLM(), task_reference=ref)
+    ctx_r = cc.resolve_task_context("sub-1_ses-2_task-rainbow_features.pt", {})
+    ctx_m = cc.resolve_task_context("sub-1_ses-2_task-Maximum-Phonation-Time_features.pt", {})
+    ctx_f = cc.resolve_task_context("sub-1_ses-2_task-Free-Speech-1_features.pt", {})
+    good_read = cc.assess_task("when the sunlight strikes raindrops in the air they act "
+                               "as a prism and form a rainbow", ctx_r)
+    bad_read = cc.assess_task("i really do not want to do this task today", ctx_r)
+    acoustic = cc.assess_task("aaaah", ctx_m)
+    checks["C: filename task-rainbow -> scripted Tier A"] = (
+        ctx_r and ctx_r["modality"] == "scripted" and ctx_r["tier"] == "A"
+        and bool(ctx_r["reference_texts"]))
+    checks["C: correct read -> Tier A high score, completed"] = (
+        good_read["score"] >= 0.7 and good_read["completed"] is True)
+    checks["C: wrong content on scripted task -> Tier A fail -> composite REVIEW"] = (
+        bad_read["score"] < 0.5
+        and composite_score([], bad_read, None, None)["decision"] == "review"
+        and composite_score([], bad_read, None, None)["flagged_by_compliance"] is True)
+    checks["C: filename task-Maximum-Phonation-Time -> acoustic Tier B, skipped"] = (
+        ctx_m and ctx_m["modality"] == "acoustic" and ctx_m["tier"] == "B"
+        and acoustic["score"] is None)
+    q_sup = cc.check_quality("aaaah", suppress=True)
+    checks["C: acoustic near-empty transcript is NOT a compliance fail"] = (
+        q_sup["score"] is None
+        and composite_score([], acoustic, None, q_sup)["decision"] == "pass"
+        and composite_score([], acoustic, None, q_sup)["compliance_fail"] is False)
+    checks["C: filename task-Free-Speech-1 -> open Tier C"] = (
+        ctx_f and ctx_f["modality"] == "open" and ctx_f["tier"] == "C")
+
+    # ---- Tier A calibration: WER on read speech is ASR noise until it is not ----
+    # These are the dominant false-positive modes on real ASR of clinical read-aloud
+    # speech. Each one is a participant who DID read the script.
+    capev = {"cape-V-sentences-4": {"instructions": "Read the sentence out loud.",
+                                    "prompts": ["We eat eggs every Easter."]}}
+    cc_a = ComplianceChecker({}, _NullLLM(), task_reference=capev)
+    ctx_a = cc_a.resolve_task_context("sub-1_ses-1_task-Cape-V-sentences-4_features.pt", {})
+    one_slip = cc_a.assess_task("we eat eggs every easter", ctx_a)          # perfect
+    misheard = cc_a.assess_task("we eat eggs every eastern", ctx_a)         # 1 sub in 5 -> WER 0.2
+    mangled = cc_a.assess_task("he eats eggs every eastern", ctx_a)         # 3 subs in 5 -> WER 0.6
+    restart = cc_a.assess_task("sorry let me start over we eat eggs every easter", ctx_a)
+    off_script = cc_a.assess_task("i do not want to read this one", ctx_a)
+    stats_ins = alignment_stats("we eat eggs every easter",
+                                "sorry let me start over we eat eggs every easter")
+
+    checks["G: alignment separates insertions from missed reference words"] = (
+        stats_ins["coverage"] == 1.0 and stats_ins["insertions"] == 5
+        and stats_ins["substitutions"] == 0 and stats_ins["deletions"] == 0
+        and stats_ins["wer"] == 1.0)
+    checks["G: perfect read -> WER 0, coverage 1, PASS"] = (
+        one_slip["wer"] == 0.0 and one_slip["coverage"] == 1.0
+        and composite_score([], one_slip, None, None)["decision"] == "pass")
+    checks["G: 1 misheard word in a 5-word sentence -> NOT flagged (WER threshold)"] = (
+        misheard["wer"] == 0.2 and misheard["word_errors"] == 1
+        and misheard["precision_guard"] is None
+        and composite_score([], misheard, None, None)["decision"] == "pass")
+    checks["G: 3 misheard words in a 5-word sentence -> NOT flagged (min-word-errors guard)"] = (
+        mangled["wer"] == 0.6 and mangled["word_errors"] == 3
+        and mangled["precision_guard"] == "below_min_word_errors"
+        and composite_score([], mangled, None, None)["decision"] == "pass")
+    checks["G: false start before a correct read -> flagged while the coverage guard is OFF"] = (
+        restart["wer"] >= 1.0 and restart["coverage"] == 1.0
+        and restart["precision_guard"] is None
+        and composite_score([], restart, None, None)["decision"] == "review")
+    # ...and the guard does what it claims when a study's labels call for it.
+    _saved_cov, globals()["TIER_A_COVERAGE_PASS"] = TIER_A_COVERAGE_PASS, 0.90
+    try:
+        restart_guarded = cc_a.assess_task(
+            "sorry let me start over we eat eggs every easter", ctx_a)
+        off_script_guarded = cc_a.assess_task("i do not want to read this one", ctx_a)
+    finally:
+        globals()["TIER_A_COVERAGE_PASS"] = _saved_cov
+    checks["G: coverage guard, when enabled, clears an insertion-only read"] = (
+        restart_guarded["precision_guard"] == "reference_covered"
+        and composite_score([], restart_guarded, None, None)["decision"] == "pass")
+    checks["G: coverage guard, even enabled, never clears an off-script read"] = (
+        off_script_guarded["precision_guard"] is None
+        and composite_score([], off_script_guarded, None, None)["decision"] == "review")
+    checks["G: read the WRONG text -> still flagged (guards never hide a real miss)"] = (
+        off_script["coverage"] < 0.5 and off_script["precision_guard"] is None
+        and composite_score([], off_script, None, None)["decision"] == "review"
+        and composite_score([], off_script, None, None)["compliance_fail"] is True)
+    checks["G: tier_a_score bands land on the composite cutoffs"] = (
+        tier_a_score(0.0) == 1.0
+        and tier_a_score(TIER_A_WER_REVIEW) >= Q_PASS_CUTOFF          # boundary -> PASS
+        and Q_FAIL_CUTOFF <= tier_a_score(TIER_A_WER_FAIL) < Q_PASS_CUTOFF
+        and tier_a_score(TIER_A_WER_FAIL + 0.01) < Q_FAIL_CUTOFF
+        and tier_a_score(1.5) == 0.0)
+    checks["G: tier_a_score is monotonically non-increasing in WER"] = all(
+        tier_a_score(w / 100) >= tier_a_score((w + 1) / 100) for w in range(0, 150))
+    # ---- Single-model LLM judgement -> compliance score (no network) ----
+    _llm = LocalLLM.__new__(LocalLLM)          # bypass __init__: no Ollama probe needed
+    _llm.model = "gemma4"
+    j_yes = _llm._judgement({"completed": True, "confidence": 0.95, "reasoning": "r"})
+    j_no = _llm._judgement({"completed": False, "confidence": 0.95})
+    j_meh = _llm._judgement({"completed": False, "confidence": 0.1})
+    j_bad = _llm._judgement({"completed": True, "confidence": "not-a-number"})
+    checks["H: confident 'completed' -> pass band"] = (
+        j_yes["score"] >= Q_PASS_CUTOFF and j_yes["uncertain"] is False
+        and composite_score([], dict(j_yes, tier="C"), None, None)["decision"] == "pass")
+    checks["H: confident 'not completed' -> fail band -> REVIEW"] = (
+        j_no["score"] < Q_FAIL_CUTOFF
+        and composite_score([], dict(j_no, tier="C"), None, None)["decision"] == "review"
+        and composite_score([], dict(j_no, tier="C"), None, None)["compliance_fail"] is True)
+    checks["H: unsure answer lands in the REVIEW band, not fail"] = (
+        Q_FAIL_CUTOFF <= j_meh["score"] < Q_PASS_CUTOFF and j_meh["uncertain"] is True
+        and composite_score([], dict(j_meh, tier="C"), None, None)["decision"] == "review"
+        and composite_score([], dict(j_meh, tier="C"), None, None)["compliance_fail"] is False)
+    checks["H: unparseable confidence -> undecided, review band, no crash"] = (
+        j_bad["confidence"] == 0.5
+        and Q_FAIL_CUTOFF <= j_bad["score"] <= 1.0)
+    checks["H: judgement bands land on the composite cutoffs"] = (
+        llm_judgement_score(True, 1.0) == 1.0
+        and llm_judgement_score(True, LLM_CONFIDENT_AT) >= Q_PASS_CUTOFF
+        and llm_judgement_score(False, 1.0) == 0.0
+        and llm_judgement_score(False, LLM_CONFIDENT_AT) < Q_FAIL_CUTOFF
+        # every sub-threshold confidence, either answer, stays in the review band
+        and all(Q_FAIL_CUTOFF <= llm_judgement_score(done, c / 100) < Q_PASS_CUTOFF
+                for done in (True, False) for c in range(0, int(LLM_CONFIDENT_AT * 100))))
+    checks["H: judgement score is monotonic in confidence"] = (
+        all(llm_judgement_score(True, c / 20) <= llm_judgement_score(True, (c + 1) / 20)
+            for c in range(20))
+        and all(llm_judgement_score(False, c / 20) >= llm_judgement_score(False, (c + 1) / 20)
+                for c in range(20)))
+    checks["H: a dead/unreachable model yields None, never a bogus score"] = (
+        _llm._judgement(None) is None)
+    checks["H: _NullLLM covers every method LocalLLM exposes"] = all(
+        hasattr(_NullLLM(), m) for m in
+        ("active", "pii_spans", "pii_combinatorial_vote", "compliance_vote",
+         "task_judge_vote", "transcript_completion_vote"))
+
+    checks["G: word_error_rate unchanged by the alignment rewrite"] = (
+        abs(word_error_rate("the cat sat on the mat", "the cat sat on a mat") - 1 / 6) < 1e-9
+        and word_error_rate("", "") == 0.0 and word_error_rate("", "hello") == 1.0
+        and word_error_rate("a b c", "") == 1.0)
+
+    # ---- Always-flag identifiers: every NAME, and any age over the threshold ----
+    def _age_flagged(txt):
+        ents = age_scan(txt)
+        merged_ = merge_pii(ents, txt)
+        return bool(merged_) and merged_[0]["review_worthy"] is True
+
+    checks["E: '95 years old' -> flagged (phrasing the old AGE regex missed)"] = _age_flagged(
+        "she is 95 years old and lives alone")
+    checks["E: '97-year-old' -> flagged"] = _age_flagged("a 97-year-old participant")
+    checks["E: 'aged 102' -> flagged"] = _age_flagged("aged 102 at the time")
+    checks["E: spelled-out 'ninety-five years old' -> flagged"] = _age_flagged(
+        "he is ninety-five years old")
+    checks["E: 'a hundred and two years old' -> flagged"] = _age_flagged(
+        "my grandmother is a hundred and two years old")
+    checks["E: 'in her nineties' -> flagged"] = _age_flagged("she is in her nineties now")
+    checks["E: 'centenarian' -> flagged"] = _age_flagged("he is a centenarian")
+    checks["E: age AT/below the threshold is NOT flagged"] = (
+        age_scan("she is 90 years old") == [] and age_scan("I am 45 years old") == []
+        and age_scan("a 12-year-old boy") == [])
+    checks["E: non-age numbers never read as an age"] = (
+        age_scan("I'm 100 percent sure") == [] and age_scan("it cost 95 dollars") == []
+        and age_scan("we drove 95 miles") == [])
+    checks["E: age word->int parsing"] = (
+        _age_word_to_int("ninety-five") == 95 and _age_word_to_int("a hundred and two") == 102
+        and _age_word_to_int("one hundred") == 100 and _age_word_to_int("ninety") == 90)
+    checks["E: threshold is configurable (over_years=89 flags 90)"] = (
+        len(age_scan("she is 90 years old", over_years=89)) == 1)
+    # Every name flags the file, regardless of who it is or how weak the signal.
+    for _label, _txt, _span in (("bare first name", "Will you sit down now", (0, 4)),
+                                ("full name", "I met Sarah Connor yesterday.", (6, 18)),
+                                ("common word name", "May came to visit", (0, 3))):
+        _m = merge_pii([_entity(_span[0], _span[1], "NAME", 0.7, "ner")], _txt)
+        checks[f"E: NAME always flagged -- {_label}"] = (
+            bool(_m) and _m[0]["review_worthy"] is True
+            and composite_score(_m, None, None, q_ok)["decision"] == "review")
+    checks["E: a flagged NAME still never auto-fails (not confirmed)"] = (
+        composite_score(merge_pii([_entity(0, 4, "NAME", 0.7, "ner")], "Will is here"),
+                        None, None, q_ok)["pii_confirmed"] is False)
+
+    # ---- Task -> reference-key resolution must not mix SIBLING VARIANTS ----
+    # Plain bidirectional prefix matching pulled another task's prompt into this file's
+    # compliance test ('diadochokinesisPA' is a prefix of 'diadochokinesisPataka').
+    sib_ref = {"diadochokinesis-PA": {"instructions": "Say puh.", "prompts": []},
+               "diadochokinesis-Pataka": {"instructions": "Say pataka.", "prompts": []},
+               "picture-description": {"instructions": "Describe picture A.",
+                                       "prompts": ["Picture A prompt"]},
+               "picture-description-option2": {"instructions": "Describe picture B.",
+                                              "prompts": ["Picture B prompt"]},
+               "free-speech": {"instructions": "Talk freely.", "prompts": []},
+               "free-speech-1": {"instructions": "Question one.", "prompts": []},
+               "rainbow": {"instructions": "Read it.", "prompts": ["When the sunlight strikes"]},
+               "cape-V-sentences": {"instructions": "Read.", "prompts": ["a"]},
+               "cape-V-sentences-1": {"instructions": "Read 1.", "prompts": ["b"]}}
+    cc_sib = ComplianceChecker({}, _NullLLM(), task_reference=sib_ref)
+    checks["F: exact match wins -- 'Diadochokinesis-PA' does NOT pull in 'Pataka'"] = (
+        cc_sib._resolve_reference_keys("Diadochokinesis-PA") == (["diadochokinesis-PA"], False))
+    checks["F: 'Picture-description' does NOT pull in '-option2' (a different picture)"] = (
+        cc_sib._resolve_reference_keys("Picture-description") == (["picture-description"], False))
+    checks["F: 'Free-speech-1' resolves to itself, not the generic 'free-speech'"] = (
+        cc_sib._resolve_reference_keys("Free-speech-1") == (["free-speech-1"], False))
+    checks["F: no exact key -> most specific (longest) prefix wins"] = (
+        cc_sib._resolve_reference_keys("Rainbow-Passage") == (["rainbow"], False))
+    checks["F: unknown task -> no keys, no crash"] = (
+        cc_sib._resolve_reference_keys("Harvard-Sentences-List-12-1") == ([], False))
+    # A filename LESS specific than the reference (no exact key, and no key is a prefix
+    # of it) is genuinely ambiguous between the variants -> all returned, flagged.
+    cc_amb = ComplianceChecker({}, _NullLLM(), task_reference={
+        "cape-V-sentences-1": {"instructions": "Read 1.", "prompts": ["a"]},
+        "cape-V-sentences-2": {"instructions": "Read 2.", "prompts": ["b"]}})
+    amb_keys, amb_flag = cc_amb._resolve_reference_keys("cape-V-sentences")
+    checks["F: filename less specific than reference -> flagged ambiguous"] = (
+        amb_flag is True and len(amb_keys) == 2)
+    # ...whereas a token MORE specific than the only key resolves cleanly to it.
+    checks["F: token more specific than the key -> unambiguous"] = (
+        cc_sib._resolve_reference_keys("cape-V-sentences-x") == (["cape-V-sentences"], False))
+    # A scripted task with no reference text is RECORDED, not silently skipped.
+    ctx_missing = cc_sib.resolve_task_context("sub-1_task-Harvard-Sentences-List-12-1_features.pt", {})
+    checks["F: scripted w/o reference -> reference_missing recorded"] = (
+        ctx_missing["modality"] == "scripted" and ctx_missing["reference_missing"] is True
+        and ctx_missing["reference_texts"] == [])
+    # ...but a reference_text carried in the .pt itself is used instead of giving up.
+    ctx_meta = cc_sib.resolve_task_context(
+        "sub-1_task-Harvard-Sentences-List-12-1_features.pt",
+        {"reference_text": "the birch canoe slid on the smooth planks"})
+    checks["F: scripted w/o reference falls back to the .pt's own reference_text"] = (
+        ctx_meta["reference_texts"] == ["the birch canoe slid on the smooth planks"]
+        and ctx_meta["reference_missing"] is False)
+    _ta = cc_sib.assess_task("the birch canoe slid on the smooth planks", ctx_meta)
+    checks["F: that fallback actually enables the Tier A WER check"] = (
+        _ta is not None and _ta["tier"] == "A" and _ta["score"] == 1.0)
+    checks["F: correct prompt reaches Tier C for an open task"] = (
+        (cc_sib.resolve_task_context("sub-1_task-Picture-description_features.pt", {})
+         or {}).get("reference_texts") == ["Picture A prompt"])
+
+    # ---- Compliance-only mode: PII skipped entirely (pii_entities is None) ----
+    # The corner case that matters: an ACOUSTIC task in compliance-only mode has NO
+    # assessable check at all (quality suppressed, Tier B skipped, no protocol steps),
+    # so composite_score must not divide by an empty weight list.
+    acoustic_skipped = {"tier": "B", "method": "acoustic", "score": None,
+                        "confidence": None, "completed": None, "status": "skipped"}
+    q_suppressed = {"applies": False, "score": None, "confidence": None, "hard_fail": False}
+    co_acoustic = composite_score(None, acoustic_skipped, None, q_suppressed)
+    checks["G: compliance-only + acoustic (no checks at all) -> no crash"] = (
+        co_acoustic["decision"] == "pass" and co_acoustic["checks"] == {})
+    checks["G: no assessable check -> Q and C are None (unknown), not 0 (bad)"] = (
+        co_acoustic["Q"] is None and co_acoustic["C"] is None)
+    checks["G: compliance-only marks pii_skipped and never flags PII"] = (
+        co_acoustic["pii_skipped"] is True
+        and co_acoustic["flagged_by_pii"] is False
+        and co_acoustic["pii_confirmed"] is False)
+    # Compliance still scores normally when a check IS available.
+    co_scored = composite_score(None, {"tier": "A", "score": 0.2, "confidence": 0.9,
+                                       "completed": False, "required": True}, None, None)
+    checks["G: compliance-only still scores a failing scripted task"] = (
+        co_scored["decision"] == "review" and co_scored["flagged_by_compliance"] is True
+        and co_scored["pii_skipped"] is True and co_scored["Q"] == 0.2)
+    # ...and with PII enabled (entities list, even empty) the PII check is present.
+    with_pii = composite_score([], None, None, q_ok)
+    checks["G: PII enabled -> pii check present, pii_skipped False"] = (
+        with_pii["pii_skipped"] is False and "pii" in with_pii["checks"])
+
+    # ---- Part D: high-recall screening mode (opt-in; defaults above untouched) ----
+    _mod.HIGH_RECALL = True
+    _mod.RECALL_FLAG_ALL_PII = False
+    _mod.RECALL_FLAG_ACOUSTIC = True
+    hr_age = merge_pii([_entity(0, 3, "AGE", 0.6, "regex")], "old")          # weak, normally quiet
+    hr_name = merge_pii([_entity(0, 4, "NAME", 0.8, "ner"),
+                         _entity(0, 4, "NAME", 0.75, "gliner")], "Will you sit down now")
+    hr_ac = _recall_compliance_override("well sorry I cannot really do this task today",
+                                        "acoustic", {"applies": False, "score": None})
+    hr_ac_clean = _recall_compliance_override("ah", "acoustic", {"applies": False, "score": None})
+    hr_open = _recall_compliance_override("yes", "open", {"applies": True, "score": 1.0})
+    checks["D: high-recall flags a weak AGE-alone detection for review"] = (
+        bool(hr_age) and hr_age[0]["review_worthy"] is True
+        and composite_score(hr_age, None, None, q_ok)["decision"] == "review")
+    checks["D: high-recall flags the lone common-word NAME too (FLAG_ALL_NAMES)"] = (
+        bool(hr_name) and hr_name[0]["review_worthy"] is True)
+    checks["D: acoustic w/ unexpected speech -> review-band (not fail)"] = (
+        hr_ac.get("score") == 0.6 and hr_ac.get("hard_fail") is False
+        and composite_score([], None, None, hr_ac)["decision"] == "review")
+    checks["D: clean near-empty acoustic stays a pass"] = (hr_ac_clean.get("score") is None)
+    checks["D: thin open response -> review-band compliance"] = (hr_open.get("score") == 0.6)
+    _mod.HIGH_RECALL = False
+    _mod.RECALL_FLAG_ACOUSTIC = False
+
+    # ---- Part I: the COMPANION task_reference.json beside this script ----
+    # The script and its task reference are a pair. These checks fail loudly if the
+    # JSON is missing, malformed, or has drifted from the shape the pipeline expects
+    # -- i.e. exactly the cases where scripted-task checking would otherwise go
+    # quietly dead and off-script reads would start passing.
+    ref_path = resolve_task_reference_path(TASK_REFERENCE)
+    print(f"\n[Part I] Companion task reference: {ref_path.name} (beside the script).")
+    checks["I: task_reference.json sits next to the script"] = ref_path.is_file()
+    ref = load_task_reference(TASK_REFERENCE)
+    checks["I: it loads and carries all 797 task definitions"] = (len(ref) == 797)
+    checks["I: every entry has the same {instructions, prompts} shape"] = all(
+        set(v) == {"instructions", "prompts"}
+        and isinstance(v["instructions"], str) and isinstance(v["prompts"], list)
+        and all(isinstance(p, str) for p in v["prompts"])
+        for v in ref.values())
+    checks["I: read-aloud tasks carry their reference text"] = (
+        ref.get("harvard-sentences-list-1-1", {}).get("prompts")
+        == ["The birch canoe slid on the smooth planks."]
+        and len([k for k in ref if k.startswith("harvard-sentences-list-")]) == 720
+        and ref["rainbow"]["prompts"][0].lower().startswith("when the sunlight"))
+    checks["I: acoustic tasks carry instructions but no reference text"] = (
+        ref["maximum-phonation-time"]["prompts"] == []
+        and bool(ref["maximum-phonation-time"]["instructions"]))
+    checks["I: acoustic / scripted / open tasks are all present"] = all(
+        k in ref for k in ("rainbow", "maximum-phonation-time", "free-speech-1",
+                           "cape-V-sentences-1", "caterpillar-passage",
+                           "picture-description", "diadochokinesis-Pataka"))
+    checks["I: a relative path resolves next to the SCRIPT, not the cwd"] = (
+        resolve_task_reference_path("task_reference.json").parent
+        == Path(__file__).resolve().parent)
+
+    # The reference file drives filename -> tier routing.
+    cc_b = ComplianceChecker({}, _NullLLM(), task_reference=ref)
+    ctx_rb = cc_b.resolve_task_context("sub-1_ses-1_task-Rainbow_features.pt", {})
+    ctx_hb = cc_b.resolve_task_context("sub-1_ses-1_task-Harvard-Sentences-List-1-1_features.pt", {})
+    ctx_mb = cc_b.resolve_task_context("sub-1_ses-1_task-Maximum-Phonation-Time_features.pt", {})
+    ctx_ob = cc_b.resolve_task_context("sub-1_ses-1_task-Free-Speech-1_features.pt", {})
+    checks["I: the reference gives a scripted task its Tier A reference text"] = (
+        ctx_rb and ctx_rb["tier"] == "A" and bool(ctx_rb["reference_texts"])
+        and ctx_rb["reference_missing"] is False)
+    checks["I: a Harvard sentence resolves to its own prompt"] = (
+        ctx_hb and ctx_hb["reference_texts"] == ["The birch canoe slid on the smooth planks."])
+    checks["I: acoustic -> Tier B and open -> Tier C"] = (
+        ctx_mb and ctx_mb["tier"] == "B" and ctx_ob and ctx_ob["tier"] == "C")
+    read_ok = cc_b.assess_task("the birch canoe slid on the smooth planks", ctx_hb)
+    read_bad = cc_b.assess_task("i would rather not read anything at all today thanks", ctx_hb)
+    checks["I: a correct read against a reference prompt PASSES"] = (
+        read_ok["score"] >= Q_PASS_CUTOFF
+        and composite_score([], read_ok, None, None)["decision"] == "pass")
+    checks["I: an off-script read against a reference prompt is FLAGGED"] = (
+        composite_score([], read_bad, None, None)["decision"] == "review"
+        and composite_score([], read_bad, None, None)["flagged_by_compliance"] is True)
+
+    # A MISSING reference stops the run -- it is never silently treated as "no tasks",
+    # which would turn every scripted check off without saying so.
+    missing_stops = False
+    try:
+        load_task_reference("definitely_not_a_real_file_9f2c.json")
+    except SystemExit:
+        missing_stops = True
+    checks["I: a missing task reference STOPS the run (never a silent skip)"] = missing_stops
+    bad_stops = False
+    with tempfile.TemporaryDirectory() as tmp:
+        broken = Path(tmp) / "broken.json"
+        broken.write_text("{not valid json")
+        try:
+            load_task_reference(str(broken))
+        except SystemExit:
+            bad_stops = True
+        # ...and an explicitly chosen alternative file is used as-is.
+        alt = Path(tmp) / "study_tasks.json"
+        alt.write_text(json.dumps({
+            "rainbow": {"instructions": "Read ours.", "prompts": ["a different passage"]},
+            "my-new-task": {"instructions": "Do the new thing.", "prompts": []}}))
+        alt_ref = load_task_reference(str(alt))
+    checks["I: an unparseable task reference STOPS the run"] = bad_stops
+    checks["I: --task-reference points at another study's file"] = (
+        len(alt_ref) == 2 and alt_ref["rainbow"]["prompts"] == ["a different passage"])
+    checks["I: --no-task-reference runs without filename-based compliance"] = (
+        load_task_reference("") == {})
+
+    # ---- Part J: the whole pipeline, end to end, on nothing but built-ins ----
+    #   .pt files in  ->  task identified from each filename against the built-in
+    #   task reference  ->  list of flagged file names out.
+    # This is the contract the script exists to satisfy, so it is asserted here
+    # rather than left to a manual run.
+    print("\n[Part J] End to end: .pt folder -> task_reference.json -> flagged names.")
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        # A correct read of a Harvard prompt from the reference -> compliant.
+        torch.save({"transcription": "the birch canoe slid on the smooth planks"},
+                   tmp / "sub-01_ses-1_task-Harvard-Sentences-List-1-1_features.pt")
+        # The WRONG text for that same prompt -> only the task reference catches this.
+        torch.save({"transcription": "i do not really want to read this one today sorry"},
+                   tmp / "sub-02_ses-1_task-Harvard-Sentences-List-1-1_features.pt")
+        # Acoustic task: a near-empty transcript is EXPECTED, never a failure.
+        torch.save({"transcription": "aaaah"},
+                   tmp / "sub-03_ses-1_task-Maximum-Phonation-Time_features.pt")
+        # Open task carrying a direct identifier -> flagged on PII.
+        torch.save({"transcription": "You can reach me any time at sarah.connor@example.com."},
+                   tmp / "sub-04_ses-1_task-Free-Speech-1_features.pt")
+
+        args.protocol = None
+        e2e = Pipeline(args, {}, ref)
+        e2e_report = process_folder(tmp, e2e, False, None)
+        print_flagged_files(e2e_report)
+        flagged = e2e_report["summary"]["flagged_files"]
+        by_name = {f["name"]: f for f in flagged}
+        e2e_by = {Path(r["file"]).name: r for r in e2e_report["files"]}
+        listing = tmp / "flagged.txt"
+        write_flagged_list(e2e_report, listing)
+        lines = [l for l in listing.read_text().split("\n") if l]
+
+    n_off, n_pii = ("sub-02_ses-1_task-Harvard-Sentences-List-1-1_features.pt",
+                    "sub-04_ses-1_task-Free-Speech-1_features.pt")
+    n_ok, n_ac = ("sub-01_ses-1_task-Harvard-Sentences-List-1-1_features.pt",
+                  "sub-03_ses-1_task-Maximum-Phonation-Time_features.pt")
+    checks["J: all four .pt files were read and scored"] = (
+        e2e_report["num_files"] == 4 and e2e_report["summary"]["errors"] == 0)
+    checks["J: filenames resolved via the reference (scripted/acoustic/open)"] = (
+        e2e_by[n_ok]["modality"] == "scripted" and e2e_by[n_ac]["modality"] == "acoustic"
+        and e2e_by[n_pii]["modality"] == "open"
+        and e2e_report["summary"]["scripted_without_reference"] == [])
+    checks["J: reading the WRONG script is caught -- only the reference reveals it"] = (
+        n_off in by_name and "compliance:fail" in by_name[n_off]["reasons"])
+    checks["J: a direct identifier flags its file on PII"] = (
+        n_pii in by_name and "pii:confirmed" in by_name[n_pii]["reasons"])
+    # Engine-independent: these two must never be flagged BY COMPLIANCE, whatever
+    # PII engines happen to be installed on the machine running the self-test.
+    checks["J: a correct read is not a compliance flag"] = (
+        e2e_by[n_ok]["composite"]["flagged_by_compliance"] is False)
+    checks["J: a near-empty ACOUSTIC transcript is not a compliance flag"] = (
+        e2e_by[n_ac]["composite"]["flagged_by_compliance"] is False)
+    checks["J: flagged_files is exactly the set of non-pass decisions"] = (
+        {f["name"] for f in flagged}
+        == {n for n, r in e2e_by.items() if r["decision"] != "pass"})
+    checks["J: every flagged entry says WHY, and names a real file"] = (
+        all(f["reasons"] and Path(f["file"]).name == f["name"] for f in flagged))
+    checks["J: --flagged-list writes one flagged path per line"] = (
+        lines == [f["file"] for f in flagged] and len(lines) == len(flagged))
+
+    print()
+    for label, ok in checks.items():
+        print(f"  [{'PASS' if ok else 'FAIL'}] {label}")
+    overall = all(checks.values())
+    print("\nSELF-TEST PASSED" if overall else "\nSELF-TEST FAILED")
+    sys.exit(0 if overall else 1)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def build_args():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("folder", type=Path, nargs="?",
+                   default=(Path(INPUT_FOLDER) if INPUT_FOLDER else None),
+                   help="Folder of .pt files. Optional only if INPUT_FOLDER is set in "
+                        "the CONFIG block at the top of this file; with neither, the "
+                        "script stops.")
+    p.add_argument("--protocol", default=PROTOCOL_SPEC,
+                   help="OPTIONAL protocol spec JSON. Omit for zero-config: task info "
+                        "is read from each .pt's own metadata. Provide only for "
+                        "interview-style protocol-step checking.")
+    p.add_argument("--task-reference", dest="task_reference", default=TASK_REFERENCE,
+                   help="Task reference JSON (task -> instructions/prompts) driving "
+                        "filename-based Tier A/B/C compliance. Default %(default)r, the "
+                        "companion file beside this script; a relative path resolves "
+                        "there. Missing -> the run stops.")
+    p.add_argument("--no-task-reference", dest="task_reference", action="store_const",
+                   const="",
+                   help="Run WITHOUT the task reference, disabling filename-based task "
+                        "compliance (compliance falls back to transcript quality only).")
+    p.add_argument("--output", "-o", type=Path, default=Path(OUTPUT_JSON),
+                   help="Full JSON report path. Default %(default)s.")
+    # Kept as a plain string rather than type=Path: Path("") is Path("."), so an empty
+    # --csv would otherwise sail through as a directory and blow up on write, at the very
+    # end of a long run. Empty (or --no-csv) means "skip the CSV" instead.
+    p.add_argument("--csv", default=OUTPUT_CSV or "",
+                   help="Flat CSV summary path. Pass '' or --no-csv to skip it. "
+                        "Default %(default)r.")
+    p.add_argument("--no-csv", dest="csv", action="store_const", const="",
+                   help="Skip the CSV summary (the JSON report is still written).")
+    p.add_argument("--flagged-list", dest="flagged_list", default=OUTPUT_FLAGGED_LIST or "",
+                   help="Also write JUST the flagged file paths, one per line, to this "
+                        "path -- the plain-text list of what needs human review. The same "
+                        "list is always printed and is in the JSON report.")
+    p.add_argument("--recursive", action="store_true", default=RECURSIVE)
+    p.add_argument("--max-files", type=int, default=MAX_FILES)
+    p.add_argument("--spacy-model", default=SPACY_MODEL)
+    p.add_argument("--gliner-model", default=GLINER_MODEL)
+    p.add_argument("--enable-spacy", action="store_true", default=ENABLE_SPACY)
+    p.add_argument("--no-spacy", dest="enable_spacy", action="store_false")
+    p.add_argument("--enable-gliner", action="store_true", default=ENABLE_GLINER)
+    p.add_argument("--no-gliner", dest="enable_gliner", action="store_false")
+    p.add_argument("--enable-presidio", action="store_true", default=ENABLE_PRESIDIO)
+    p.add_argument("--no-presidio", dest="enable_presidio", action="store_false")
+    p.add_argument("--no-precision", dest="precision", action="store_false", default=PRECISION_MODE,
+                   help="Disable the false-positive precision guards (revert to recall-max).")
+    p.add_argument("--gliner-threshold", type=float, default=GLINER_THRESHOLD,
+                   help="GLiNER detection threshold; raise to cut GLiNER false positives.")
+    p.add_argument("--tier-a-wer-review", type=float, default=TIER_A_WER_REVIEW,
+                   help="Tier A: word error rate at or below which a scripted read counts "
+                        "as compliant (ASR noise on a correctly-read script). Above it the "
+                        "file goes to REVIEW. Default %(default)s.")
+    p.add_argument("--tier-a-wer-fail", type=float, default=TIER_A_WER_FAIL,
+                   help="Tier A: word error rate above which the read is treated as a hard "
+                        "failure (wrong text / not read). Default %(default)s.")
+    p.add_argument("--tier-a-min-word-errors", type=int, default=TIER_A_MIN_WORD_ERRORS,
+                   help="Tier A: never flag a scripted read with fewer than this many word "
+                        "errors, however bad the ratio -- stops one misheard word flagging a "
+                        "short sentence. Default %(default)s.")
+    p.add_argument("--tier-a-coverage-pass", type=float, default=TIER_A_COVERAGE_PASS,
+                   help="Tier A: reference-word coverage at or above which an insertion-heavy "
+                        "read counts as compliant (the script WAS read, plus extra speech). "
+                        "Set to 1.1 to disable the guard. Default %(default)s.")
+    p.add_argument("--enable-llm", dest="enable_llm", action="store_true",
+                   default=ENABLE_LLM,
+                   help="Local LLM via Ollama: enables open-ended (Tier C) task compliance "
+                        "plus extra PII judgement. Roughly DOUBLES the catch rate on "
+                        "open tasks, at ~10x the review queue. Off by default; slow.")
+    p.add_argument("--no-llm", dest="enable_llm", action="store_false",
+                   help="Force the LLM off (the default) -- a fast rules-only pass. "
+                        "Open-ended (Tier C) compliance is then not assessed.")
+    p.add_argument("--llm-compliance", dest="llm_compliance", action="store_true",
+                   default=ENABLE_LLM_COMPLIANCE_JUDGE,
+                   help="Let the LLM also judge borderline transcripts for task completion. "
+                        "Runs only on review-band files, and only with --enable-llm.")
+    p.add_argument("--no-llm-compliance", dest="llm_compliance", action="store_false",
+                   help="Disable the borderline-transcript LLM judge (Tier C is unaffected).")
+    p.add_argument("--ollama-host", default=OLLAMA_HOST)
+    p.add_argument("--ollama-model", dest="ollama_model", default=OLLAMA_MODEL,
+                   help="The single Ollama model used for every LLM call "
+                        "(default: %(default)s). Any tag Ollama can serve.")
+    p.add_argument("--high-recall", dest="high_recall", action="store_true", default=HIGH_RECALL,
+                   help="SCREENING mode: maximize recall (catch PII / non-compliance), routing "
+                        "more files to REVIEW. Fewer false negatives, more false positives. Also "
+                        "keeps low-confidence detections (implies no-precision).")
+    p.add_argument("--flag-all-open", dest="flag_all_open", action="store_true", default=RECALL_FLAG_ALL_OPEN,
+                   help="High-recall: route EVERY open free-speech task to REVIEW (max open-task "
+                        "compliance recall).")
+    p.add_argument("--flag-all-pii", dest="flag_all_pii", action="store_true", default=RECALL_FLAG_ALL_PII,
+                   help="High-recall: flag even lone common-word NAME guesses (absolute max PII recall).")
+    p.add_argument("--flag-acoustic", dest="flag_acoustic", action="store_true", default=RECALL_FLAG_ACOUSTIC,
+                   help="High-recall: also route acoustic tasks with unexpected speech to REVIEW "
+                        "(high false-positive; off by default).")
+    p.add_argument("--acoustic-max-content-words", dest="acoustic_max_content_words",
+                   type=int, default=RECALL_ACOUSTIC_MAX_CONTENT_WORDS,
+                   help="With --flag-acoustic: an acoustic task with MORE content words than "
+                        "this goes to REVIEW. Use -1 to route EVERY acoustic task to review -- "
+                        "the only way to reach acoustic misses, at the cost of the entire "
+                        "acoustic half of the corpus. Default %(default)s.")
+    p.add_argument("--open-min-content-words", dest="open_min_content_words",
+                   type=int, default=RECALL_OPEN_MIN_CONTENT_WORDS,
+                   help="High-recall: an open free-speech task with FEWER content words than "
+                        "this goes to REVIEW. Default %(default)s.")
+    p.add_argument("--compliance-only", dest="compliance_only", action="store_true",
+                   default=COMPLIANCE_ONLY,
+                   help="TASK COMPLIANCE ONLY: skip PII detection entirely (no spaCy/GLiNER/"
+                        "Presidio load, no PII scan). Much faster. PII fields are reported as "
+                        "skipped rather than clean, and the composite score reflects "
+                        "compliance alone.")
+    p.add_argument("--selftest", action="store_true", default=SELFTEST)
+    return p.parse_args()
+
+
+def _apply_runtime_config(args):
+    """Let CLI flags override the CONFIG-block globals that functions read at runtime."""
+    global PRECISION_MODE, ENABLE_LLM_COMPLIANCE_JUDGE
+    global HIGH_RECALL, RECALL_FLAG_ALL_OPEN, RECALL_FLAG_ALL_PII, RECALL_FLAG_ACOUSTIC
+    global RECALL_ACOUSTIC_MAX_CONTENT_WORDS, RECALL_OPEN_MIN_CONTENT_WORDS
+    RECALL_ACOUSTIC_MAX_CONTENT_WORDS = getattr(args, "acoustic_max_content_words",
+                                                RECALL_ACOUSTIC_MAX_CONTENT_WORDS)
+    RECALL_OPEN_MIN_CONTENT_WORDS = getattr(args, "open_min_content_words",
+                                            RECALL_OPEN_MIN_CONTENT_WORDS)
+    global TIER_A_WER_REVIEW, TIER_A_WER_FAIL, TIER_A_MIN_WORD_ERRORS, TIER_A_COVERAGE_PASS
+    TIER_A_WER_REVIEW = getattr(args, "tier_a_wer_review", TIER_A_WER_REVIEW)
+    TIER_A_WER_FAIL = max(TIER_A_WER_REVIEW, getattr(args, "tier_a_wer_fail", TIER_A_WER_FAIL))
+    TIER_A_MIN_WORD_ERRORS = getattr(args, "tier_a_min_word_errors", TIER_A_MIN_WORD_ERRORS)
+    TIER_A_COVERAGE_PASS = getattr(args, "tier_a_coverage_pass", TIER_A_COVERAGE_PASS)
+    PRECISION_MODE = getattr(args, "precision", PRECISION_MODE)
+    # The borderline-transcript judge runs THROUGH the same model, so --no-llm switches it
+    # off too; keeping it "on" with no LLM would only misreport what actually ran.
+    ENABLE_LLM_COMPLIANCE_JUDGE = (getattr(args, "llm_compliance", ENABLE_LLM_COMPLIANCE_JUDGE)
+                                   and getattr(args, "enable_llm", True))
+    HIGH_RECALL = getattr(args, "high_recall", HIGH_RECALL)
+    RECALL_FLAG_ALL_OPEN = getattr(args, "flag_all_open", RECALL_FLAG_ALL_OPEN)
+    RECALL_FLAG_ALL_PII = getattr(args, "flag_all_pii", RECALL_FLAG_ALL_PII)
+    RECALL_FLAG_ACOUSTIC = getattr(args, "flag_acoustic", RECALL_FLAG_ACOUSTIC)
+    if HIGH_RECALL:
+        # Recall over precision: keep low-confidence detections so more spans exist
+        # to flag (the precision guards otherwise drop them -> false negatives).
+        PRECISION_MODE = False
+    else:
+        # The acoustic / open recall nets live inside the high-recall override, so on
+        # their own they do nothing. Silently ignoring them would look like "I turned
+        # that on and it caught nothing" -- say so instead.
+        stray = [f for f, on in (("--flag-acoustic", RECALL_FLAG_ACOUSTIC),
+                                 ("--flag-all-open", RECALL_FLAG_ALL_OPEN)) if on]
+        if stray:
+            print(f"  [note] {', '.join(stray)} has no effect without --high-recall "
+                  f"(the recall nets run inside high-recall mode); enabling it now.")
+            HIGH_RECALL = True
+            PRECISION_MODE = False
+
+
+def print_active_modes(args):
+    """Echo the modes actually in force at the top of a run.
+
+    Written for IDE use: hitting Run gives no visible command line, so without this
+    there is nothing in the output saying which toggles were set. Reads the EFFECTIVE
+    values (the MODES block as overridden by any CLI flags and by the HIGH_RECALL
+    interlock), not the literals in the file, so it cannot drift from what really ran."""
+    def sw(flag):
+        return "ON" if flag else "off"
+
+    scope = [str(args.folder)]
+    if args.recursive:
+        scope.append("recursive")
+    if args.max_files:
+        scope.append(f"first {args.max_files} files")
+    print("--- Modes ---")
+    print(f"  input           {'  |  '.join(scope)}")
+    if getattr(args, "compliance_only", False):
+        print("  PII detection   SKIPPED entirely (compliance-only mode)")
+    else:
+        print(f"  PII engines     spaCy={sw(args.enable_spacy)}  GLiNER={sw(args.enable_gliner)}"
+              f"  Presidio={sw(args.enable_presidio)}   (missing ones are skipped with a notice)")
+        print(f"  always flag     names={sw(FLAG_ALL_NAMES)}  demographics={sw(DEMOGRAPHIC_PII)}"
+              f"  age>{AGE_REVIEW_OVER_YEARS}   hard-fail labels: "
+              f"{', '.join(sorted(HARD_GATE_PII_LABELS)) or 'none'}")
+    if args.enable_llm:
+        print(f"  local LLM       ON -- {args.ollama_model!r} at {args.ollama_host}"
+              f"{'  + borderline judge' if ENABLE_LLM_COMPLIANCE_JUDGE else ''}")
+        print("                  Tier C open-task compliance + extra PII judgement; "
+              "~1-2s per file once warm.")
+    else:
+        print("  local LLM       off -- open-ended (Tier C) task compliance is NOT assessed, so "
+              "open tasks")
+        print("                  are judged only on whether a real response was spoken. "
+              "Set ENABLE_LLM = True.")
+    print(f"  posture         precision guards={sw(PRECISION_MODE)}  high-recall={sw(HIGH_RECALL)}"
+          + (f"  (all-PII={sw(RECALL_FLAG_ALL_PII)} all-open={sw(RECALL_FLAG_ALL_OPEN)} "
+             f"acoustic={sw(RECALL_FLAG_ACOUSTIC)})" if HIGH_RECALL else ""))
+    ref = getattr(args, "task_reference", TASK_REFERENCE)
+    print(f"  task reference  {ref if ref else 'DISABLED -- no filename-based task compliance'}")
+    outs = [str(args.output)] + [x for x in (args.csv, getattr(args, "flagged_list", "")) if x]
+    print(f"  outputs         {', '.join(outs)}")
+
+
+def main():
+    args = build_args()
+    if args.selftest:
+        # The self-test must stay hermetic, fast and deterministic: synthetic data, no
+        # network, no model server. Force the LLM off regardless of the defaults so a
+        # machine with Ollama running gets the same result as one without.
+        args.enable_llm = args.llm_compliance = False
+    _apply_runtime_config(args)
+    if args.selftest:
+        run_selftest(args)
+        return
+    # STOP if there is no input path. Checked BEFORE any status is printed, so a
+    # misconfigured run ends with just this message rather than an unrelated notice
+    # above it. Nothing is guessed: no default folder, no scanning the working
+    # directory -- the script would otherwise silently report on the wrong data.
+    if args.folder is None:
+        raise SystemExit(
+            "No input folder set -- stopping.\n"
+            "Set INPUT_FOLDER in the CONFIG block at the top of this file:\n"
+            '    INPUT_FOLDER = "/path/to/your/pt_files"\n'
+            "or pass the folder as the first argument:\n"
+            f"    python {Path(__file__).name} /path/to/your/pt_files")
+    if not args.folder.is_dir():
+        raise SystemExit(
+            f"{str(args.folder)!r} is not a directory -- stopping.\n"
+            "Point INPUT_FOLDER (CONFIG block, top of this file) or the first argument "
+            "at a folder of .pt files.")
+    print_active_modes(args)
+    protocol = load_protocol(args.protocol)
+    task_reference = load_task_reference(getattr(args, "task_reference", TASK_REFERENCE))
+    pipeline = Pipeline(args, protocol, task_reference)
+    report = process_folder(args.folder, pipeline, args.recursive, args.max_files)
+    print_summary(report)
+    write_json(report, args.output)
+    if args.csv:
+        write_csv(report, Path(args.csv))
+    if getattr(args, "flagged_list", ""):
+        write_flagged_list(report, Path(args.flagged_list))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pii_compliance_pipeline.py
+++ b/scripts/pii_compliance_pipeline.py
@@ -1213,7 +1213,7 @@ class LocalLLM:
         try:
             confidence = min(1.0, max(0.0, float(d.get("confidence", 0.5))))
         except (TypeError, ValueError):
-            confidence = 0.5      # unparseable confidence -> maximally undecided
+            confidence = 0.5      # unparsable confidence -> maximally undecided
         completed = bool(d.get("completed"))
         out = {"model": self.model, "completed": completed,
                "confidence": round(confidence, 3),
@@ -2485,7 +2485,7 @@ def load_task_reference(path):
     field of a filename is looked up here to learn the task's modality and, for a
     scripted task, the reference text the participant was supposed to read.
 
-    A configured path that is missing or unparseable STOPS the run. It is not treated
+    A configured path that is missing or unparsable STOPS the run. It is not treated
     as "no reference": without this table every scripted task silently loses its Tier A
     word-error-rate check, so reading the WRONG script stops being detectable and the
     files sail through as clean passes. That failure is invisible in the output, so it
@@ -2862,7 +2862,7 @@ def run_selftest(args):
         Q_FAIL_CUTOFF <= j_meh["score"] < Q_PASS_CUTOFF and j_meh["uncertain"] is True
         and composite_score([], dict(j_meh, tier="C"), None, None)["decision"] == "review"
         and composite_score([], dict(j_meh, tier="C"), None, None)["compliance_fail"] is False)
-    checks["H: unparseable confidence -> undecided, review band, no crash"] = (
+    checks["H: unparsable confidence -> undecided, review band, no crash"] = (
         j_bad["confidence"] == 0.5
         and Q_FAIL_CUTOFF <= j_bad["score"] <= 1.0)
     checks["H: judgement bands land on the composite cutoffs"] = (
@@ -3110,7 +3110,7 @@ def run_selftest(args):
             "rainbow": {"instructions": "Read ours.", "prompts": ["a different passage"]},
             "my-new-task": {"instructions": "Do the new thing.", "prompts": []}}))
         alt_ref = load_task_reference(str(alt))
-    checks["I: an unparseable task reference STOPS the run"] = bad_stops
+    checks["I: an unparsable task reference STOPS the run"] = bad_stops
     checks["I: --task-reference points at another study's file"] = (
         len(alt_ref) == 2 and alt_ref["rainbow"]["prompts"] == ["a different passage"])
     checks["I: --no-task-reference runs without filename-based compliance"] = (

--- a/scripts/task_reference.json
+++ b/scripts/task_reference.json
@@ -4448,7 +4448,7 @@
         "prompts": []
     },
     "prolonged-Vowel": {
-        "instructions": "This task helps us analyze features in your voice. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the sentence “1, 2, 3 aah” in your normal voice. Please hold the sound “aah” until the timer runs out.",
+        "instructions": "This task helps us analyze features in your voice. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the sentence \u201c1, 2, 3 aah\u201d in your normal voice. Please hold the sound \u201caah\u201d until the timer runs out.",
         "prompts": []
     },
     "productive-Vocabulary": {
@@ -4456,23 +4456,23 @@
         "prompts": []
     },
     "maximum-phonation-time": {
-        "instructions": "This task helps us analyze the way your breathing is connected to your voice. Take a very deep breath, tap on the record button, and hold out “ah” for as long as possible until you completely run out of air. Try to hold it until the progress bar reaches the end of the screen.",
+        "instructions": "This task helps us analyze the way your breathing is connected to your voice. Take a very deep breath, tap on the record button, and hold out \u201cah\u201d for as long as possible until you completely run out of air. Try to hold it until the progress bar reaches the end of the screen.",
         "prompts": []
     },
     "loudness": {
-        "instructions": "This helps us to determine the loudness of the voice. When you're ready, press the record button and say “hey” in your normal voice. Then, shout “hey” as loud as you can. Try to reach the target line on the screen. Follow the prompts on the screen to continue.",
+        "instructions": "This helps us to determine the loudness of the voice. When you're ready, press the record button and say \u201chey\u201d in your normal voice. Then, shout \u201chey\u201d as loud as you can. Try to reach the target line on the screen. Follow the prompts on the screen to continue.",
         "prompts": []
     },
     "glides-low-to-high": {
-        "instructions": "Please watch the video to help you understand the next task and imitate what the speaker does. When you're ready, press the record button and use the sound “ee” to gradually move from your lowest note to your highest.",
+        "instructions": "Please watch the video to help you understand the next task and imitate what the speaker does. When you're ready, press the record button and use the sound \u201cee\u201d to gradually move from your lowest note to your highest.",
         "prompts": []
     },
     "glides-high-to-low": {
-        "instructions": "Next, please watch this video for the following task and imitate what the speaker does. When you're ready, press the record button again and use the sound “ee” to gradually move from your highest note to your lowest note.",
+        "instructions": "Next, please watch this video for the following task and imitate what the speaker does. When you're ready, press the record button again and use the sound \u201cee\u201d to gradually move from your highest note to your lowest note.",
         "prompts": []
     },
     "high-to-low": {
-        "instructions": "Next, please watch this video for the following task and imitate what the speaker does. When you're ready, press the record button again and use the sound “ee” to gradually move from your highest note to your lowest note.",
+        "instructions": "Next, please watch this video for the following task and imitate what the speaker does. When you're ready, press the record button again and use the sound \u201cee\u201d to gradually move from your highest note to your lowest note.",
         "prompts": []
     },
     "respiration-and-cough-cough": {
@@ -4556,7 +4556,7 @@
         "prompts": []
     },
     "long-sounds": {
-        "instructions": "First, let's start by saying 'ahhhhh' for around 5 seconds. We're going to repeat this three times during one recording. Try to have the child produce the sound at a habitual pitch – some tend to use a higher \"note\" or create vibrato if they have any singing background The sound produced should be as steady/consistent as possible Re-record if you perceive the child is using a higher pitch when sustaining the vowel (in comparison to speaking) When you are ready, press \"record\". Next, say the 'eeeeee' sound as steady as you can for about 5 seconds. We'll do this three times as well. When you are ready, press \"record\".",
+        "instructions": "First, let's start by saying 'ahhhhh' for around 5 seconds. We're going to repeat this three times during one recording. Try to have the child produce the sound at a habitual pitch \u2013 some tend to use a higher \"note\" or create vibrato if they have any singing background The sound produced should be as steady/consistent as possible Re-record if you perceive the child is using a higher pitch when sustaining the vowel (in comparison to speaking) When you are ready, press \"record\". Next, say the 'eeeeee' sound as steady as you can for about 5 seconds. We'll do this three times as well. When you are ready, press \"record\".",
         "prompts": []
     },
     "repeat-words": {
@@ -4572,7 +4572,7 @@
         "prompts": []
     },
     "pictures-and-doors": {
-        "instructions": "There are lots of pictures inside – let's talk about some of the things you see. When you are ready, press \"record\".",
+        "instructions": "There are lots of pictures inside \u2013 let's talk about some of the things you see. When you are ready, press \"record\".",
         "prompts": []
     },
     "role-naming": {
@@ -4580,37 +4580,37 @@
         "prompts": []
     },
     "sentence": {
-        "instructions": "Next we have some silly sentences to look at. They don’t exactly make sense – but that’s what makes them silly! If you can read them on your own go right ahead! Or you can have someone else say the sentence first and you just repeat it after them (just be sure to only record when you are talking) You are doing a great job! We have only two more tasks to complete before we’re all finished!",
+        "instructions": "Next we have some silly sentences to look at. They don\u2019t exactly make sense \u2013 but that\u2019s what makes them silly! If you can read them on your own go right ahead! Or you can have someone else say the sentence first and you just repeat it after them (just be sure to only record when you are talking) You are doing a great job! We have only two more tasks to complete before we\u2019re all finished!",
         "prompts": [
-            "The blue spot is on the key again. When you are ready, press “record.",
-            "How hard did he hug him. When you are ready, press “record.”",
-            "We were away a year ago. When you are ready, press “record.”",
-            "We eat eggs every eve. When you are ready, press “record.”",
-            "My momma makes lemon muffins. When you are ready, press “record.”",
-            "Peter will keep at the park. When you are ready, press “record.”"
+            "The blue spot is on the key again. When you are ready, press \u201crecord.",
+            "How hard did he hug him. When you are ready, press \u201crecord.\u201d",
+            "We were away a year ago. When you are ready, press \u201crecord.\u201d",
+            "We eat eggs every eve. When you are ready, press \u201crecord.\u201d",
+            "My momma makes lemon muffins. When you are ready, press \u201crecord.\u201d",
+            "Peter will keep at the park. When you are ready, press \u201crecord.\u201d"
         ]
     },
     "noisy-sounds": {
         "instructions": "What a great job! Do you like making silly sounds? Do you know what sound a ghost or a mouse makes? Let's see if we can figure out what sound each of these pictures make.",
         "prompts": [
-            "Here's a picture of an airplane – it makes an 'ah' sound – we're going to say that three times – 'ah ah ah' When you are ready, press \"record\".",
-            "Next is a little mouse – it makes an 'ee ee ee' sound - your turn! When you are ready, press \"record\".",
-            "Here's a little ghost – he says 'oo oo oo' – your turn! When you are ready, press \"record\".",
-            "Looks like this baby is sleeping, so we have to remind everyone to be quiet by saying ‘sh sh sh’ Now you try! When you are ready, press “record.”",
-            "Do you know what sound a snake makes? It says ‘ss ss ss’. Can I hear you make that snake sound? When you are ready, press “record.”",
-            "Oh ice cream is so delicious! I like to eat it really fast – “muh muh muh” – your turn! When you are ready, press “record.”",
-            "Uh oh! Looks like the baby has been colouring on the walls. We should tell him to stop – “nuh nuh nuh”. You tell him too! When you are ready, press “record.”",
-            "Here’s a little bumble bee buzzing around the garden – ‘zz zz zz’. Let’s hear your bee noise When you are ready, press “record.”",
-            "Sometimes I see bunnies hopping in my garden too – ‘hh hh hh’. Can you make a bunny hopping noise too? When you are ready, press “record.”"
+            "Here's a picture of an airplane \u2013 it makes an 'ah' sound \u2013 we're going to say that three times \u2013 'ah ah ah' When you are ready, press \"record\".",
+            "Next is a little mouse \u2013 it makes an 'ee ee ee' sound - your turn! When you are ready, press \"record\".",
+            "Here's a little ghost \u2013 he says 'oo oo oo' \u2013 your turn! When you are ready, press \"record\".",
+            "Looks like this baby is sleeping, so we have to remind everyone to be quiet by saying \u2018sh sh sh\u2019 Now you try! When you are ready, press \u201crecord.\u201d",
+            "Do you know what sound a snake makes? It says \u2018ss ss ss\u2019. Can I hear you make that snake sound? When you are ready, press \u201crecord.\u201d",
+            "Oh ice cream is so delicious! I like to eat it really fast \u2013 \u201cmuh muh muh\u201d \u2013 your turn! When you are ready, press \u201crecord.\u201d",
+            "Uh oh! Looks like the baby has been colouring on the walls. We should tell him to stop \u2013 \u201cnuh nuh nuh\u201d. You tell him too! When you are ready, press \u201crecord.\u201d",
+            "Here\u2019s a little bumble bee buzzing around the garden \u2013 \u2018zz zz zz\u2019. Let\u2019s hear your bee noise When you are ready, press \u201crecord.\u201d",
+            "Sometimes I see bunnies hopping in my garden too \u2013 \u2018hh hh hh\u2019. Can you make a bunny hopping noise too? When you are ready, press \u201crecord.\u201d"
         ]
     },
     "silly-sounds": {
-        "instructions": "That was great! Let’s try some more sounds",
+        "instructions": "That was great! Let\u2019s try some more sounds",
         "prompts": [
-            "First, we’re going to say PUH PUH PUH over and over for about 5 seconds. Remember to take a breath if you need one! When you are ready, press “record.”",
-            "Next let’s do the same thing, but this time say TUH TUH TUH. When you are ready, press “record.",
-            "Amazing! We’ve got one more to try. Tell me KUH KUH KUH... When you are ready, press “record.",
-            "Fantastic! You did so well with those sounds, let’s try to put them together and say PUH TUH KUH over and over until the timer stops. If that word seems a little too tricky, you can say PAT-A-CAKE over and over instead When you are ready, press “record.”"
+            "First, we\u2019re going to say PUH PUH PUH over and over for about 5 seconds. Remember to take a breath if you need one! When you are ready, press \u201crecord.\u201d",
+            "Next let\u2019s do the same thing, but this time say TUH TUH TUH. When you are ready, press \u201crecord.",
+            "Amazing! We\u2019ve got one more to try. Tell me KUH KUH KUH... When you are ready, press \u201crecord.",
+            "Fantastic! You did so well with those sounds, let\u2019s try to put them together and say PUH TUH KUH over and over until the timer stops. If that word seems a little too tricky, you can say PAT-A-CAKE over and over instead When you are ready, press \u201crecord.\u201d"
         ]
     },
     "caterpillar-passage": {
@@ -4622,7 +4622,7 @@
     "story-recall": {
         "instructions": "Below you will be presented with a story about a boy and a frog. You may click forward to see the next image in the series. Feel free to move back and forth as much as you like until you are comfortable with the story. You will have up to 5 minutes to view the story, but you are not required to use the full 5 minutes. Once the time is up, please retell the story in as much detail as possible. When you are ready, please click the record button below. Once you click the record button, the story will disappear.",
         "prompts": [
-            "There was once a boy who had a dog and a pet frog. He kept the frog in a large jar in his bedroom. One night while he and his dog were sleeping, the frog climbed out of the jar. He jumped out of an open window. When the boy and the dog woke up the next morning, they saw that the jar was empty. The boy looked everywhere for the frog. The dog looked for the frog too. When the dog tried to look in the jar, he got his head stuck. he boy and the dog looked outside for the frog. The boy called out, “Frog, where are you? ”The boy climbed up on a rock and called again for his frog. He held onto some branches so he wouldn't fall. But the branches weren't really branches! They were deer antlers. The deer picked the boy up on his head and started running. The deer stopped suddenly and the boy and the dog fell over the edge of a cliff. There was a pond below the cliff. They landed with a splash right on top of one another. They heard a familiar sound. They crept up and looked behind a big log. There they found the boy's pet frog, with a mother frog and other baby frogs. The end."
+            "There was once a boy who had a dog and a pet frog. He kept the frog in a large jar in his bedroom. One night while he and his dog were sleeping, the frog climbed out of the jar. He jumped out of an open window. When the boy and the dog woke up the next morning, they saw that the jar was empty. The boy looked everywhere for the frog. The dog looked for the frog too. When the dog tried to look in the jar, he got his head stuck. he boy and the dog looked outside for the frog. The boy called out, \u201cFrog, where are you? \u201dThe boy climbed up on a rock and called again for his frog. He held onto some branches so he wouldn't fall. But the branches weren't really branches! They were deer antlers. The deer picked the boy up on his head and started running. The deer stopped suddenly and the boy and the dog fell over the edge of a cliff. There was a pond below the cliff. They landed with a splash right on top of one another. They heard a familiar sound. They crept up and looked behind a big log. There they found the boy's pet frog, with a mother frog and other baby frogs. The end."
         ]
     },
     "word-color-stroop": {
@@ -4693,7 +4693,7 @@
         "prompts": []
     },
     "naming-food": {
-        "instructions": "Next I want you to name as many food items you can think of. When you are ready, press “record.”",
+        "instructions": "Next I want you to name as many food items you can think of. When you are ready, press \u201crecord.\u201d",
         "prompts": []
     },
     "abcs": {
@@ -4701,7 +4701,7 @@
         "prompts": []
     },
     "choose-book": {
-        "instructions": "To start, we have a few books for you to choose from – you can choose which book you want to look at.",
+        "instructions": "To start, we have a few books for you to choose from \u2013 you can choose which book you want to look at.",
         "prompts": []
     },
     "months": {
@@ -4713,13 +4713,13 @@
         "prompts": []
     },
     "picture": {
-        "instructions": "If the child makes a sound effect vs naming the picture that’s ok! We’re not actually using this task as an evaluation of articulation. Pictures presented one at a time on the screen – option to swipe/click to “next” once the child has named the item or if it is an unknown for the child it may be skipped.",
+        "instructions": "If the child makes a sound effect vs naming the picture that\u2019s ok! We\u2019re not actually using this task as an evaluation of articulation. Pictures presented one at a time on the screen \u2013 option to swipe/click to \u201cnext\u201d once the child has named the item or if it is an unknown for the child it may be skipped.",
         "prompts": []
     },
     "passage": {
-        "instructions": "Fantastic Job! We only have one more thing to do today. Since you did so well reading the sentences earlier, let's try a few more. We're going to read a short story about a roller coaster ride called \"The Caterpillar\". A sentence or two will appear on the screen – read it aloud as if you were reading any regular story book. If you're not sure about a word, just skip it and keep going. When you are ready, press \"record\".",
+        "instructions": "Fantastic Job! We only have one more thing to do today. Since you did so well reading the sentences earlier, let's try a few more. We're going to read a short story about a roller coaster ride called \"The Caterpillar\". A sentence or two will appear on the screen \u2013 read it aloud as if you were reading any regular story book. If you're not sure about a word, just skip it and keep going. When you are ready, press \"record\".",
         "prompts": [
-            "Do you like amusement parks? Well, I sure do. To amuse myself, I went twice last spring. My most MEMORABLE moment was riding on the Caterpillar, which is a gigantic rollercoaster high above the ground. When I saw how high the Caterpillar rose into the bright blue sky I knew it was for me. After waiting in line for thirty minutes, I made it to the front where the man measured my height to see if I was tall enough. I gave the man my coins, asked for change, and jumped on the cart. Tick, tick, tick, the Caterpillar climbed slowly up the tracks. It went SO high I could see the parking lot. Boy was I SCARED! I thought to myself, “There’s no turning back now.” People were so scared they screamed as we swiftly zoomed fast, fast, and faster along the tracks. As quickly as it started, the Caterpillar came to a stop. Unfortunately, it was time to pack the car and drive home. That night I dreamt of the wild ride on the Caterpillar. Taking a trip to the amusement park and riding on the Caterpillar was my MOST memorable moment ever!"
+            "Do you like amusement parks? Well, I sure do. To amuse myself, I went twice last spring. My most MEMORABLE moment was riding on the Caterpillar, which is a gigantic rollercoaster high above the ground. When I saw how high the Caterpillar rose into the bright blue sky I knew it was for me. After waiting in line for thirty minutes, I made it to the front where the man measured my height to see if I was tall enough. I gave the man my coins, asked for change, and jumped on the cart. Tick, tick, tick, the Caterpillar climbed slowly up the tracks. It went SO high I could see the parking lot. Boy was I SCARED! I thought to myself, \u201cThere\u2019s no turning back now.\u201d People were so scared they screamed as we swiftly zoomed fast, fast, and faster along the tracks. As quickly as it started, the Caterpillar came to a stop. Unfortunately, it was time to pack the car and drive home. That night I dreamt of the wild ride on the Caterpillar. Taking a trip to the amusement park and riding on the Caterpillar was my MOST memorable moment ever!"
         ]
     }
 }

--- a/scripts/task_reference.json
+++ b/scripts/task_reference.json
@@ -1,0 +1,4725 @@
+{
+    "harvard-sentences-list-1-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The birch canoe slid on the smooth planks."
+        ]
+    },
+    "harvard-sentences-list-1-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Glue the sheet to the dark blue background."
+        ]
+    },
+    "harvard-sentences-list-1-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It's easy to tell the depth of a well."
+        ]
+    },
+    "harvard-sentences-list-1-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "These days a chicken leg is a rare dish."
+        ]
+    },
+    "harvard-sentences-list-1-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Rice is often served in round bowls."
+        ]
+    },
+    "harvard-sentences-list-1-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The juice of lemons makes fine punch."
+        ]
+    },
+    "harvard-sentences-list-1-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The box was thrown beside the parked truck."
+        ]
+    },
+    "harvard-sentences-list-1-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The hogs were fed chopped corn and garbage."
+        ]
+    },
+    "harvard-sentences-list-1-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Four hours of steady work faced us."
+        ]
+    },
+    "harvard-sentences-list-1-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A large size in stockings is hard to sell."
+        ]
+    },
+    "harvard-sentences-list-2-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The boy was there when the sun rose."
+        ]
+    },
+    "harvard-sentences-list-2-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A rod is used to catch pink salmon."
+        ]
+    },
+    "harvard-sentences-list-2-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The source of the huge river is the clear spring."
+        ]
+    },
+    "harvard-sentences-list-2-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Kick the ball straight and follow through."
+        ]
+    },
+    "harvard-sentences-list-2-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Help the woman get back to her feet."
+        ]
+    },
+    "harvard-sentences-list-2-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A pot of tea helps to pass the evening."
+        ]
+    },
+    "harvard-sentences-list-2-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Smoky fires lack flame and heat."
+        ]
+    },
+    "harvard-sentences-list-2-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The soft cushion broke the man's fall."
+        ]
+    },
+    "harvard-sentences-list-2-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The salt breeze came across from the sea."
+        ]
+    },
+    "harvard-sentences-list-2-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The girl at the booth sold fifty bonds."
+        ]
+    },
+    "harvard-sentences-list-3-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The small pup gnawed a hole in the sock."
+        ]
+    },
+    "harvard-sentences-list-3-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The fish twisted and turned on the bent hook."
+        ]
+    },
+    "harvard-sentences-list-3-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Press the pants and sew a button on the vest."
+        ]
+    },
+    "harvard-sentences-list-3-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The swan dive was far short of perfect."
+        ]
+    },
+    "harvard-sentences-list-3-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The beauty of the view stunned the young boy."
+        ]
+    },
+    "harvard-sentences-list-3-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Two blue fish swam in the tank."
+        ]
+    },
+    "harvard-sentences-list-3-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Her purse was full of useless trash."
+        ]
+    },
+    "harvard-sentences-list-3-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The colt reared and threw the tall rider."
+        ]
+    },
+    "harvard-sentences-list-3-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It snowed, rained, and hailed the same morning."
+        ]
+    },
+    "harvard-sentences-list-3-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Read verse out loud for pleasure."
+        ]
+    },
+    "harvard-sentences-list-4-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Hoist the load to your left shoulder."
+        ]
+    },
+    "harvard-sentences-list-4-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Take the winding path to reach the lake."
+        ]
+    },
+    "harvard-sentences-list-4-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Note closely the size of the gas tank."
+        ]
+    },
+    "harvard-sentences-list-4-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Wipe the grease off his dirty face."
+        ]
+    },
+    "harvard-sentences-list-4-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Mend the coat before you go out."
+        ]
+    },
+    "harvard-sentences-list-4-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The wrist was badly strained and hung limp."
+        ]
+    },
+    "harvard-sentences-list-4-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The stray cat gave birth to kittens."
+        ]
+    },
+    "harvard-sentences-list-4-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The young girl gave no clear response."
+        ]
+    },
+    "harvard-sentences-list-4-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The meal was cooked before the bell rang."
+        ]
+    },
+    "harvard-sentences-list-4-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "What joy there is in living."
+        ]
+    },
+    "harvard-sentences-list-5-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A king ruled the state in the early days."
+        ]
+    },
+    "harvard-sentences-list-5-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The ship was torn apart on the sharp reef."
+        ]
+    },
+    "harvard-sentences-list-5-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Sickness kept him home the third week."
+        ]
+    },
+    "harvard-sentences-list-5-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The wide road shimmered in the hot sun."
+        ]
+    },
+    "harvard-sentences-list-5-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The lazy cow lay in the cool grass."
+        ]
+    },
+    "harvard-sentences-list-5-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Lift the square stone over the fence."
+        ]
+    },
+    "harvard-sentences-list-5-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The rope will bind the seven books at once."
+        ]
+    },
+    "harvard-sentences-list-5-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Hop over the fence and plunge in."
+        ]
+    },
+    "harvard-sentences-list-5-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The friendly gang left the drug store."
+        ]
+    },
+    "harvard-sentences-list-5-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Mesh wire keeps chicks inside."
+        ]
+    },
+    "harvard-sentences-list-6-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The frosty air passed through the coat."
+        ]
+    },
+    "harvard-sentences-list-6-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The crooked maze failed to fool the mouse."
+        ]
+    },
+    "harvard-sentences-list-6-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Adding fast leads to wrong sums."
+        ]
+    },
+    "harvard-sentences-list-6-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The show was a flop from the very start."
+        ]
+    },
+    "harvard-sentences-list-6-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A saw is a tool used for making boards."
+        ]
+    },
+    "harvard-sentences-list-6-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The wagon moved on well oiled wheels."
+        ]
+    },
+    "harvard-sentences-list-6-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "March the soldiers past the next hill."
+        ]
+    },
+    "harvard-sentences-list-6-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A cup of sugar makes sweet fudge."
+        ]
+    },
+    "harvard-sentences-list-6-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Place a rosebush near the porch steps."
+        ]
+    },
+    "harvard-sentences-list-6-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Both lost their lives in the raging storm."
+        ]
+    },
+    "harvard-sentences-list-7-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We talked of the side show in the circus."
+        ]
+    },
+    "harvard-sentences-list-7-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Use a pencil to write the first draft."
+        ]
+    },
+    "harvard-sentences-list-7-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He ran half way to the hardware store."
+        ]
+    },
+    "harvard-sentences-list-7-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The clock struck to mark the third period."
+        ]
+    },
+    "harvard-sentences-list-7-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A small creek cut across the field."
+        ]
+    },
+    "harvard-sentences-list-7-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Cars and busses stalled in snow drifts."
+        ]
+    },
+    "harvard-sentences-list-7-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The set of china hit the floor with a crash."
+        ]
+    },
+    "harvard-sentences-list-7-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "This is a grand season for hikes on the road."
+        ]
+    },
+    "harvard-sentences-list-7-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The dune rose from the edge of the water."
+        ]
+    },
+    "harvard-sentences-list-7-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Those words were the cue for the actor to leave."
+        ]
+    },
+    "harvard-sentences-list-8-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A yacht slid around the point into the bay."
+        ]
+    },
+    "harvard-sentences-list-8-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The two met while playing on the sand."
+        ]
+    },
+    "harvard-sentences-list-8-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The ink stain dried on the finished page."
+        ]
+    },
+    "harvard-sentences-list-8-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The walled town was seized without a fight."
+        ]
+    },
+    "harvard-sentences-list-8-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The lease ran out in sixteen weeks."
+        ]
+    },
+    "harvard-sentences-list-8-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A tame squirrel makes a nice pet."
+        ]
+    },
+    "harvard-sentences-list-8-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The horn of the car woke the sleeping cop."
+        ]
+    },
+    "harvard-sentences-list-8-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The heart beat strongly and with firm strokes."
+        ]
+    },
+    "harvard-sentences-list-8-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The pearl was worn in a thin silver ring."
+        ]
+    },
+    "harvard-sentences-list-8-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The fruit peel was cut in thick slices."
+        ]
+    },
+    "harvard-sentences-list-9-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The Navy attacked the big task force."
+        ]
+    },
+    "harvard-sentences-list-9-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "See the cat glaring at the scared mouse."
+        ]
+    },
+    "harvard-sentences-list-9-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "There are more than two factors here."
+        ]
+    },
+    "harvard-sentences-list-9-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The hat brim was wide and too droopy."
+        ]
+    },
+    "harvard-sentences-list-9-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The lawyer tried to lose his case."
+        ]
+    },
+    "harvard-sentences-list-9-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The grass curled around the fence post."
+        ]
+    },
+    "harvard-sentences-list-9-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Cut the pie into large parts."
+        ]
+    },
+    "harvard-sentences-list-9-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Men strive but seldom get rich."
+        ]
+    },
+    "harvard-sentences-list-9-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Always close the barn door tight."
+        ]
+    },
+    "harvard-sentences-list-9-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He lay prone and hardly moved a limb."
+        ]
+    },
+    "harvard-sentences-list-10-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The slush lay deep along the street."
+        ]
+    },
+    "harvard-sentences-list-10-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A wisp of cloud hung in the blue air."
+        ]
+    },
+    "harvard-sentences-list-10-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A pound of sugar costs more than eggs."
+        ]
+    },
+    "harvard-sentences-list-10-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The fin was sharp and cut the clear water."
+        ]
+    },
+    "harvard-sentences-list-10-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The play seems dull and quite stupid."
+        ]
+    },
+    "harvard-sentences-list-10-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Bail the boat to stop it from sinking."
+        ]
+    },
+    "harvard-sentences-list-10-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The term ended in late June that year."
+        ]
+    },
+    "harvard-sentences-list-10-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A tusk is used to make costly gifts."
+        ]
+    },
+    "harvard-sentences-list-10-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Ten pins were set in order."
+        ]
+    },
+    "harvard-sentences-list-10-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The bill was paid every third week."
+        ]
+    },
+    "harvard-sentences-list-11-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Oak is strong and also gives shade."
+        ]
+    },
+    "harvard-sentences-list-11-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Cats and dogs each hate the other."
+        ]
+    },
+    "harvard-sentences-list-11-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The pipe began to rust while new."
+        ]
+    },
+    "harvard-sentences-list-11-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Open the crate but don't break the glass."
+        ]
+    },
+    "harvard-sentences-list-11-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Add the sum to the product of these three."
+        ]
+    },
+    "harvard-sentences-list-11-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Thieves who rob friends deserve jail."
+        ]
+    },
+    "harvard-sentences-list-11-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The ripe taste of cheese improves with age."
+        ]
+    },
+    "harvard-sentences-list-11-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Act on these orders with great speed."
+        ]
+    },
+    "harvard-sentences-list-11-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The hog crawled under the high fence."
+        ]
+    },
+    "harvard-sentences-list-11-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Move the vat over the hot fire."
+        ]
+    },
+    "harvard-sentences-list-12-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The bark of the pine tree was shiny and dark."
+        ]
+    },
+    "harvard-sentences-list-12-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Leaves turn brown and yellow in the fall."
+        ]
+    },
+    "harvard-sentences-list-12-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The pennant waved when the wind blew."
+        ]
+    },
+    "harvard-sentences-list-12-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Split the log with a quick, sharp blow."
+        ]
+    },
+    "harvard-sentences-list-12-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Burn peat after the logs give out."
+        ]
+    },
+    "harvard-sentences-list-12-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He ordered peach pie with ice cream."
+        ]
+    },
+    "harvard-sentences-list-12-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Weave the carpet on the right hand side."
+        ]
+    },
+    "harvard-sentences-list-12-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Hemp is a weed found in parts of the tropics."
+        ]
+    },
+    "harvard-sentences-list-12-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A lame back kept his score low."
+        ]
+    },
+    "harvard-sentences-list-12-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We find joy in the simplest things."
+        ]
+    },
+    "harvard-sentences-list-13-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Type out three lists of orders."
+        ]
+    },
+    "harvard-sentences-list-13-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The harder he tried the less he got done."
+        ]
+    },
+    "harvard-sentences-list-13-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The boss ran the show with a watchful eye."
+        ]
+    },
+    "harvard-sentences-list-13-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The cup cracked and spilled its contents."
+        ]
+    },
+    "harvard-sentences-list-13-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Paste can cleanse the most dirty brass."
+        ]
+    },
+    "harvard-sentences-list-13-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The slang word for raw whiskey is booze."
+        ]
+    },
+    "harvard-sentences-list-13-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It caught its hind paw in a rusty trap."
+        ]
+    },
+    "harvard-sentences-list-13-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The wharf could be seen at the farther shore."
+        ]
+    },
+    "harvard-sentences-list-13-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Feel the heat of the weak dying flame."
+        ]
+    },
+    "harvard-sentences-list-13-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The tiny girl took off her hat."
+        ]
+    },
+    "harvard-sentences-list-14-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A cramp is no small danger on a swim."
+        ]
+    },
+    "harvard-sentences-list-14-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He said the same phrase thirty times."
+        ]
+    },
+    "harvard-sentences-list-14-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Pluck the bright rose without leaves."
+        ]
+    },
+    "harvard-sentences-list-14-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Two plus seven is less than ten."
+        ]
+    },
+    "harvard-sentences-list-14-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The glow deepened in the eyes of the sweet girl."
+        ]
+    },
+    "harvard-sentences-list-14-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Bring your problems to the wise chief."
+        ]
+    },
+    "harvard-sentences-list-14-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Write a fond note to the friend you cherish."
+        ]
+    },
+    "harvard-sentences-list-14-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Clothes and lodging are free to new men."
+        ]
+    },
+    "harvard-sentences-list-14-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We frown when events take a bad turn."
+        ]
+    },
+    "harvard-sentences-list-14-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Port is a strong wine with a smoky taste."
+        ]
+    },
+    "harvard-sentences-list-15-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The young kid jumped the rusty gate."
+        ]
+    },
+    "harvard-sentences-list-15-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Guess the results from the first scores."
+        ]
+    },
+    "harvard-sentences-list-15-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A salt pickle tastes fine with ham."
+        ]
+    },
+    "harvard-sentences-list-15-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The just claim got the right verdict."
+        ]
+    },
+    "harvard-sentences-list-15-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "These thistles bend in a high wind."
+        ]
+    },
+    "harvard-sentences-list-15-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Pure bred poodles have curls."
+        ]
+    },
+    "harvard-sentences-list-15-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The tree top waved in a graceful way."
+        ]
+    },
+    "harvard-sentences-list-15-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The spot on the blotter was made by green ink."
+        ]
+    },
+    "harvard-sentences-list-15-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Mud was spattered on the front of his white shirt."
+        ]
+    },
+    "harvard-sentences-list-15-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The cigar burned a hole in the desk top."
+        ]
+    },
+    "harvard-sentences-list-16-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The empty flask stood on the tin tray."
+        ]
+    },
+    "harvard-sentences-list-16-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A speedy man can beat this track mark."
+        ]
+    },
+    "harvard-sentences-list-16-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He broke a new shoelace that day."
+        ]
+    },
+    "harvard-sentences-list-16-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The coffee stand is too high for the couch."
+        ]
+    },
+    "harvard-sentences-list-16-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The urge to write short stories is rare."
+        ]
+    },
+    "harvard-sentences-list-16-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The pencils have all been used."
+        ]
+    },
+    "harvard-sentences-list-16-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The pirates seized the crew of the lost ship."
+        ]
+    },
+    "harvard-sentences-list-16-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We tried to replace the coin but failed."
+        ]
+    },
+    "harvard-sentences-list-16-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "She sewed the torn coat quite neatly."
+        ]
+    },
+    "harvard-sentences-list-16-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The sofa cushion is red and of light weight."
+        ]
+    },
+    "harvard-sentences-list-17-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The jacket hung on the back of the wide chair."
+        ]
+    },
+    "harvard-sentences-list-17-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "At that high level the air is pure."
+        ]
+    },
+    "harvard-sentences-list-17-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Drop the two when you add the figures."
+        ]
+    },
+    "harvard-sentences-list-17-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A filing case is now hard to buy."
+        ]
+    },
+    "harvard-sentences-list-17-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "An abrupt start does not win the prize."
+        ]
+    },
+    "harvard-sentences-list-17-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Wood is best for making toys and blocks."
+        ]
+    },
+    "harvard-sentences-list-17-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The office paint was a dull, sad tan."
+        ]
+    },
+    "harvard-sentences-list-17-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He knew the skill of the great young actress."
+        ]
+    },
+    "harvard-sentences-list-17-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A rag will soak up spilled water."
+        ]
+    },
+    "harvard-sentences-list-17-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A shower of dirt fell from the hot pipes."
+        ]
+    },
+    "harvard-sentences-list-18-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Steam hissed from the broken valve."
+        ]
+    },
+    "harvard-sentences-list-18-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The child almost hurt the small dog."
+        ]
+    },
+    "harvard-sentences-list-18-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "There was a sound of dry leaves outside."
+        ]
+    },
+    "harvard-sentences-list-18-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The sky that morning was clear and bright blue."
+        ]
+    },
+    "harvard-sentences-list-18-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Torn scraps littered the stone floor."
+        ]
+    },
+    "harvard-sentences-list-18-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Sunday is the best part of the week."
+        ]
+    },
+    "harvard-sentences-list-18-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The doctor cured him with these pills."
+        ]
+    },
+    "harvard-sentences-list-18-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The new girl was fired today at noon."
+        ]
+    },
+    "harvard-sentences-list-18-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "They felt gay when the ship arrived in port."
+        ]
+    },
+    "harvard-sentences-list-18-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Add the store's account to the last cent."
+        ]
+    },
+    "harvard-sentences-list-19-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Acid burns holes in wool cloth."
+        ]
+    },
+    "harvard-sentences-list-19-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Fairy tales should be fun to write."
+        ]
+    },
+    "harvard-sentences-list-19-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Eight miles of woodland burned to waste."
+        ]
+    },
+    "harvard-sentences-list-19-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The third act was dull and tired the players."
+        ]
+    },
+    "harvard-sentences-list-19-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A young child should not suffer fright."
+        ]
+    },
+    "harvard-sentences-list-19-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Add the column and put the sum here."
+        ]
+    },
+    "harvard-sentences-list-19-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We admire and love a good cook."
+        ]
+    },
+    "harvard-sentences-list-19-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "There the flood mark is ten inches."
+        ]
+    },
+    "harvard-sentences-list-19-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He carved a head from the round block of marble."
+        ]
+    },
+    "harvard-sentences-list-19-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "She has a smart way of wearing clothes."
+        ]
+    },
+    "harvard-sentences-list-20-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The fruit of a fig tree is apple-shaped."
+        ]
+    },
+    "harvard-sentences-list-20-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Corn cobs can be used to kindle a fire."
+        ]
+    },
+    "harvard-sentences-list-20-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Where were they when the noise started."
+        ]
+    },
+    "harvard-sentences-list-20-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The paper box is full of thumb tacks."
+        ]
+    },
+    "harvard-sentences-list-20-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Sell your gift to a buyer at a good gain."
+        ]
+    },
+    "harvard-sentences-list-20-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The tongs lay beside the ice pail."
+        ]
+    },
+    "harvard-sentences-list-20-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The petals fall with the next puff of wind."
+        ]
+    },
+    "harvard-sentences-list-20-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Bring your best compass to the third class."
+        ]
+    },
+    "harvard-sentences-list-20-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "They could laugh although they were sad."
+        ]
+    },
+    "harvard-sentences-list-20-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Farmers came in to thresh the oat crop."
+        ]
+    },
+    "harvard-sentences-list-21-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The brown house was on fire to the attic."
+        ]
+    },
+    "harvard-sentences-list-21-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The lure is used to catch trout and flounder."
+        ]
+    },
+    "harvard-sentences-list-21-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Float the soap on top of the bath water."
+        ]
+    },
+    "harvard-sentences-list-21-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A blue crane is a tall wading bird."
+        ]
+    },
+    "harvard-sentences-list-21-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A fresh start will work such wonders."
+        ]
+    },
+    "harvard-sentences-list-21-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The club rented the rink for the fifth night."
+        ]
+    },
+    "harvard-sentences-list-21-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "After the dance, they went straight home."
+        ]
+    },
+    "harvard-sentences-list-21-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The hostess taught the new maid to serve."
+        ]
+    },
+    "harvard-sentences-list-21-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He wrote his last novel there at the inn."
+        ]
+    },
+    "harvard-sentences-list-21-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Even the worst will beat his low score."
+        ]
+    },
+    "harvard-sentences-list-22-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The cement had dried when he moved it."
+        ]
+    },
+    "harvard-sentences-list-22-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The loss of the second ship was hard to take."
+        ]
+    },
+    "harvard-sentences-list-22-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The fly made its way along the wall."
+        ]
+    },
+    "harvard-sentences-list-22-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Do that with a wooden stick."
+        ]
+    },
+    "harvard-sentences-list-22-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Live wires should be kept covered."
+        ]
+    },
+    "harvard-sentences-list-22-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The large house had hot water taps."
+        ]
+    },
+    "harvard-sentences-list-22-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It is hard to erase blue or red ink."
+        ]
+    },
+    "harvard-sentences-list-22-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Write at once or you may forget it."
+        ]
+    },
+    "harvard-sentences-list-22-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The doorknob was made of bright clean brass."
+        ]
+    },
+    "harvard-sentences-list-22-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The wreck occurred by the bank on Main Street."
+        ]
+    },
+    "harvard-sentences-list-23-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A pencil with black lead writes best."
+        ]
+    },
+    "harvard-sentences-list-23-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Coax a young calf to drink from a bucket."
+        ]
+    },
+    "harvard-sentences-list-23-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Schools for ladies teach charm and grace."
+        ]
+    },
+    "harvard-sentences-list-23-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The lamp shone with a steady green flame."
+        ]
+    },
+    "harvard-sentences-list-23-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "They took the axe and the saw to the forest."
+        ]
+    },
+    "harvard-sentences-list-23-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The ancient coin was quite dull and worn."
+        ]
+    },
+    "harvard-sentences-list-23-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The shaky barn fell with a loud crash."
+        ]
+    },
+    "harvard-sentences-list-23-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Jazz and swing fans like fast music."
+        ]
+    },
+    "harvard-sentences-list-23-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Rake the rubbish up and then burn it."
+        ]
+    },
+    "harvard-sentences-list-23-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Slash the gold cloth into fine ribbons."
+        ]
+    },
+    "harvard-sentences-list-24-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Try to have the court decide the case."
+        ]
+    },
+    "harvard-sentences-list-24-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "They are pushed back each time they attack."
+        ]
+    },
+    "harvard-sentences-list-24-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He broke his ties with groups of former friends."
+        ]
+    },
+    "harvard-sentences-list-24-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "They floated on the raft to sun their white backs."
+        ]
+    },
+    "harvard-sentences-list-24-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The map had an X that meant nothing."
+        ]
+    },
+    "harvard-sentences-list-24-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Whitings are small fish caught in nets."
+        ]
+    },
+    "harvard-sentences-list-24-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Some ads serve to cheat buyers."
+        ]
+    },
+    "harvard-sentences-list-24-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Jerk the rope and the bell rings weakly."
+        ]
+    },
+    "harvard-sentences-list-24-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A waxed floor makes us lose balance."
+        ]
+    },
+    "harvard-sentences-list-24-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Madam, this is the best brand of corn."
+        ]
+    },
+    "harvard-sentences-list-25-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "On the islands the sea breeze is soft and mild."
+        ]
+    },
+    "harvard-sentences-list-25-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The play began as soon as we sat down."
+        ]
+    },
+    "harvard-sentences-list-25-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "This will lead the world to more sound and fury."
+        ]
+    },
+    "harvard-sentences-list-25-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Add salt before you fry the egg."
+        ]
+    },
+    "harvard-sentences-list-25-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The rush for funds reached its peak Tuesday."
+        ]
+    },
+    "harvard-sentences-list-25-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The birch looked stark white and lonesome."
+        ]
+    },
+    "harvard-sentences-list-25-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The box is held by a bright red snapper."
+        ]
+    },
+    "harvard-sentences-list-25-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "To make pure ice, you freeze water."
+        ]
+    },
+    "harvard-sentences-list-25-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The first worm gets snapped early."
+        ]
+    },
+    "harvard-sentences-list-25-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Jump the fence and hurry up the bank."
+        ]
+    },
+    "harvard-sentences-list-26-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Yell and clap as the curtain slides back."
+        ]
+    },
+    "harvard-sentences-list-26-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "They are men who walk the middle of the road."
+        ]
+    },
+    "harvard-sentences-list-26-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Both brothers wear the same size."
+        ]
+    },
+    "harvard-sentences-list-26-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "In some form or other we need fun."
+        ]
+    },
+    "harvard-sentences-list-26-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The prince ordered his head chopped off."
+        ]
+    },
+    "harvard-sentences-list-26-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The houses are built of red clay bricks."
+        ]
+    },
+    "harvard-sentences-list-26-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Ducks fly north but lack a compass."
+        ]
+    },
+    "harvard-sentences-list-26-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Fruit flavors are used in fizz drinks."
+        ]
+    },
+    "harvard-sentences-list-26-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "These pills do less good than others."
+        ]
+    },
+    "harvard-sentences-list-26-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Canned pears lack full flavor."
+        ]
+    },
+    "harvard-sentences-list-27-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The dark pot hung in the front closet."
+        ]
+    },
+    "harvard-sentences-list-27-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Carry the pail to the wall and spill it there."
+        ]
+    },
+    "harvard-sentences-list-27-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The train brought our hero to the big town."
+        ]
+    },
+    "harvard-sentences-list-27-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We are sure that one war is enough."
+        ]
+    },
+    "harvard-sentences-list-27-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Gray paint stretched for miles around."
+        ]
+    },
+    "harvard-sentences-list-27-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The rude laugh filled the empty room."
+        ]
+    },
+    "harvard-sentences-list-27-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "High seats are best for football fans."
+        ]
+    },
+    "harvard-sentences-list-27-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Tea served from the brown jug is tasty."
+        ]
+    },
+    "harvard-sentences-list-27-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A dash of pepper spoils beef stew."
+        ]
+    },
+    "harvard-sentences-list-27-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A zestful food is the hot-cross bun."
+        ]
+    },
+    "harvard-sentences-list-28-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The horse trotted around the field at a brisk pace."
+        ]
+    },
+    "harvard-sentences-list-28-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Find the twin who stole the pearl necklace."
+        ]
+    },
+    "harvard-sentences-list-28-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Cut the cord that binds the box tightly."
+        ]
+    },
+    "harvard-sentences-list-28-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The red tape bound the smuggled food."
+        ]
+    },
+    "harvard-sentences-list-28-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Look in the corner to find the tan shirt."
+        ]
+    },
+    "harvard-sentences-list-28-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The cold drizzle will halt the bond drive."
+        ]
+    },
+    "harvard-sentences-list-28-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Nine men were hired to dig the ruins."
+        ]
+    },
+    "harvard-sentences-list-28-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The junk yard had a mouldy smell."
+        ]
+    },
+    "harvard-sentences-list-28-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The flint sputtered and lit a pine torch."
+        ]
+    },
+    "harvard-sentences-list-28-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Soak the cloth and drown the sharp odor."
+        ]
+    },
+    "harvard-sentences-list-29-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The shelves were bare of both jam or crackers."
+        ]
+    },
+    "harvard-sentences-list-29-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A joy to every child is the swan boat."
+        ]
+    },
+    "harvard-sentences-list-29-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "All sat frozen and watched the screen."
+        ]
+    },
+    "harvard-sentences-list-29-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A cloud of dust stung his tender eyes."
+        ]
+    },
+    "harvard-sentences-list-29-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "To reach the end he needs much courage."
+        ]
+    },
+    "harvard-sentences-list-29-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Shape the clay gently into block form."
+        ]
+    },
+    "harvard-sentences-list-29-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A ridge on a smooth surface is a bump or flaw."
+        ]
+    },
+    "harvard-sentences-list-29-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Hedge apples may stain your hands green."
+        ]
+    },
+    "harvard-sentences-list-29-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Quench your thirst, then eat the crackers."
+        ]
+    },
+    "harvard-sentences-list-29-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Tight curls get limp on rainy days."
+        ]
+    },
+    "harvard-sentences-list-30-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The mute muffled the high tones of the horn."
+        ]
+    },
+    "harvard-sentences-list-30-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The gold ring fits only a pierced ear."
+        ]
+    },
+    "harvard-sentences-list-30-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The old pan was covered with hard fudge."
+        ]
+    },
+    "harvard-sentences-list-30-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Watch the log float in the wide river."
+        ]
+    },
+    "harvard-sentences-list-30-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The node on the stalk of wheat grew daily."
+        ]
+    },
+    "harvard-sentences-list-30-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The heap of fallen leaves was set on fire."
+        ]
+    },
+    "harvard-sentences-list-30-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Write fast if you want to finish early."
+        ]
+    },
+    "harvard-sentences-list-30-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "His shirt was clean but one button was gone."
+        ]
+    },
+    "harvard-sentences-list-30-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The barrel of beer was a brew of malt and hops."
+        ]
+    },
+    "harvard-sentences-list-30-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Tin cans are absent from store shelves."
+        ]
+    },
+    "harvard-sentences-list-31-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Slide the box into that empty space."
+        ]
+    },
+    "harvard-sentences-list-31-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The plant grew large and green in the window."
+        ]
+    },
+    "harvard-sentences-list-31-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The beam dropped down on the workmen's head."
+        ]
+    },
+    "harvard-sentences-list-31-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Pink clouds floated with the breeze."
+        ]
+    },
+    "harvard-sentences-list-31-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "She danced like a swan, tall and graceful."
+        ]
+    },
+    "harvard-sentences-list-31-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The tube was blown and the tire flat and useless."
+        ]
+    },
+    "harvard-sentences-list-31-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It is late morning on the old wall clock."
+        ]
+    },
+    "harvard-sentences-list-31-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Let's all join as we sing the last chorus."
+        ]
+    },
+    "harvard-sentences-list-31-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The last switch cannot be turned off."
+        ]
+    },
+    "harvard-sentences-list-31-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The fight will end in just six minutes."
+        ]
+    },
+    "harvard-sentences-list-32-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The store walls were lined with colored frocks."
+        ]
+    },
+    "harvard-sentences-list-32-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The peace league met to discuss their plans."
+        ]
+    },
+    "harvard-sentences-list-32-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The rise to fame of a person takes luck."
+        ]
+    },
+    "harvard-sentences-list-32-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Paper is scarce, so write with much care."
+        ]
+    },
+    "harvard-sentences-list-32-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The quick fox jumped on the sleeping cat."
+        ]
+    },
+    "harvard-sentences-list-32-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The nozzle of the fire hose was bright brass."
+        ]
+    },
+    "harvard-sentences-list-32-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Screw the round cap on as tight as needed."
+        ]
+    },
+    "harvard-sentences-list-32-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Time brings us many changes."
+        ]
+    },
+    "harvard-sentences-list-32-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The purple tie was ten years old."
+        ]
+    },
+    "harvard-sentences-list-32-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Men think and plan and sometimes act."
+        ]
+    },
+    "harvard-sentences-list-33-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Fill the ink jar with sticky glue."
+        ]
+    },
+    "harvard-sentences-list-33-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He smoke a big pipe with strong contents."
+        ]
+    },
+    "harvard-sentences-list-33-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We need grain to keep our mules healthy."
+        ]
+    },
+    "harvard-sentences-list-33-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Pack the records in a neat thin case."
+        ]
+    },
+    "harvard-sentences-list-33-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The crunch of feet in the snow was the only sound."
+        ]
+    },
+    "harvard-sentences-list-33-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The copper bowl shone in the sun's rays."
+        ]
+    },
+    "harvard-sentences-list-33-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Boards will warp unless kept dry."
+        ]
+    },
+    "harvard-sentences-list-33-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The plush chair leaned against the wall."
+        ]
+    },
+    "harvard-sentences-list-33-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Glass will clink when struck by metal."
+        ]
+    },
+    "harvard-sentences-list-33-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Bathe and relax in the cool green grass."
+        ]
+    },
+    "harvard-sentences-list-34-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Nine rows of soldiers stood in line."
+        ]
+    },
+    "harvard-sentences-list-34-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The beach is dry and shallow at low tide."
+        ]
+    },
+    "harvard-sentences-list-34-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The idea is to sew both edges straight."
+        ]
+    },
+    "harvard-sentences-list-34-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The kitten chased the dog down the street."
+        ]
+    },
+    "harvard-sentences-list-34-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Pages bound in cloth make a book."
+        ]
+    },
+    "harvard-sentences-list-34-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Try to trace the fine lines of the painting."
+        ]
+    },
+    "harvard-sentences-list-34-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Women form less than half of the group."
+        ]
+    },
+    "harvard-sentences-list-34-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The zones merge in the central part of town."
+        ]
+    },
+    "harvard-sentences-list-34-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A gem in the rough needs work to polish."
+        ]
+    },
+    "harvard-sentences-list-34-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Code is used when secrets are sent."
+        ]
+    },
+    "harvard-sentences-list-35-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Most of the news is easy for us to hear."
+        ]
+    },
+    "harvard-sentences-list-35-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He used the lathe to make brass objects."
+        ]
+    },
+    "harvard-sentences-list-35-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The vane on top of the pole revolved in the wind."
+        ]
+    },
+    "harvard-sentences-list-35-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Mince pie is a dish served to children."
+        ]
+    },
+    "harvard-sentences-list-35-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The clan gathered on each dull night."
+        ]
+    },
+    "harvard-sentences-list-35-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Let it burn, it gives us warmth and comfort."
+        ]
+    },
+    "harvard-sentences-list-35-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A castle built from sand fails to endure."
+        ]
+    },
+    "harvard-sentences-list-35-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A child's wit saved the day for us."
+        ]
+    },
+    "harvard-sentences-list-35-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Tack the strip of carpet to the worn floor."
+        ]
+    },
+    "harvard-sentences-list-35-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Next Tuesday we must vote."
+        ]
+    },
+    "harvard-sentences-list-36-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Pour the stew from the pot into the plate."
+        ]
+    },
+    "harvard-sentences-list-36-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Each penny shone like new."
+        ]
+    },
+    "harvard-sentences-list-36-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The man went to the woods to gather sticks."
+        ]
+    },
+    "harvard-sentences-list-36-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The dirt piles were lines along the road."
+        ]
+    },
+    "harvard-sentences-list-36-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The logs fell and tumbled into the clear stream."
+        ]
+    },
+    "harvard-sentences-list-36-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Just hoist it up and take it away."
+        ]
+    },
+    "harvard-sentences-list-36-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A ripe plum is fit for a king's palate."
+        ]
+    },
+    "harvard-sentences-list-36-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Our plans right now are hazy."
+        ]
+    },
+    "harvard-sentences-list-36-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Brass rings are sold by these natives."
+        ]
+    },
+    "harvard-sentences-list-36-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It takes a good trap to capture a bear."
+        ]
+    },
+    "harvard-sentences-list-37-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Feed the white mouse some flower seeds."
+        ]
+    },
+    "harvard-sentences-list-37-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The thaw came early and freed the stream."
+        ]
+    },
+    "harvard-sentences-list-37-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He took the lead and kept it the whole distance."
+        ]
+    },
+    "harvard-sentences-list-37-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The key you designed will fit the lock."
+        ]
+    },
+    "harvard-sentences-list-37-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Plead to the council to free the poor thief."
+        ]
+    },
+    "harvard-sentences-list-37-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Better hash is made of rare beef."
+        ]
+    },
+    "harvard-sentences-list-37-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "This plank was made for walking on."
+        ]
+    },
+    "harvard-sentences-list-37-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The lake sparkled in the red hot sun."
+        ]
+    },
+    "harvard-sentences-list-37-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He crawled with care along the ledge."
+        ]
+    },
+    "harvard-sentences-list-37-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Tend the sheep while the dog wanders."
+        ]
+    },
+    "harvard-sentences-list-38-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It takes a lot of help to finish these."
+        ]
+    },
+    "harvard-sentences-list-38-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Mark the spot with a sign painted red."
+        ]
+    },
+    "harvard-sentences-list-38-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Take two shares as a fair profit."
+        ]
+    },
+    "harvard-sentences-list-38-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The fur of cats goes by many names."
+        ]
+    },
+    "harvard-sentences-list-38-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "North winds bring colds and fevers."
+        ]
+    },
+    "harvard-sentences-list-38-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He asks no person to vouch for him."
+        ]
+    },
+    "harvard-sentences-list-38-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Go now and come here later."
+        ]
+    },
+    "harvard-sentences-list-38-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A sash of gold silk will trim her dress."
+        ]
+    },
+    "harvard-sentences-list-38-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Soap can wash most dirt away."
+        ]
+    },
+    "harvard-sentences-list-38-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "That move means the game is over."
+        ]
+    },
+    "harvard-sentences-list-39-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He wrote down a long list of items."
+        ]
+    },
+    "harvard-sentences-list-39-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A siege will crack the strong defense."
+        ]
+    },
+    "harvard-sentences-list-39-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Grape juice and water mix well."
+        ]
+    },
+    "harvard-sentences-list-39-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Roads are paved with sticky tar."
+        ]
+    },
+    "harvard-sentences-list-39-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Fake stones shine but cost little."
+        ]
+    },
+    "harvard-sentences-list-39-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The drip of the rain made a pleasant sound."
+        ]
+    },
+    "harvard-sentences-list-39-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Smoke poured out of every crack."
+        ]
+    },
+    "harvard-sentences-list-39-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Serve the hot rum to the tired heroes."
+        ]
+    },
+    "harvard-sentences-list-39-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Much of the story makes good sense."
+        ]
+    },
+    "harvard-sentences-list-39-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The sun came up to light the eastern sky."
+        ]
+    },
+    "harvard-sentences-list-40-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Heave the line over the port side."
+        ]
+    },
+    "harvard-sentences-list-40-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A lathe cuts and trims any wood."
+        ]
+    },
+    "harvard-sentences-list-40-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It's a dense crowd in two distinct ways."
+        ]
+    },
+    "harvard-sentences-list-40-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "His hip struck the knee of the next player."
+        ]
+    },
+    "harvard-sentences-list-40-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The stale smell of old beer lingers."
+        ]
+    },
+    "harvard-sentences-list-40-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The desk was firm on the shaky floor."
+        ]
+    },
+    "harvard-sentences-list-40-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It takes heat to bring out the odor."
+        ]
+    },
+    "harvard-sentences-list-40-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Beef is scarcer than some lamb."
+        ]
+    },
+    "harvard-sentences-list-40-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Raise the sail and steer the ship northward."
+        ]
+    },
+    "harvard-sentences-list-40-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A cone costs five cents on Mondays."
+        ]
+    },
+    "harvard-sentences-list-41-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A pod is what peas always grow in."
+        ]
+    },
+    "harvard-sentences-list-41-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Jerk the dart from the cork target."
+        ]
+    },
+    "harvard-sentences-list-41-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "No cement will hold hard wood."
+        ]
+    },
+    "harvard-sentences-list-41-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We now have a new base for shipping."
+        ]
+    },
+    "harvard-sentences-list-41-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A list of names is carved around the base."
+        ]
+    },
+    "harvard-sentences-list-41-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The sheep were led home by a dog."
+        ]
+    },
+    "harvard-sentences-list-41-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Three for a dime, the young peddler cried."
+        ]
+    },
+    "harvard-sentences-list-41-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The sense of smell is better than that of touch."
+        ]
+    },
+    "harvard-sentences-list-41-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "No hardship seemed to keep him sad."
+        ]
+    },
+    "harvard-sentences-list-41-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Grace makes up for lack of beauty."
+        ]
+    },
+    "harvard-sentences-list-42-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Nudge gently but wake her now."
+        ]
+    },
+    "harvard-sentences-list-42-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The news struck doubt into restless minds."
+        ]
+    },
+    "harvard-sentences-list-42-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Once we stood beside the shore."
+        ]
+    },
+    "harvard-sentences-list-42-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A chink in the wall allowed a draft to blow."
+        ]
+    },
+    "harvard-sentences-list-42-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Fasten two pins on each side."
+        ]
+    },
+    "harvard-sentences-list-42-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A cold dip restores health and zest."
+        ]
+    },
+    "harvard-sentences-list-42-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He takes the oath of office each March."
+        ]
+    },
+    "harvard-sentences-list-42-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The sand drifts over the sill of the old house."
+        ]
+    },
+    "harvard-sentences-list-42-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The point of the steel pen was bent and twisted."
+        ]
+    },
+    "harvard-sentences-list-42-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "There is a lag between thought and act."
+        ]
+    },
+    "harvard-sentences-list-43-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Seed is needed to plant the spring corn."
+        ]
+    },
+    "harvard-sentences-list-43-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Draw the chart with heavy black lines."
+        ]
+    },
+    "harvard-sentences-list-43-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The boy owed his pal thirty cents."
+        ]
+    },
+    "harvard-sentences-list-43-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The chap slipped into the crowd and was lost."
+        ]
+    },
+    "harvard-sentences-list-43-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Hats are worn to tea and not to dinner."
+        ]
+    },
+    "harvard-sentences-list-43-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The ramp led up to the wide highway."
+        ]
+    },
+    "harvard-sentences-list-43-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Beat the dust from the rug onto the lawn."
+        ]
+    },
+    "harvard-sentences-list-43-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Say it slowly but make it ring clear."
+        ]
+    },
+    "harvard-sentences-list-43-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The straw nest housed five robins."
+        ]
+    },
+    "harvard-sentences-list-43-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Screen the porch with woven straw mats."
+        ]
+    },
+    "harvard-sentences-list-44-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "This horse will nose his way to the finish."
+        ]
+    },
+    "harvard-sentences-list-44-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The dry wax protects the deep scratch."
+        ]
+    },
+    "harvard-sentences-list-44-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He picked up the dice for a second roll."
+        ]
+    },
+    "harvard-sentences-list-44-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "These coins will be needed to pay his debt."
+        ]
+    },
+    "harvard-sentences-list-44-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The nag pulled the frail cart along."
+        ]
+    },
+    "harvard-sentences-list-44-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Twist the valve and release hot steam."
+        ]
+    },
+    "harvard-sentences-list-44-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The vamp of the shoe had a gold buckle."
+        ]
+    },
+    "harvard-sentences-list-44-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The smell of burned rags itches my nose."
+        ]
+    },
+    "harvard-sentences-list-44-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "New pants lack cuffs and pockets."
+        ]
+    },
+    "harvard-sentences-list-44-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The marsh will freeze when cold enough."
+        ]
+    },
+    "harvard-sentences-list-45-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "They slice the sausage thin with a knife."
+        ]
+    },
+    "harvard-sentences-list-45-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The bloom of the rose lasts a few days."
+        ]
+    },
+    "harvard-sentences-list-45-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A gray mare walked before the colt."
+        ]
+    },
+    "harvard-sentences-list-45-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Breakfast buns are fine with a hot drink."
+        ]
+    },
+    "harvard-sentences-list-45-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Bottles hold four kinds of rum."
+        ]
+    },
+    "harvard-sentences-list-45-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The man wore a feather in his felt hat."
+        ]
+    },
+    "harvard-sentences-list-45-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He wheeled the bike past the winding road."
+        ]
+    },
+    "harvard-sentences-list-45-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Drop the ashes on the worn old rug."
+        ]
+    },
+    "harvard-sentences-list-45-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The desk and both chairs were painted tan."
+        ]
+    },
+    "harvard-sentences-list-45-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Throw out the used paper cup and plate."
+        ]
+    },
+    "harvard-sentences-list-46-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A clean neck means a neat collar."
+        ]
+    },
+    "harvard-sentences-list-46-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The couch cover and hall drapes were blue."
+        ]
+    },
+    "harvard-sentences-list-46-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The stems of the tall glasses cracked and broke."
+        ]
+    },
+    "harvard-sentences-list-46-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The wall phone rang loud and often."
+        ]
+    },
+    "harvard-sentences-list-46-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The clothes dried on a thin wooden rack."
+        ]
+    },
+    "harvard-sentences-list-46-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Turn on the lantern which gives us light."
+        ]
+    },
+    "harvard-sentences-list-46-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The cleat sank deeply into the soft turf."
+        ]
+    },
+    "harvard-sentences-list-46-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The bills were mailed promptly on the tenth of the month."
+        ]
+    },
+    "harvard-sentences-list-46-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "To have is better than to wait and hope."
+        ]
+    },
+    "harvard-sentences-list-46-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The price is fair for a good antique clock."
+        ]
+    },
+    "harvard-sentences-list-47-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The music played on while they talked."
+        ]
+    },
+    "harvard-sentences-list-47-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Dispense with a vest on a day like this."
+        ]
+    },
+    "harvard-sentences-list-47-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The bunch of grapes was pressed into wine."
+        ]
+    },
+    "harvard-sentences-list-47-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He sent the figs, but kept the ripe cherries."
+        ]
+    },
+    "harvard-sentences-list-47-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The hinge on the door creaked with old age."
+        ]
+    },
+    "harvard-sentences-list-47-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The screen before the fire kept in the sparks."
+        ]
+    },
+    "harvard-sentences-list-47-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Fly by night, and you waste little time."
+        ]
+    },
+    "harvard-sentences-list-47-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Thick glasses helped him read the print."
+        ]
+    },
+    "harvard-sentences-list-47-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Birth and death mark the limits of life."
+        ]
+    },
+    "harvard-sentences-list-47-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The chair looked strong but had no bottom."
+        ]
+    },
+    "harvard-sentences-list-48-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The kite flew wildly in the high wind."
+        ]
+    },
+    "harvard-sentences-list-48-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A fur muff is stylish once more."
+        ]
+    },
+    "harvard-sentences-list-48-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The tin box held priceless stones."
+        ]
+    },
+    "harvard-sentences-list-48-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We need an end of all such matter."
+        ]
+    },
+    "harvard-sentences-list-48-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The case was puzzling to the old and wise."
+        ]
+    },
+    "harvard-sentences-list-48-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The bright lanterns were gay on the dark lawn."
+        ]
+    },
+    "harvard-sentences-list-48-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We don't get much money but we have fun."
+        ]
+    },
+    "harvard-sentences-list-48-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The youth drove with zest, but little skill."
+        ]
+    },
+    "harvard-sentences-list-48-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Five years he lived with a shaggy dog."
+        ]
+    },
+    "harvard-sentences-list-48-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A fence cuts through the corner lot."
+        ]
+    },
+    "harvard-sentences-list-49-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The way to save money is not to spend much."
+        ]
+    },
+    "harvard-sentences-list-49-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Shut the hatch before the waves push it in."
+        ]
+    },
+    "harvard-sentences-list-49-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The odor of spring makes young hearts jump."
+        ]
+    },
+    "harvard-sentences-list-49-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Crack the walnut with your sharp side teeth."
+        ]
+    },
+    "harvard-sentences-list-49-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He offered proof in the form of a large chart."
+        ]
+    },
+    "harvard-sentences-list-49-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Send the stuff in a thick paper bag."
+        ]
+    },
+    "harvard-sentences-list-49-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A quart of milk is water for the most part."
+        ]
+    },
+    "harvard-sentences-list-49-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "They told wild tales to frighten him."
+        ]
+    },
+    "harvard-sentences-list-49-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The three story house was built of stone."
+        ]
+    },
+    "harvard-sentences-list-49-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "In the rear of the ground floor was a large passage."
+        ]
+    },
+    "harvard-sentences-list-50-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A man in a blue sweater sat at the desk."
+        ]
+    },
+    "harvard-sentences-list-50-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Oats are a food eaten by horse and man."
+        ]
+    },
+    "harvard-sentences-list-50-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Their eyelids droop for want of sleep."
+        ]
+    },
+    "harvard-sentences-list-50-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A sip of tea revives his tired friend."
+        ]
+    },
+    "harvard-sentences-list-50-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "There are many ways to do these things."
+        ]
+    },
+    "harvard-sentences-list-50-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Tuck the sheet under the edge of the mat."
+        ]
+    },
+    "harvard-sentences-list-50-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A force equal to that would move the earth."
+        ]
+    },
+    "harvard-sentences-list-50-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We like to see clear weather."
+        ]
+    },
+    "harvard-sentences-list-50-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The work of the tailor is seen on each side."
+        ]
+    },
+    "harvard-sentences-list-50-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Take a chance and win a china doll."
+        ]
+    },
+    "harvard-sentences-list-51-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Shake the dust from your shoes, stranger."
+        ]
+    },
+    "harvard-sentences-list-51-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "She was kind to sick old people."
+        ]
+    },
+    "harvard-sentences-list-51-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The square wooden crate was packed to be shipped."
+        ]
+    },
+    "harvard-sentences-list-51-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The dusty bench stood by the stone wall."
+        ]
+    },
+    "harvard-sentences-list-51-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We dress to suit the weather of most days."
+        ]
+    },
+    "harvard-sentences-list-51-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Smile when you say nasty words."
+        ]
+    },
+    "harvard-sentences-list-51-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A bowl of rice is free with chicken stew."
+        ]
+    },
+    "harvard-sentences-list-51-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The water in this well is a source of good health."
+        ]
+    },
+    "harvard-sentences-list-51-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Take shelter in this tent, but keep still."
+        ]
+    },
+    "harvard-sentences-list-51-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "That guy is the writer of a few banned books."
+        ]
+    },
+    "harvard-sentences-list-52-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The little tales they tell are false."
+        ]
+    },
+    "harvard-sentences-list-52-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The door was barred, locked, and bolted as well."
+        ]
+    },
+    "harvard-sentences-list-52-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Ripe pears are fit for a queen's table."
+        ]
+    },
+    "harvard-sentences-list-52-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A big wet stain was on the round carpet."
+        ]
+    },
+    "harvard-sentences-list-52-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The kite dipped and swayed, but stayed aloft."
+        ]
+    },
+    "harvard-sentences-list-52-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The pleasant hours fly by much too soon."
+        ]
+    },
+    "harvard-sentences-list-52-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The room was crowded with a wild mob."
+        ]
+    },
+    "harvard-sentences-list-52-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "This strong arm shall shield your honor."
+        ]
+    },
+    "harvard-sentences-list-52-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "She blushed when he gave her a white orchid."
+        ]
+    },
+    "harvard-sentences-list-52-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The beetle droned in the hot June sun."
+        ]
+    },
+    "harvard-sentences-list-53-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Press the pedal with your left foot."
+        ]
+    },
+    "harvard-sentences-list-53-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Neat plans fail without luck."
+        ]
+    },
+    "harvard-sentences-list-53-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The black trunk fell from the landing."
+        ]
+    },
+    "harvard-sentences-list-53-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The bank pressed for payment of the debt."
+        ]
+    },
+    "harvard-sentences-list-53-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The theft of the pearl pin was kept secret."
+        ]
+    },
+    "harvard-sentences-list-53-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Shake hands with this friendly child."
+        ]
+    },
+    "harvard-sentences-list-53-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The vast space stretched into the far distance."
+        ]
+    },
+    "harvard-sentences-list-53-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A rich farm is rare in this sandy waste."
+        ]
+    },
+    "harvard-sentences-list-53-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "His wide grin earned many friends."
+        ]
+    },
+    "harvard-sentences-list-53-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Flax makes a fine brand of paper."
+        ]
+    },
+    "harvard-sentences-list-54-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Hurdle the pit with the aid of a long pole."
+        ]
+    },
+    "harvard-sentences-list-54-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A strong bid may scare your partner stiff."
+        ]
+    },
+    "harvard-sentences-list-54-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Even a just cause needs power to win."
+        ]
+    },
+    "harvard-sentences-list-54-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Peep under the tent and see the clowns."
+        ]
+    },
+    "harvard-sentences-list-54-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The leaf drifts along with a slow spin."
+        ]
+    },
+    "harvard-sentences-list-54-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Cheap clothes are flashy but don't last."
+        ]
+    },
+    "harvard-sentences-list-54-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A thing of small note can cause despair."
+        ]
+    },
+    "harvard-sentences-list-54-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Flood the mails with requests for this book."
+        ]
+    },
+    "harvard-sentences-list-54-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A thick coat of black paint covered all."
+        ]
+    },
+    "harvard-sentences-list-54-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The pencil was cut to be sharp at both ends."
+        ]
+    },
+    "harvard-sentences-list-55-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Those last words were a strong statement."
+        ]
+    },
+    "harvard-sentences-list-55-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He wrote his name boldly at the top of the sheet."
+        ]
+    },
+    "harvard-sentences-list-55-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Dill pickles are sour but taste fine."
+        ]
+    },
+    "harvard-sentences-list-55-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Down that road is the way to the grain farmer."
+        ]
+    },
+    "harvard-sentences-list-55-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Either mud or dust are found at all times."
+        ]
+    },
+    "harvard-sentences-list-55-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The best method is to fix it in place with clips."
+        ]
+    },
+    "harvard-sentences-list-55-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "If you mumble your speech will be lost."
+        ]
+    },
+    "harvard-sentences-list-55-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "At night the alarm roused him from a deep sleep."
+        ]
+    },
+    "harvard-sentences-list-55-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Read just what the meter says."
+        ]
+    },
+    "harvard-sentences-list-55-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Fill your pack with bright trinkets for the poor."
+        ]
+    },
+    "harvard-sentences-list-56-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The small red neon lamp went out."
+        ]
+    },
+    "harvard-sentences-list-56-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Clams are small, round, soft, and tasty."
+        ]
+    },
+    "harvard-sentences-list-56-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The fan whirled its round blades softly."
+        ]
+    },
+    "harvard-sentences-list-56-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The line where the edges join was clean."
+        ]
+    },
+    "harvard-sentences-list-56-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Breathe deep and smell the piny air."
+        ]
+    },
+    "harvard-sentences-list-56-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It matters not if he reads these words or those."
+        ]
+    },
+    "harvard-sentences-list-56-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A brown leather bag hung from its strap."
+        ]
+    },
+    "harvard-sentences-list-56-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A toad and a frog are hard to tell apart."
+        ]
+    },
+    "harvard-sentences-list-56-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A white silk jacket goes with any shoes."
+        ]
+    },
+    "harvard-sentences-list-56-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A break in the dam almost caused a flood."
+        ]
+    },
+    "harvard-sentences-list-57-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Paint the sockets in the wall dull green."
+        ]
+    },
+    "harvard-sentences-list-57-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The child crawled into the dense grass."
+        ]
+    },
+    "harvard-sentences-list-57-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Bribes fail where honest men work."
+        ]
+    },
+    "harvard-sentences-list-57-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Trample the spark, else the flames will spread."
+        ]
+    },
+    "harvard-sentences-list-57-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The hilt of the sword was carved with fine designs."
+        ]
+    },
+    "harvard-sentences-list-57-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A round hole was drilled through the thin board."
+        ]
+    },
+    "harvard-sentences-list-57-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Footprints showed the path he took up the beach."
+        ]
+    },
+    "harvard-sentences-list-57-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "She was waiting at my front lawn."
+        ]
+    },
+    "harvard-sentences-list-57-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A vent near the edge brought in fresh air."
+        ]
+    },
+    "harvard-sentences-list-57-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Prod the old mule with a crooked stick."
+        ]
+    },
+    "harvard-sentences-list-58-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It is a band of steel three inches wide."
+        ]
+    },
+    "harvard-sentences-list-58-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The pipe ran almost the length of the ditch."
+        ]
+    },
+    "harvard-sentences-list-58-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It was hidden from sight by a mass of leaves and shrubs."
+        ]
+    },
+    "harvard-sentences-list-58-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The weight of the package was seen on the high scale."
+        ]
+    },
+    "harvard-sentences-list-58-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Wake and rise, and step into the green outdoors."
+        ]
+    },
+    "harvard-sentences-list-58-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The green light in the brown box flickered."
+        ]
+    },
+    "harvard-sentences-list-58-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The brass tube circled the high wall."
+        ]
+    },
+    "harvard-sentences-list-58-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The lobes of her ears were pierced to hold rings."
+        ]
+    },
+    "harvard-sentences-list-58-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Hold the hammer near the end to drive the nail."
+        ]
+    },
+    "harvard-sentences-list-58-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Next Sunday is the twelfth of the month."
+        ]
+    },
+    "harvard-sentences-list-59-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Every word and phrase he speaks is true."
+        ]
+    },
+    "harvard-sentences-list-59-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He put his last cartridge into the gun and fired."
+        ]
+    },
+    "harvard-sentences-list-59-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "They took their kids from the public school."
+        ]
+    },
+    "harvard-sentences-list-59-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Drive the screw straight into the wood."
+        ]
+    },
+    "harvard-sentences-list-59-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Keep the hatch tight and the watch constant."
+        ]
+    },
+    "harvard-sentences-list-59-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Sever the twine with a quick snip of the knife."
+        ]
+    },
+    "harvard-sentences-list-59-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Paper will dry out when wet."
+        ]
+    },
+    "harvard-sentences-list-59-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Slide the catch back and open the desk."
+        ]
+    },
+    "harvard-sentences-list-59-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Help the weak to preserve their strength."
+        ]
+    },
+    "harvard-sentences-list-59-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A sullen smile gets few friends."
+        ]
+    },
+    "harvard-sentences-list-60-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Stop whistling and watch the boys march."
+        ]
+    },
+    "harvard-sentences-list-60-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Jerk the cord, and out tumbles the gold."
+        ]
+    },
+    "harvard-sentences-list-60-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Slide the tray across the glass top."
+        ]
+    },
+    "harvard-sentences-list-60-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The cloud moved in a stately way and was gone."
+        ]
+    },
+    "harvard-sentences-list-60-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Light maple makes for a swell room."
+        ]
+    },
+    "harvard-sentences-list-60-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Set the piece here and say nothing."
+        ]
+    },
+    "harvard-sentences-list-60-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Dull stories make her laugh."
+        ]
+    },
+    "harvard-sentences-list-60-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A stiff cord will do to fasten your shoe."
+        ]
+    },
+    "harvard-sentences-list-60-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Get the trust fund to the bank early."
+        ]
+    },
+    "harvard-sentences-list-60-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Choose between the high road and the low."
+        ]
+    },
+    "harvard-sentences-list-61-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A plea for funds seems to come again."
+        ]
+    },
+    "harvard-sentences-list-61-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He lent his coat to the tall gaunt stranger."
+        ]
+    },
+    "harvard-sentences-list-61-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "There is a strong chance it will happen once more."
+        ]
+    },
+    "harvard-sentences-list-61-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The duke left the park in a silver coach."
+        ]
+    },
+    "harvard-sentences-list-61-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Greet the new guests and leave quickly."
+        ]
+    },
+    "harvard-sentences-list-61-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "When the frost has come it is time for turkey."
+        ]
+    },
+    "harvard-sentences-list-61-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Sweet words work better than fierce."
+        ]
+    },
+    "harvard-sentences-list-61-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A thin stripe runs down the middle."
+        ]
+    },
+    "harvard-sentences-list-61-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A six comes up more often than a ten."
+        ]
+    },
+    "harvard-sentences-list-61-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Lush fern grow on the lofty rocks."
+        ]
+    },
+    "harvard-sentences-list-62-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The ram scared the school children off."
+        ]
+    },
+    "harvard-sentences-list-62-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The team with the best timing looks good."
+        ]
+    },
+    "harvard-sentences-list-62-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The farmer swapped his horse for a brown ox."
+        ]
+    },
+    "harvard-sentences-list-62-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Sit on the perch and tell the others what to do."
+        ]
+    },
+    "harvard-sentences-list-62-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A steep trail is painful for our feet."
+        ]
+    },
+    "harvard-sentences-list-62-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The early phase of life moves fast."
+        ]
+    },
+    "harvard-sentences-list-62-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Green moss grows on the northern side."
+        ]
+    },
+    "harvard-sentences-list-62-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Tea in thin china has a sweet taste."
+        ]
+    },
+    "harvard-sentences-list-62-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Pitch the straw through the door of the stable."
+        ]
+    },
+    "harvard-sentences-list-62-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The latch on the back gate needed a nail."
+        ]
+    },
+    "harvard-sentences-list-63-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The goose was brought straight from the old market."
+        ]
+    },
+    "harvard-sentences-list-63-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The sink is the thing in which we pile dishes."
+        ]
+    },
+    "harvard-sentences-list-63-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A whiff of it will cure the most stubborn cold."
+        ]
+    },
+    "harvard-sentences-list-63-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The facts don't always show who is right."
+        ]
+    },
+    "harvard-sentences-list-63-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "She flaps her cape as she parades the street."
+        ]
+    },
+    "harvard-sentences-list-63-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The loss of the cruiser was a blow to the fleet."
+        ]
+    },
+    "harvard-sentences-list-63-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Loop the braid to the left and then over."
+        ]
+    },
+    "harvard-sentences-list-63-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Plead with the lawyer to drop the lost cause."
+        ]
+    },
+    "harvard-sentences-list-63-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Calves thrive on tender spring grass."
+        ]
+    },
+    "harvard-sentences-list-63-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Post no bills on this office wall."
+        ]
+    },
+    "harvard-sentences-list-64-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Tear a thin sheet from the yellow pad."
+        ]
+    },
+    "harvard-sentences-list-64-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A cruise in warm waters in a sleek yacht is fun."
+        ]
+    },
+    "harvard-sentences-list-64-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A streak of color ran down the left edge."
+        ]
+    },
+    "harvard-sentences-list-64-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It was done before the boy could see it."
+        ]
+    },
+    "harvard-sentences-list-64-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Crouch before you jump or miss the mark."
+        ]
+    },
+    "harvard-sentences-list-64-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Pack the kits and don't forget the salt."
+        ]
+    },
+    "harvard-sentences-list-64-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The square peg will settle in the round hole."
+        ]
+    },
+    "harvard-sentences-list-64-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Fine soap saves tender skin."
+        ]
+    },
+    "harvard-sentences-list-64-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Poached eggs and tea must suffice."
+        ]
+    },
+    "harvard-sentences-list-64-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Bad nerves are jangled by a door slam."
+        ]
+    },
+    "harvard-sentences-list-65-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Ship maps are different from those for planes."
+        ]
+    },
+    "harvard-sentences-list-65-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Dimes showered down from all sides."
+        ]
+    },
+    "harvard-sentences-list-65-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "They sang the same tunes at each party."
+        ]
+    },
+    "harvard-sentences-list-65-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The sky in the west is tinged with orange red."
+        ]
+    },
+    "harvard-sentences-list-65-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The pods of peas ferment in bare fields."
+        ]
+    },
+    "harvard-sentences-list-65-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The horse balked and threw the tall rider."
+        ]
+    },
+    "harvard-sentences-list-65-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The hitch between the horse and cart broke."
+        ]
+    },
+    "harvard-sentences-list-65-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Pile the coal high in the shed corner."
+        ]
+    },
+    "harvard-sentences-list-65-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A gold vase is both rare and costly."
+        ]
+    },
+    "harvard-sentences-list-65-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The knife was hung inside its bright sheath."
+        ]
+    },
+    "harvard-sentences-list-66-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The rarest spice comes from the far East."
+        ]
+    },
+    "harvard-sentences-list-66-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The roof should be tilted at a sharp slant."
+        ]
+    },
+    "harvard-sentences-list-66-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A smatter of French is worse than none."
+        ]
+    },
+    "harvard-sentences-list-66-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The mule trod the treadmill day and night."
+        ]
+    },
+    "harvard-sentences-list-66-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The aim of the contest is to raise a great fund."
+        ]
+    },
+    "harvard-sentences-list-66-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "To send it now in large amounts is bad."
+        ]
+    },
+    "harvard-sentences-list-66-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "There is a fine hard tang in salty air."
+        ]
+    },
+    "harvard-sentences-list-66-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Cod is the main business of the north shore."
+        ]
+    },
+    "harvard-sentences-list-66-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The slab was hewn from heavy blocks of slate."
+        ]
+    },
+    "harvard-sentences-list-66-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Dunk the stale biscuits into strong drink."
+        ]
+    },
+    "harvard-sentences-list-67-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Hang tinsel from both branches."
+        ]
+    },
+    "harvard-sentences-list-67-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Cap the jar with a tight brass cover."
+        ]
+    },
+    "harvard-sentences-list-67-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The poor boy missed the boat again."
+        ]
+    },
+    "harvard-sentences-list-67-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Be sure to set the lamp firmly in the hole."
+        ]
+    },
+    "harvard-sentences-list-67-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Pick a card and slip it under the pack."
+        ]
+    },
+    "harvard-sentences-list-67-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A round mat will cover the dull spot."
+        ]
+    },
+    "harvard-sentences-list-67-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The first part of the plan needs changing."
+        ]
+    },
+    "harvard-sentences-list-67-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A good book informs of what we ought to know."
+        ]
+    },
+    "harvard-sentences-list-67-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The mail comes in three batches per day."
+        ]
+    },
+    "harvard-sentences-list-67-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "You cannot brew tea in a cold pot."
+        ]
+    },
+    "harvard-sentences-list-68-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Dots of light betrayed the black cat."
+        ]
+    },
+    "harvard-sentences-list-68-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Put the chart on the mantel and tack it down."
+        ]
+    },
+    "harvard-sentences-list-68-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The night shift men rate extra pay."
+        ]
+    },
+    "harvard-sentences-list-68-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The red paper brightened the dim stage."
+        ]
+    },
+    "harvard-sentences-list-68-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "See the player scoot to third base."
+        ]
+    },
+    "harvard-sentences-list-68-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Slide the bill between the two leaves."
+        ]
+    },
+    "harvard-sentences-list-68-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Many hands help get the job done."
+        ]
+    },
+    "harvard-sentences-list-68-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We don't like to admit our small faults."
+        ]
+    },
+    "harvard-sentences-list-68-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "No doubt about the way the wind blows."
+        ]
+    },
+    "harvard-sentences-list-68-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Dig deep in the earth for pirate's gold."
+        ]
+    },
+    "harvard-sentences-list-69-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The steady drip is worse than a drenching rain."
+        ]
+    },
+    "harvard-sentences-list-69-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A flat pack takes less luggage space."
+        ]
+    },
+    "harvard-sentences-list-69-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Green ice frosted the punch bowl."
+        ]
+    },
+    "harvard-sentences-list-69-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A stuffed chair slipped from the moving van."
+        ]
+    },
+    "harvard-sentences-list-69-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The stitch will serve but needs to be shortened."
+        ]
+    },
+    "harvard-sentences-list-69-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A thin book fits in the side pocket."
+        ]
+    },
+    "harvard-sentences-list-69-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The gloss on top made it unfit to read."
+        ]
+    },
+    "harvard-sentences-list-69-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The hail pattered on the burnt brown grass."
+        ]
+    },
+    "harvard-sentences-list-69-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Seven seals were stamped on great sheets."
+        ]
+    },
+    "harvard-sentences-list-69-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Our troops are set to strike heavy blows."
+        ]
+    },
+    "harvard-sentences-list-70-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The store was jammed before the sale could start."
+        ]
+    },
+    "harvard-sentences-list-70-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "It was a bad error on the part of the new judge."
+        ]
+    },
+    "harvard-sentences-list-70-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "One step more and the board will collapse."
+        ]
+    },
+    "harvard-sentences-list-70-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Take the match and strike it against your shoe."
+        ]
+    },
+    "harvard-sentences-list-70-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The pot boiled, but the contents failed to jell."
+        ]
+    },
+    "harvard-sentences-list-70-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The baby puts his right foot in his mouth."
+        ]
+    },
+    "harvard-sentences-list-70-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The bombs left most of the town in ruins."
+        ]
+    },
+    "harvard-sentences-list-70-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Stop and stare at the hard working man."
+        ]
+    },
+    "harvard-sentences-list-70-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The streets are narrow and full of sharp turns."
+        ]
+    },
+    "harvard-sentences-list-70-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The pup jerked the leash as he saw a feline shape."
+        ]
+    },
+    "harvard-sentences-list-71-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Open your book to the first page."
+        ]
+    },
+    "harvard-sentences-list-71-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Fish evade the net and swim off."
+        ]
+    },
+    "harvard-sentences-list-71-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Dip the pail once and let it settle."
+        ]
+    },
+    "harvard-sentences-list-71-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Will you please answer that phone."
+        ]
+    },
+    "harvard-sentences-list-71-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The big red apple fell to the ground."
+        ]
+    },
+    "harvard-sentences-list-71-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The curtain rose and the show was on."
+        ]
+    },
+    "harvard-sentences-list-71-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The young prince became heir to the throne."
+        ]
+    },
+    "harvard-sentences-list-71-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He sent the boy on a short errand."
+        ]
+    },
+    "harvard-sentences-list-71-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Leave now and you will arrive on time."
+        ]
+    },
+    "harvard-sentences-list-71-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The corner store was robbed last night."
+        ]
+    },
+    "harvard-sentences-list-72-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A gold ring will please most any girl."
+        ]
+    },
+    "harvard-sentences-list-72-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The long journey home took a year."
+        ]
+    },
+    "harvard-sentences-list-72-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "She saw a cat in the neighbor's house."
+        ]
+    },
+    "harvard-sentences-list-72-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A pink shell was found on the sandy beach."
+        ]
+    },
+    "harvard-sentences-list-72-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Small children came to see him."
+        ]
+    },
+    "harvard-sentences-list-72-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The grass and bushes were wet with dew."
+        ]
+    },
+    "harvard-sentences-list-72-7": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The blind man counted his old coins."
+        ]
+    },
+    "harvard-sentences-list-72-8": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "A severe storm tore down the barn."
+        ]
+    },
+    "harvard-sentences-list-72-9": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "She called his name many times."
+        ]
+    },
+    "harvard-sentences-list-72-10": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "When you hear the bell, come quickly."
+        ]
+    },
+    "cape-V-sentences-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The blue spot is on the key again."
+        ]
+    },
+    "cape-V-sentences-(v2)-1": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "The blue spot is on the key again."
+        ]
+    },
+    "cape-V-sentences-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "How hard did he hit him?"
+        ]
+    },
+    "cape-V-sentences-(v2)-2": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "He helped her hurry home."
+        ]
+    },
+    "cape-V-sentences-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We were away a year ago."
+        ]
+    },
+    "cape-V-sentences-(v2)-3": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We were away a year ago."
+        ]
+    },
+    "cape-V-sentences-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "We eat eggs every Easter."
+        ]
+    },
+    "cape-V-sentences-(v2)-4": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "I eat eggs every morning."
+        ]
+    },
+    "cape-V-sentences-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "My mama makes lemon muffins."
+        ]
+    },
+    "cape-V-sentences-(v2)-5": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "My mama makes lemon muffins."
+        ]
+    },
+    "cape-V-sentences-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Peter will keep at the peak."
+        ]
+    },
+    "cape-V-sentences-(v2)-6": {
+        "instructions": "Please read the following sentences out loud in your typical voice.",
+        "prompts": [
+            "Papa took a piece of cake."
+        ]
+    },
+    "animal-Fluency": {
+        "instructions": "For this task, you say as many animals as you can, while avoiding repeating the same ones. There is a 1 minute timer on this, and we will ask that you continue trying until the time is up. ",
+        "prompts": []
+    },
+    "random-item-generation": {
+        "instructions": "Say as many letters or numbers (0-9) as you can. You are allowed to repeat items. Your goal is to list as many as possible in a random order. Time limit 2 minutes. The selection will appear when you start recording. The recording will automatically stop at the end.",
+        "prompts": []
+    },
+    "breath-sounds": {
+        "instructions": "Breathing: Click on the Record button below and breathe deeply through your mouth. Continue to do this until the recording automatically stops after 5 seconds. Click Play to hear your recording. If you hear background noise, please go to a quieter place and try again by selecting Redo Recording. If it sounds good, continue.",
+        "prompts": []
+    },
+    "cinderella-story": {
+        "instructions": "You'll receive a hard copy of the Cinderella storybook from our study team to refresh your memory of the story. When ready, click the 'Record' button below to begin narrating the story. Once you've finished, tap on 'Stop Recording'.",
+        "prompts": []
+    },
+    "diadochokinesis-(v2)-puhtuhkuh": {
+        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllables 'puhtuhkuh' as quickly and consistently as possible until the timer runs out - 'puhtuhkuhpuhtuhkuh'",
+        "prompts": []
+    },
+    "diadochokinesis-(v2)-buttercup": {
+        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the word 'buttercup' as quickly and consistently as possible until the timer runs out.",
+        "prompts": []
+    },
+    "diadochokinesis-buttercup": {
+        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the word 'buttercup' as quickly and consistently as possible until the timer runs out.",
+        "prompts": []
+    },
+    "diadochokinesis-(v2)-kuh": {
+        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllable 'kuh' as quickly and consistently as possible until the timer runs out - 'kuhkuhkuhkuhkuhkuh'",
+        "prompts": []
+    },
+    "diadochokinesis-KA": {
+        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllable 'ka' as quickly and consistently as possible until the timer runs out - 'kakakakakaka'",
+        "prompts": []
+    },
+    "diadochokinesis-(v2)-puh": {
+        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllable 'puh' as quickly and consistently as possible until the timer runs out - 'puhpuhpuhpuhpuhpuh'",
+        "prompts": []
+    },
+    "diadochokinesis-Pataka": {
+        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllables 'pataka' as quickly and consistently as possible until the timer runs out - 'patakapataka'",
+        "prompts": []
+    },
+    "diadochokinesis-PA": {
+        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllable 'pa' as quickly and consistently as possible until the timer runs out - 'papapapapapa'",
+        "prompts": []
+    },
+    "diadochokinesis-(v2)-tuh": {
+        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllable 'tuh' as quickly and consistently as possible until the timer runs out - 'tuhtuhtuhtuhtuhtuh'",
+        "prompts": []
+    },
+    "diadochokinesis-TA": {
+        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllable 'ta' as quickly and consistently as possible until the timer runs out - 'tatatatatata'",
+        "prompts": []
+    },
+    "prolonged-Vowel": {
+        "instructions": "This task helps us analyze features in your voice. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the sentence “1, 2, 3 aah” in your normal voice. Please hold the sound “aah” until the timer runs out.",
+        "prompts": []
+    },
+    "productive-Vocabulary": {
+        "instructions": "Below you will be provided with a series of words. You may or may not know the word. If you know the word, please provide a definition of the word. After you have defined the word, press 'Next Word'. If you do NOT know the word, press 'I don't know this word, next', and you will be provided a new word. Once 6 words are defined, the 'Done' button appears.",
+        "prompts": []
+    },
+    "maximum-phonation-time": {
+        "instructions": "This task helps us analyze the way your breathing is connected to your voice. Take a very deep breath, tap on the record button, and hold out “ah” for as long as possible until you completely run out of air. Try to hold it until the progress bar reaches the end of the screen.",
+        "prompts": []
+    },
+    "loudness": {
+        "instructions": "This helps us to determine the loudness of the voice. When you're ready, press the record button and say “hey” in your normal voice. Then, shout “hey” as loud as you can. Try to reach the target line on the screen. Follow the prompts on the screen to continue.",
+        "prompts": []
+    },
+    "glides-low-to-high": {
+        "instructions": "Please watch the video to help you understand the next task and imitate what the speaker does. When you're ready, press the record button and use the sound “ee” to gradually move from your lowest note to your highest.",
+        "prompts": []
+    },
+    "glides-high-to-low": {
+        "instructions": "Next, please watch this video for the following task and imitate what the speaker does. When you're ready, press the record button again and use the sound “ee” to gradually move from your highest note to your lowest note.",
+        "prompts": []
+    },
+    "high-to-low": {
+        "instructions": "Next, please watch this video for the following task and imitate what the speaker does. When you're ready, press the record button again and use the sound “ee” to gradually move from your highest note to your lowest note.",
+        "prompts": []
+    },
+    "respiration-and-cough-cough": {
+        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
+        "prompts": [
+            "Please do not cover your mouth or place your hand between your mouth and the microphone during recording. Breathe normally, then when you are ready, tap the record button below and cough HARD as if something were stuck in your throat. Tap stop when finished."
+        ]
+    },
+    "respiration-and-cough-(v2)-hardcough": {
+        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
+        "prompts": [
+            "Please do not cover your mouth or place your hand between your mouth and the microphone during recording. Breathe normally, then when you are ready, tap the record button below and cough HARD as if something were stuck in your throat. Tap stop when finished."
+        ]
+    },
+    "respiration-and-cough-(v2)-threebreathsmouth": {
+        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
+        "prompts": [
+            "After pressing on record, take 3 deep breaths in and out through your mouth. Tap stop when finished."
+        ]
+    },
+    "respiration-and-cough-(v2)-threebreathsnose": {
+        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
+        "prompts": [
+            "After pressing on record, take 3 deep breaths in and out through your nose with your mouth closed. Tap stop when finished."
+        ]
+    },
+    "respiration-and-cough-(v2)-threebreaths": {
+        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
+        "prompts": [
+            "After pressing on record, exhale normally, then inhale quickly through your mouth, as if you are trying to catch your breath. Record 3 of these breaths in a single recording. Tap stop when finished."
+        ]
+    },
+    "respiration-and-cough-threequickbreaths": {
+        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
+        "prompts": [
+            "After pressing on record, exhale normally, then inhale quickly through your mouth, as if you are trying to catch your breath. Record 3 of these breaths in a single recording. Tap stop when finished."
+        ]
+    },
+    "respiration-and-cough-breath": {
+        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
+        "prompts": [
+            "After pressing on record, breathe comfortably through your mouth for 20 seconds, until the timer runs out."
+        ]
+    },
+    "respiration-and-cough-(v2)-breath": {
+        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
+        "prompts": [
+            "After pressing on record, breathe comfortably through your mouth for 20 seconds, until the timer runs out."
+        ]
+    },
+    "respiration-and-Cough-fivebreaths": {
+        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
+        "prompts": [
+            "After pressing on record, exhale normally, then inhale quickly through your mouth, as if you are trying to catch your breath. Record 5 of these breaths in a single recording. Tap stop when finished."
+        ]
+    },
+    "rainbow": {
+        "instructions": "This task helps us evaluate how you use breathing to support your voice. Please read the following passage out loud in your typical voice.",
+        "prompts": [
+            "When the sunlight strikes raindrops in the air, they act as a prism and form a rainbow. The rainbow is a division of white light into many beautiful colors. These take the shape of a long round arch, with its path high above, and its two ends apparently beyond the horizon. There is, according to legend, a boiling pot of gold at one end."
+        ]
+    },
+    "123s": {
+        "instructions": "Wow that was great! I wonder how high you can count? Let's start at 1, 2... When you are ready, press \"record\".",
+        "prompts": []
+    },
+    "picture-description-option2": {
+        "instructions": "Describe everything that is happening in the picture (as though describing it for the blind), trying to use complete sentences.",
+        "prompts": []
+    },
+    "picture-description": {
+        "instructions": "Tell me everything you see going on in this picture.",
+        "prompts": []
+    },
+    "favorite-food": {
+        "instructions": "Do you have a favourite food? Or a food you really don't like? When you're ready to share, press \"record\".",
+        "prompts": []
+    },
+    "favorite-show-movie-game": {
+        "instructions": "Do you have a favourite movie? Video game? Show? I'd love to hear about it! When you're ready to share, press \"record\".",
+        "prompts": []
+    },
+    "long-sounds": {
+        "instructions": "First, let's start by saying 'ahhhhh' for around 5 seconds. We're going to repeat this three times during one recording. Try to have the child produce the sound at a habitual pitch – some tend to use a higher \"note\" or create vibrato if they have any singing background The sound produced should be as steady/consistent as possible Re-record if you perceive the child is using a higher pitch when sustaining the vowel (in comparison to speaking) When you are ready, press \"record\". Next, say the 'eeeeee' sound as steady as you can for about 5 seconds. We'll do this three times as well. When you are ready, press \"record\".",
+        "prompts": []
+    },
+    "repeat-words": {
+        "instructions": "Say the following word 3 times",
+        "prompts": []
+    },
+    "ready-for-school": {
+        "instructions": "To start, let's learn a little more about you! Tell me about how you get ready for school in the morning.",
+        "prompts": []
+    },
+    "outside-of-school": {
+        "instructions": "What do you like to do when you're not at school? Tell me about any activities you do like sports, dance, karate, art, etc. When you're ready to share, press \"record\".",
+        "prompts": []
+    },
+    "pictures-and-doors": {
+        "instructions": "There are lots of pictures inside – let's talk about some of the things you see. When you are ready, press \"record\".",
+        "prompts": []
+    },
+    "role-naming": {
+        "instructions": "Thank you for sharing all of that information with me! It was super interesting Let's try some different questions - if you're not sure what the answer is, you can just move on to the next question. I bet you know the months of the year too. Let's start with January... When you are ready, press \"record\". That was great Next can you count from 60 to 70? When you are ready, press \"record\".",
+        "prompts": []
+    },
+    "sentence": {
+        "instructions": "Next we have some silly sentences to look at. They don’t exactly make sense – but that’s what makes them silly! If you can read them on your own go right ahead! Or you can have someone else say the sentence first and you just repeat it after them (just be sure to only record when you are talking) You are doing a great job! We have only two more tasks to complete before we’re all finished!",
+        "prompts": [
+            "The blue spot is on the key again. When you are ready, press “record.",
+            "How hard did he hug him. When you are ready, press “record.”",
+            "We were away a year ago. When you are ready, press “record.”",
+            "We eat eggs every eve. When you are ready, press “record.”",
+            "My momma makes lemon muffins. When you are ready, press “record.”",
+            "Peter will keep at the park. When you are ready, press “record.”"
+        ]
+    },
+    "noisy-sounds": {
+        "instructions": "What a great job! Do you like making silly sounds? Do you know what sound a ghost or a mouse makes? Let's see if we can figure out what sound each of these pictures make.",
+        "prompts": [
+            "Here's a picture of an airplane – it makes an 'ah' sound – we're going to say that three times – 'ah ah ah' When you are ready, press \"record\".",
+            "Next is a little mouse – it makes an 'ee ee ee' sound - your turn! When you are ready, press \"record\".",
+            "Here's a little ghost – he says 'oo oo oo' – your turn! When you are ready, press \"record\".",
+            "Looks like this baby is sleeping, so we have to remind everyone to be quiet by saying ‘sh sh sh’ Now you try! When you are ready, press “record.”",
+            "Do you know what sound a snake makes? It says ‘ss ss ss’. Can I hear you make that snake sound? When you are ready, press “record.”",
+            "Oh ice cream is so delicious! I like to eat it really fast – “muh muh muh” – your turn! When you are ready, press “record.”",
+            "Uh oh! Looks like the baby has been colouring on the walls. We should tell him to stop – “nuh nuh nuh”. You tell him too! When you are ready, press “record.”",
+            "Here’s a little bumble bee buzzing around the garden – ‘zz zz zz’. Let’s hear your bee noise When you are ready, press “record.”",
+            "Sometimes I see bunnies hopping in my garden too – ‘hh hh hh’. Can you make a bunny hopping noise too? When you are ready, press “record.”"
+        ]
+    },
+    "silly-sounds": {
+        "instructions": "That was great! Let’s try some more sounds",
+        "prompts": [
+            "First, we’re going to say PUH PUH PUH over and over for about 5 seconds. Remember to take a breath if you need one! When you are ready, press “record.”",
+            "Next let’s do the same thing, but this time say TUH TUH TUH. When you are ready, press “record.",
+            "Amazing! We’ve got one more to try. Tell me KUH KUH KUH... When you are ready, press “record.",
+            "Fantastic! You did so well with those sounds, let’s try to put them together and say PUH TUH KUH over and over until the timer stops. If that word seems a little too tricky, you can say PAT-A-CAKE over and over instead When you are ready, press “record.”"
+        ]
+    },
+    "caterpillar-passage": {
+        "instructions": "This is a passage that contains speech sounds in English by sound frequency to test your ability to produce speech sounds. Please read the following passage out loud in your typical voice.",
+        "prompts": [
+            "Do you like amusement parks? Well, I sure do. To amuse myself, I went twice last spring. My most MEMORABLE moment was riding on the Caterpillar, which is a gigantic rollercoaster high above the ground. When I saw how high the Caterpillar rose into the bright blue sky I knew it was for me. After waiting in line for thirty minutes, I made it to the front where the man measured my height to see if I was tall enough. I gave the man my coins, asked for change, and jumped on the cart. Tick, tick, tick, the Caterpillar climbed slowly up the tracks. It went SO high I could see the parking lot. Boy was I SCARED! I thought to myself, 'There's no turning back now.' People were so scared they screamed as we swiftly zoomed fast, fast, and faster along the tracks. As quickly as it started, the Caterpillar came to a stop. Unfortunately, it was time to pack the car and drive home. That night I dreamt of the wild ride on the Caterpillar. Taking a trip to the amusement park and riding on the Caterpillar was my MOST memorable moment ever!"
+        ]
+    },
+    "story-recall": {
+        "instructions": "Below you will be presented with a story about a boy and a frog. You may click forward to see the next image in the series. Feel free to move back and forth as much as you like until you are comfortable with the story. You will have up to 5 minutes to view the story, but you are not required to use the full 5 minutes. Once the time is up, please retell the story in as much detail as possible. When you are ready, please click the record button below. Once you click the record button, the story will disappear.",
+        "prompts": [
+            "There was once a boy who had a dog and a pet frog. He kept the frog in a large jar in his bedroom. One night while he and his dog were sleeping, the frog climbed out of the jar. He jumped out of an open window. When the boy and the dog woke up the next morning, they saw that the jar was empty. The boy looked everywhere for the frog. The dog looked for the frog too. When the dog tried to look in the jar, he got his head stuck. he boy and the dog looked outside for the frog. The boy called out, “Frog, where are you? ”The boy climbed up on a rock and called again for his frog. He held onto some branches so he wouldn't fall. But the branches weren't really branches! They were deer antlers. The deer picked the boy up on his head and started running. The deer stopped suddenly and the boy and the dog fell over the edge of a cliff. There was a pond below the cliff. They landed with a splash right on top of one another. They heard a familiar sound. They crept up and looked behind a big log. There they found the boy's pet frog, with a mother frog and other baby frogs. The end."
+        ]
+    },
+    "word-color-stroop": {
+        "instructions": "This exercise asks you to name out loud the color in which a word is displayed. Sometimes the word will be a color word: do not read the word aloud, just state the color in which it's displayed. For example, if you see the word \"brown\", and its letters are displayed in blue, you will say the word \"blue\". Please answer as quickly as possible. Time limit = 5 seconds/item, 15 random words. Total time 75s. Tap on the red circle below to start recording. The recording will continue through all tasks and automatically stop at the end.",
+        "prompts": [
+            "red",
+            "green",
+            "blue",
+            "brown",
+            "purple",
+            "oooo"
+        ]
+    },
+    "free-speech-(v2)-1": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. We'd like to get a recording of your natural speech. Please answer the following questions as though you were having a conversation. We'll record about 30 seconds of your response.",
+        "prompts": [
+            "What is your favorite season (winter, fall, summer, or spring) and why? Talk about the food, clothing, and activities you enjoy at that time."
+        ]
+    },
+    "free-speech-(v2)-2": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. We'd like to get a recording of your natural speech. Please answer the following questions as though you were having a conversation. We'll record about 30 seconds of your response.",
+        "prompts": [
+            "Thinking back over the past 2 weeks, describe your general mood, either positive or negative. What things have contributed to you feeling this way?"
+        ]
+    },
+    "free-speech-(v2)-3": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. We'd like to get a recording of your natural speech. Please answer the following questions as though you were having a conversation. We'll record about 30 seconds of your response.",
+        "prompts": [
+            "Tell us about your favorite book or movie. Why do you like it?"
+        ]
+    },
+    "free-speech-1": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. Please answer the following questions and record your answer. Keep talking until the time stops.",
+        "prompts": [
+            "Can you talk to us about why you are interested by this study? Who told you about it? Why is it meaningful or valuable to you? How do you think it will help patients in the future?"
+        ]
+    },
+    "free-speech-2": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. Please answer the following questions and record your answer. Keep talking until the time stops.",
+        "prompts": [
+            "If you are enrolled due to a health condition, can you tell us about it? When did it start, what kind of symptoms have you had and for how long? Tell us how you are managing it and how you are doing? If you are healthy and don't have any health conditions, please tell us about how you stay healthy."
+        ]
+    },
+    "free-speech-3": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. Please answer the following questions and record your answer. Keep talking until the time stops.",
+        "prompts": [
+            "Can you tell us about your mood in the past couple of weeks? What makes you feel happiness and what makes you feel sadness or stress?"
+        ]
+    },
+    "free-speech": {
+        "instructions": "Please answer the following question. You can read the question, then click on the recording button when you are ready to answer. You can keep talking until the timer is up.",
+        "prompts": [
+            "Can you explain your voice/speech problems and why you consulted a physician for them?"
+        ]
+    },
+    "voluntary-cough": {
+        "instructions": "You are being asked to record coughing sounds. Breathe normally, then when you are ready, push record and cough HARD as if something were stuck in your throat. Then breathe normally again. Complete this task 3 times in a single recording.",
+        "prompts": []
+    },
+    "open-response-questions": {
+        "instructions": "Please answer the following questions and record your answer.",
+        "prompts": [
+            "Think of a single issue, feeling, emotion or symptom you have been experiencing lately. For example, sadness, fatigue, anxiety, loneliness, sleep issues, concentration issues, agitation, motivation, numbness, guilt, shame. If you are not experiencing anything negative, think of a positive one such as calmness or gratitude. Then describe how it shows up for you mentally and physically, what you see as its causes, and what situations trigger it."
+        ]
+    },
+    "naming-animals": {
+        "instructions": "First, I want you to name as many animals you can think of. When you are ready, press record.",
+        "prompts": []
+    },
+    "naming-food": {
+        "instructions": "Next I want you to name as many food items you can think of. When you are ready, press “record.”",
+        "prompts": []
+    },
+    "abcs": {
+        "instructions": "Let's sing our ABCs together! A,B... When you are ready, press \"record\".",
+        "prompts": []
+    },
+    "choose-book": {
+        "instructions": "To start, we have a few books for you to choose from – you can choose which book you want to look at.",
+        "prompts": []
+    },
+    "months": {
+        "instructions": "That was great! How about months of the year? Can you name some for me? Start with January... When you are ready, press \"record\".",
+        "prompts": []
+    },
+    "days": {
+        "instructions": "Fantastic! I bet you know the days of the week too. Let's start with Monday... When you are ready, press \"record\".",
+        "prompts": []
+    },
+    "picture": {
+        "instructions": "If the child makes a sound effect vs naming the picture that’s ok! We’re not actually using this task as an evaluation of articulation. Pictures presented one at a time on the screen – option to swipe/click to “next” once the child has named the item or if it is an unknown for the child it may be skipped.",
+        "prompts": []
+    },
+    "passage": {
+        "instructions": "Fantastic Job! We only have one more thing to do today. Since you did so well reading the sentences earlier, let's try a few more. We're going to read a short story about a roller coaster ride called \"The Caterpillar\". A sentence or two will appear on the screen – read it aloud as if you were reading any regular story book. If you're not sure about a word, just skip it and keep going. When you are ready, press \"record\".",
+        "prompts": [
+            "Do you like amusement parks? Well, I sure do. To amuse myself, I went twice last spring. My most MEMORABLE moment was riding on the Caterpillar, which is a gigantic rollercoaster high above the ground. When I saw how high the Caterpillar rose into the bright blue sky I knew it was for me. After waiting in line for thirty minutes, I made it to the front where the man measured my height to see if I was tall enough. I gave the man my coins, asked for change, and jumped on the cart. Tick, tick, tick, the Caterpillar climbed slowly up the tracks. It went SO high I could see the parking lot. Boy was I SCARED! I thought to myself, “There’s no turning back now.” People were so scared they screamed as we swiftly zoomed fast, fast, and faster along the tracks. As quickly as it started, the Caterpillar came to a stop. Unfortunately, it was time to pack the car and drive home. That night I dreamt of the wild ride on the Caterpillar. Taking a trip to the amusement park and riding on the Caterpillar was my MOST memorable moment ever!"
+        ]
+    }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -1191,7 +1191,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -1224,37 +1224,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1642,6 +1642,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.62.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1819,6 +1827,18 @@ http = [
 ]
 
 [[package]]
+name = "ftfy"
+version = "6.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/d3/8650919bc3c7c6e90ee3fa7fd618bf373cbbe55dff043bd67353dbb20cd8/ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec", size = 308927, upload-time = "2024-10-26T00:50:35.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl", hash = "sha256:7c70eb532015cd2f9adb53f101fb6c7945988d023a085d127d1573dc49dd0083", size = 44821, upload-time = "2024-10-26T00:50:33.425Z" },
+]
+
+[[package]]
 name = "fuzy-jon"
 version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1843,6 +1863,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/22/2c7acbe6164ed6cfd4301e9ad2dbde69c68d22268a0f9b5b0ee6052ed3ab/g2p_en-2.1.0.tar.gz", hash = "sha256:32ecb119827a3b10ea8c1197276f4ea4f44070ae56cbbd01f0f261875f556a58", size = 3116166, upload-time = "2019-12-31T01:16:12.753Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/d9/b77dc634a7a0c0c97716ba97dd0a28cbfa6267c96f359c4f27ed71cbd284/g2p_en-2.1.0-py3-none-any.whl", hash = "sha256:2a7aabf1fc7f270fcc3349881407988c9245173c2413debbe5432f4a4f31319f", size = 3117464, upload-time = "2019-12-31T01:16:03.286Z" },
+]
+
+[[package]]
+name = "gliner"
+version = "0.2.28"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "sentencepiece" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/b7/0f3e24ff0b8c1c95121532a44e09b5bb87bd771c6bed0d387d51480645c5/gliner-0.2.28.tar.gz", hash = "sha256:b1637afb5cf4235fc871f1e21498831775b7bd19cefbda6dc5fe08ee88cb07a0", size = 263394, upload-time = "2026-07-24T14:03:49.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/24/cf6a9eb70bd8eb78a74f90104180c38ae0f93bc213fdd3224ea93c2fe74a/gliner-0.2.28-py3-none-any.whl", hash = "sha256:734e333ebf8a48c135aac5c05599f51051037513030127cbaf676ae71ca501c5", size = 245603, upload-time = "2026-07-24T14:03:48.337Z" },
 ]
 
 [[package]]
@@ -2161,17 +2198,17 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
 wheels = [
@@ -2191,16 +2228,16 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
 wheels = [
@@ -2843,6 +2880,15 @@ wheels = [
 ]
 
 [[package]]
+name = "langcodes"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/75/f9edc5d72945019312f359e69ded9f82392a81d49c5051ed3209b100c0d2/langcodes-3.5.1.tar.gz", hash = "sha256:40bff315e01b01d11c2ae3928dd4f5cbd74dd38f9bd912c12b9a3606c143f731", size = 191084, upload-time = "2025-12-02T16:22:01.627Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/c1/d10b371bcba7abce05e2b33910e39c33cfa496a53f13640b7b8e10bb4d2b/langcodes-3.5.1-py3-none-any.whl", hash = "sha256:b6a9c25c603804e2d169165091d0cdb23934610524a21d226e4f463e8e958a72", size = 183050, upload-time = "2025-12-02T16:21:59.954Z" },
+]
+
+[[package]]
 name = "lark"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3044,6 +3090,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
     { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
     { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
+]
+
+[[package]]
+name = "locate"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/b0/6b303d4a2a20046dc396de914a6c1840253ff874630f00864ffe623acb68/locate-1.1.1.tar.gz", hash = "sha256:432750f5b7e89f8c99942ca7d8722ccd1e7954b20e6a973027fccb6cc00af857", size = 7831, upload-time = "2022-12-15T07:01:30.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/0d/9b6f11382b2f9080b5a366d20e90b4c08e547b6cd08c2a206729e6bad47a/locate-1.1.1-py3-none-any.whl", hash = "sha256:9e5e2f3516639240f4d975c08e95ae6a24ff4dd63d228f927541cdec30105755", size = 5364, upload-time = "2022-12-15T07:01:29.526Z" },
 ]
 
 [[package]]
@@ -3958,7 +4013,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -3970,7 +4025,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -4000,9 +4055,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -4014,7 +4069,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -4086,6 +4141,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/5a/652dac4b7affc2b37b95386f8ae78f22808af09d720689e3d7a86b6ed98e/ollama-0.6.1.tar.gz", hash = "sha256:478c67546836430034b415ed64fa890fd3d1ff91781a9d548b3325274e69d7c6", size = 51620, upload-time = "2025-11-13T23:02:17.416Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/4f/4a617ee93d8208d2bcf26b2d8b9402ceaed03e3853c754940e2290fed063/ollama-0.6.1-py3-none-any.whl", hash = "sha256:fc4c984b345735c5486faeee67d8a265214a31cbb828167782dc642ce0a2bf8c", size = 14354, upload-time = "2025-11-13T23:02:16.292Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/4d/5014667e2a3a77d6e1b74cc3d88948d06163b8e0a33a84c85073322b5dec/onnxruntime-1.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:f5c5daabd28aad610f83fdcf32acec8fb57e6adc6c6a39fe2a3c755db957b410", size = 19130506, upload-time = "2026-07-25T01:22:34.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/97/b7ce1bc8bb6048b5fe9129f55d6506dc19499068ef2e0a0af1ae3c8aa4e7/onnxruntime-1.28.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8d66f9ceb29909c70839e4e4fb3435c7b490050d8f162bd5f3aba4ca01ee517f", size = 17039880, upload-time = "2026-07-25T01:21:37.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/17/4e5ecd8764f87573c495d834ce79e61ecca47f7a01d1e444a606e570edcb/onnxruntime-1.28.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a166b78ee04f3a37fa1ef82034b6a3ce96d9684e582d4d30b296de83e9998bb5", size = 19193162, upload-time = "2026-07-25T01:21:59.151Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/10/3d946d5d5f2cdcc3c8da36cae63190c516d16349edaffd944bda60ca4c3e/onnxruntime-1.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:0d650aeee29368414367b65529e90afe4bf1bab76254789063b8b2f7ea3013c8", size = 13752539, upload-time = "2026-07-25T01:22:24.524Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/74/1c440be7af1e026280b139caa1be5d11bd4dc368011ddbe8f5362b58e12f/onnxruntime-1.28.0-cp311-cp311-win_arm64.whl", hash = "sha256:0faf85fb447a663c9cdadc39bd6b19bdf7bedded6699e45731b9b36c46fd993d", size = 13449940, upload-time = "2026-07-25T01:22:14.97Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f8/dcbe7700dca82fa540035abd3c868fe5ad0f86af00b9a3db7c2e27d15c7d/onnxruntime-1.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:26ff0fdd06efb6c155bae95387a09db1a2be89c7a03e4d0bffd5a171cc2826da", size = 19141362, upload-time = "2026-07-25T01:22:36.965Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5b/1d77e62097fdbe07e2dc827f389b1c4c0c275f6fab0369a8f46d2461af27/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e81a23df16e7acb9d51b06d30cc098e49315ef9180f97bc2221d167b4b04d9c", size = 17050628, upload-time = "2026-07-25T01:21:40.481Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/5486ab03e9be288d5268867054c8b04bebcf95bfd12e801c05cc67703dab/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a83bdb70d143cede762b677789bf2a7acca54b3fb82565601d5c30695aa933c", size = 19214257, upload-time = "2026-07-25T01:22:01.695Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3b/986ca67c274932ba9ac5332fb10de56f643dfd433c74e33f8ae8f847cf24/onnxruntime-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:c35064f9b3c43c81c5d5d282091401d0f1ff22796d93ccade4ea2ece5e137ab8", size = 13755036, upload-time = "2026-07-25T01:22:26.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/46/059dba81d46c6ba88e0c2d1c64321ac8098847d678423300a183d42ecbd6/onnxruntime-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:e02feeb0165c5f13b4cc954738078d59b90128516ac12b671ee24a530242bf02", size = 13454462, upload-time = "2026-07-25T01:22:17.38Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/3807e2b17d9eb71d3cb78ed2ba76869b05c637c9b9d6112e636098b0c97a/onnxruntime-1.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:31410f544674f534c2f27348af52ef81682ca9c8719154bf4d48f0ef23823b1e", size = 19141759, upload-time = "2026-07-25T01:21:53.765Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/23/b46045c3bf67a9cf54c12f5df0f018a422c65fbb9d6072b10071bebfaae2/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f649dd6f6452d12a8059888aa489fe519e062e18793dac72b9efa0f9fdb64135", size = 17049339, upload-time = "2026-07-25T01:21:43.005Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b6/8c5396e7894e77c5a7d1e026f3acb9dd39c4b5644e412e37a0055eaa3bc5/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54fa221d669282bd8f582708ce4c96010a7e9fb0661f9006b37fe2fedafb73fe", size = 19214329, upload-time = "2026-07-25T01:22:04.133Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f1/51225c202edba4dfc94e1ea03f3d78f1aaf307da75fd792c0ce1946b2514/onnxruntime-1.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:1a1a19175464665c9b8d50bc916f216cc0b569110045b7bbca8f9f290b186f58", size = 13755033, upload-time = "2026-07-25T01:22:29.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/db/f59f715edfdd96a051f32b5ef0e680a20a8755d4ecd75f63090e960e347a/onnxruntime-1.28.0-cp313-cp313-win_arm64.whl", hash = "sha256:cfab507abe09d6ffeb817eee07944d452fdc0b00fdcef34cab4db10a45e378c7", size = 13454175, upload-time = "2026-07-25T01:22:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/47/28/810314fa88647af9f4cdaf438a30ad1cfebebb53ded55499232d7a0094e6/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac301f53b1930402fc46c368e268acfed02f3207272aaff05070d7e09f96f031", size = 17057307, upload-time = "2026-07-25T01:21:45.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cc/9e9f193cc0f29f263a8f09ec08487aed6c96ee856d5fd77da32a425c1949/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7f022a1103cae591c75fc4565589a515f2ddd14a6ac8e8a05812dfeda142e28", size = 19222954, upload-time = "2026-07-25T01:22:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/eb/952314c451d9463e5c9aed9978eec76cf32930d407d9ab8700dd0f4ea1ea/onnxruntime-1.28.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:8adff67a3f28257b37cfe945a7e952e4122666aa8c91a0380862e9fd4c2ed19f", size = 19143748, upload-time = "2026-07-25T01:21:56.297Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/139180b4dd810329aaa42c238b4e6383c906202d98609ae29d66eb7c32b1/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc2565e487b4896fb988d6383577d875d958e071fc5f6c3550bd5d02ae98264b", size = 17051950, upload-time = "2026-07-25T01:21:48.606Z" },
+    { url = "https://files.pythonhosted.org/packages/03/88/9432428273356ad3c8aa01f52c1b3e7f53c4c0192748f41ad983872b436b/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6afdc83f1317c136e92fc29f5ee9f058de59d87c0b22cee3fdbfbaa0ccc2098a", size = 19214924, upload-time = "2026-07-25T01:22:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/e2/6feb3a43517aaf2b1bf7e46897ba5eb81a29717f7d7901420614d5ee4653/onnxruntime-1.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:f2a3b9e30ce880d4ca54999cb313569e36da4f62eefe25f87be18f43e9a3a4d5", size = 14093738, upload-time = "2026-07-25T01:22:31.629Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8f/83974a1e201dc2e58e5e7111bcaeb1ca2413e9c41f505d26419ee9e3dddf/onnxruntime-1.28.0-cp314-cp314-win_arm64.whl", hash = "sha256:07fb3cbe990d6bf0ab3c22bfbbfb0e314151266046ea6edb4a07f556b4258c5f", size = 13821117, upload-time = "2026-07-25T01:22:22.387Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/83/00e606bc25c756d76a267370c39b7516ad52f9cf134d7ff2bff8b6108bc4/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e562d6e36a749f6764481c0ddb0f2af3d0b5a3c164291361d08803c557f369af", size = 17055518, upload-time = "2026-07-25T01:21:51.08Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a9/68707e1ce345cbdbcd4df65932ebc82a673e917d63eda0007ebcff948691/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f6e92367ddce1e4d33cf295024f40192be6c6171a09208f515ba169ced06c8e", size = 19222976, upload-time = "2026-07-25T01:22:12.474Z" },
 ]
 
 [[package]]
@@ -4491,7 +4583,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -6373,8 +6465,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -6426,8 +6518,10 @@ nlp = [
     { name = "uroman" },
 ]
 pii = [
+    { name = "gliner" },
     { name = "presidio-analyzer" },
     { name = "spacy" },
+    { name = "wordfreq" },
 ]
 senselab-ai = [
     { name = "ipykernel" },
@@ -6481,6 +6575,7 @@ requires-dist = [
     { name = "av", marker = "extra == 'video'", specifier = ">=15" },
     { name = "datasets", specifier = ">=3.6" },
     { name = "g2p-en", marker = "extra == 'nlp'", specifier = ">=2.1" },
+    { name = "gliner", marker = "extra == 'pii'", specifier = ">=0.2.28" },
     { name = "huggingface-hub", specifier = ">=1.3" },
     { name = "ipykernel", marker = "extra == 'senselab-ai'", specifier = "~=7.1" },
     { name = "ipywidgets", marker = "extra == 'senselab-ai'", specifier = "~=8.1" },
@@ -6515,6 +6610,7 @@ requires-dist = [
     { name = "umap-learn", specifier = ">=0.5.4" },
     { name = "uroman", marker = "extra == 'nlp'", specifier = ">=1.3" },
     { name = "vocos", specifier = ">=0.1" },
+    { name = "wordfreq", marker = "extra == 'pii'", specifier = ">=3.1.1" },
 ]
 provides-extras = ["nlp", "pii", "senselab-ai", "text", "video"]
 
@@ -6959,8 +7055,8 @@ name = "standard-aifc"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
-    { name = "standard-chunk", marker = "python_full_version >= '3.13'" },
+    { name = "audioop-lts" },
+    { name = "standard-chunk" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/53/6050dc3dde1671eb3db592c13b55a8005e5040131f7509cef0215212cb84/standard_aifc-3.13.0.tar.gz", hash = "sha256:64e249c7cb4b3daf2fdba4e95721f811bde8bdfc43ad9f936589b7bb2fae2e43", size = 15240, upload-time = "2024-10-30T16:01:31.772Z" }
 wheels = [
@@ -6981,7 +7077,7 @@ name = "standard-sunau"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "audioop-lts" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/e3/ce8d38cb2d70e05ffeddc28bb09bad77cfef979eb0a299c9117f7ed4e6a9/standard_sunau-3.13.0.tar.gz", hash = "sha256:b319a1ac95a09a2378a8442f403c66f4fd4b36616d6df6ae82b8e536ee790908", size = 9368, upload-time = "2024-10-30T16:01:41.626Z" }
 wheels = [
@@ -7986,6 +8082,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
+]
+
+[[package]]
+name = "wordfreq"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ftfy" },
+    { name = "langcodes" },
+    { name = "locate" },
+    { name = "msgpack" },
+    { name = "regex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/cd/9581ff0ea2c581012d0caae4bba024f3ff6b46e030a55ddec1ce545e2caf/wordfreq-3.1.1.tar.gz", hash = "sha256:7943098975f25c2a70e1151ee5a62083b14a5f86f6cc5703cc9526f716ceb408", size = 56846562, upload-time = "2023-11-21T23:09:12.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/61/62835c475d69872d30689f284497853fe33fe1d6dd18f57346d13305861d/wordfreq-3.1.1-py3-none-any.whl", hash = "sha256:4b1c6ecffc6198be3396d5cf871c4423ca71c907c231348d352dd54d62b97473", size = 56834549, upload-time = "2023-11-21T23:09:07.183Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds `scripts/pii_compliance_pipeline.py` — a fully-offline triage screen for folders of `.pt` feature files carrying ASR transcripts. For each recording it answers two questions:

1. **Does this contain PII?** — names, ages over 90, dates, locations, contact details, ID numbers, and subtler quasi-identifiers that can single a participant out.
2. **Did the participant actually do the task?** — did they read the passage, sustain the vowel, answer the question, or is the recording empty / off-script?

Each file comes back **`pass`** or **`review`**, and the run ends with the list of flagged filenames. **Nothing is ever auto-deleted, auto-redacted, or auto-rejected** — it builds a triage queue and a person makes the final call.

Three files:

| File | What it is |
|---|---|
| `scripts/pii_compliance_pipeline.py` | The pipeline. Self-contained. |
| `scripts/task_reference.json` | 797 task definitions (Bridge2AI acoustic tasks) driving Tier A/B/C routing. |
| `scripts/pii_compliance_pipeline.md` | Full documentation — engines, tiers, modes, blind spots, data safety. |

## Motivation and Context

Implements the two text-level checks — **(3) PII Detection** and **(4) Task Compliance** — from the poster *"An AI Pipeline for Ensuring Audio Data Quality"* (Ng, Wilke, Johnson, Ghosh), operationalising the companion proposal *"Unified Framework for PII Detection and Task Compliance Verification in Clinical Voice Recordings."*

**PII** runs four engines in parallel and cross-validates them — a rule cascade (regex, gazetteers, spaCy NER, self-disclosed demographics, rare roles, age > 90, plus a combinatorial re-identification window), GLiNER, Presidio, and an optional local LLM. Agreement boosts confidence; disagreement surfaces the span rather than resolving it silently.

**Task compliance** identifies the task from the BIDS `task-<Name>` field of each filename, looks it up in `task_reference.json`, and routes by modality: Tier A word-error-rate against the reference prompt for scripted reads, Tier B skipped for acoustic tasks (not assessable from text — a near-empty transcript there is *expected*), Tier C LLM judge for open tasks, with an always-on transcript-quality floor underneath.

**Privacy.** Transcript text never leaves the machine — engines run in-process, and the optional LLM talks only to `localhost`. The only network traffic is a one-time download of model weights and gazetteers.

### Notes for reviewers

- **Self-contained by design.** The script imports nothing from `senselab`, and `senselab` does not import it. It needs only its companion `task_reference.json`, resolved relative to the script's own folder so the pair runs from any working directory. Every detection engine is optional and degrades with a printed notice.
- **Dependencies go in the `pii` extra, not core.** `gliner` and `wordfreq` sit alongside `presidio-analyzer` and `spacy`; `nltk` is already in `nlp`. Adding them to core dependencies would have put three heavy packages (and a duplicate `nltk`) into every senselab install for one `scripts/` tool.
- **`task_reference.json` is large (4,725 lines)** but it is *data*, not code — 797 task definitions, mostly the 720 Harvard/IEEE sentences. Tier A cannot work without it: a missing reference means every scripted read silently loses its word-error-rate check and passes as clean, so the script **stops** rather than continuing without it.
- **Configuration is one block at the top of the file** (`MODES` / `SETTINGS` / `NOTES`) — no environment variables, no config file — so it runs from an IDE with no arguments. CLI flags override for one-off terminal use.
- ⚠️ **spaCy has no wheels for CPython 3.14**, so on a 3.14 environment `--extra pii` cannot install spaCy or Presidio and the pipeline runs with two of four PII engines absent (it says so at startup). Pre-existing — `spacy>=3.7` was already in the extra — but worth knowing, and it is called out in the docs. Use 3.12/3.13 for the full engine set.

## How Has This Been Tested?

`python scripts/pii_compliance_pipeline.py --selftest` runs **127 checks** on synthetic data in a temp directory, touching no real files and never calling the LLM. Coverage:

- **Precision guards** — format-validation of structured identifiers, holiday reclassification, GLiNER windowing offsets, the common-word-NAME false-positive lever.
- **Tier A calibration** — WER banding, the absolute-error-floor and reference-coverage guards, and that neither guard can ever hide a genuine off-script read.
- **Task → reference resolution** — exact-match precedence and sibling-variant safety (`diadochokinesis-PA` must not pull in `-Pataka`).
- **Composite scoring** — the pass/review/fail bands, the fail→review collapse, and the no-assessable-check case.
- **The companion reference** — that it loads, has a uniform shape, and that a missing or unparseable file stops the run rather than silently disabling scripted checks.
- **End to end** — `.pt` folder → task identified from filename → flagged filenames out, including that reading the *wrong* script is caught (only the task reference reveals it) and that a near-empty acoustic transcript is *not* a compliance failure.

Also run against real `.pt` data and against human-reviewed ground-truth labels during development.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have added tests to cover my changes. *(built-in `--selftest`, 127 checks; not wired into pytest — see below)*
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project. *(`scripts/` is excluded from ruff and mypy in this repo)*

### Open questions

1. **Should `--selftest` be wired into the pytest suite?** It is self-contained and hermetic, so a thin `src/tests/` wrapper invoking it as a subprocess would be easy. Left out for now since `scripts/` is otherwise untested here.
2. **Is `scripts/` the right home**, or would this be better as a `senselab` module with a CLI entry point? It is currently a standalone research/ops tool, which is why it lives beside `analyze_audio.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
