### PR TITLE
fix(audio_analysis): rows must not alias the harvest's vote dicts

### DIFF
--- a/src/senselab/audio/workflows/audio_analysis/votes.py
+++ b/src/senselab/audio/workflows/audio_analysis/votes.py
@@ -148,6 +148,60 @@ def _coupling_weights(params: dict[str, Any]) -> dict[str, float]:
     return weights
 
 
+_HARVEST_VOTE_FIELDS = {
+    "presence": "presence_votes",
+    "identity": "identity_votes",
+    "utterance": "utterance_votes",
+}
+
+
+def merge_votes_into_harvest(
+    harvest: PassHarvest,
+    axis: str,
+    votes_by_bucket: dict[tuple[float, float], dict[str, dict[str, Any]]],
+    *,
+    tol: float = 1e-6,
+) -> int:
+    """Add voters to a harvest's buckets in place; return the bucket count updated.
+
+    The **only** supported way to introduce a new voter after harvest. The harvest —
+    not the ``AxisResult`` rows — is what the adaptive loop is handed
+    (``run_adaptive_loop(harvests=...)``) and what its belief store reads, so a voter
+    written only onto the rows is invisible to every adaptive round. Rows are
+    snapshots taken by :func:`aggregate_pass`; re-call it after merging to re-derive
+    them from the updated harvest.
+
+    Args:
+        harvest: The pass harvest to update in place.
+        axis: ``"presence"``, ``"identity"``, or ``"utterance"``.
+        votes_by_bucket: ``(start, end)`` → ``{source: payload}`` to merge. Buckets
+            are matched on their bounds within ``tol``; a bucket the harvest does not
+            have is skipped (and excluded from the return count) rather than added,
+            since a vote off the harvest grid has no row to attach to.
+        tol: Bucket-bound match tolerance in seconds.
+
+    Returns:
+        The number of harvest buckets that received at least one voter.
+
+    Raises:
+        ValueError: If ``axis`` is not one of the three axis names.
+    """
+    field = _HARVEST_VOTE_FIELDS.get(axis)
+    if field is None:
+        raise ValueError(f"unknown axis {axis!r}; must be one of {sorted(_HARVEST_VOTE_FIELDS)}")
+    buckets: list[dict[str, Any]] = getattr(harvest, field)
+    updated = 0
+    for (start, end), new_votes in votes_by_bucket.items():
+        if not new_votes:
+            continue
+        for bucket in buckets:
+            if abs(float(bucket["start"]) - start) <= tol and abs(float(bucket["end"]) - end) <= tol:
+                bucket["votes"].update(new_votes)
+                updated += 1
+                break
+    return updated
+
+
 def aggregate_pass(harvest: PassHarvest, *, aggregator: str, params: dict[str, Any]) -> dict[str, AxisResult]:
     """Fold one pass's harvested votes into the three per-axis ``AxisResult``s.
 
@@ -176,7 +230,7 @@ def aggregate_pass(harvest: PassHarvest, *, aggregator: str, params: dict[str, A
         bkey = (round(bucket["start"], 6), round(bucket["end"], 6))
         quality = harvest.quality_by_bucket.get(bkey)
         source = harvest.source_by_bucket.get(bkey)
-        votes = bucket["votes"]
+        votes = dict(bucket["votes"])  # snapshot: rows must not alias the harvest
         if quality is not None:
             votes = {**votes, "__quality__": quality.get("_raw", {})}
         if source is not None:
@@ -253,7 +307,7 @@ def aggregate_pass(harvest: PassHarvest, *, aggregator: str, params: dict[str, A
                 axis="identity",
                 aggregated_uncertainty=u_raw,
                 contributing_models=sorted(bucket["votes"].keys()),
-                model_votes=bucket["votes"],
+                model_votes=dict(bucket["votes"]),  # snapshot, not the harvest dict
                 comparison_status="ok" if u_raw is not None else "incomparable",
                 raw_aggregated_uncertainty=u_raw,
                 intensity_weight=mask,
@@ -290,7 +344,7 @@ def aggregate_pass(harvest: PassHarvest, *, aggregator: str, params: dict[str, A
         # Reported value carries the coupling (FR-019); the pre-coupling number stays
         # visible on raw_aggregated_uncertainty and in model_votes so the adjustment is
         # auditable rather than invisible.
-        votes = bucket["votes"]
+        votes = dict(bucket["votes"])  # snapshot: rows must not alias the harvest
         u_reported = u_raw
         if u_raw is not None:
             u_reported = max(0.0, min(1.0, u_raw * coupling))

--- a/src/senselab/audio/workflows/audio_analysis/votes.py
+++ b/src/senselab/audio/workflows/audio_analysis/votes.py
@@ -14,6 +14,7 @@ No imports beyond stdlib + the sibling pure modules (``aggregate``, ``types``).
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -164,42 +165,80 @@ def merge_votes_into_harvest(
 ) -> int:
     """Add voters to a harvest's buckets in place; return the bucket count updated.
 
-    The **only** supported way to introduce a new voter after harvest. The harvest —
-    not the ``AxisResult`` rows — is what the adaptive loop is handed
-    (``run_adaptive_loop(harvests=...)``) and what its belief store reads, so a voter
-    written only onto the rows is invisible to every adaptive round. Rows are
-    snapshots taken by :func:`aggregate_pass`; re-call it after merging to re-derive
-    them from the updated harvest.
+    The supported way to introduce a new voter into a harvest, for a caller that then
+    re-derives rows with :func:`aggregate_pass` — one code path owns the fold, so rows
+    cannot drift from the harvest they came from.
+
+    **Timing matters.** The adaptive loop seeds its belief store from the harvests *once*
+    (``VoteStore.from_harvests``) and every later voter is added through
+    ``VoteStore.add_vote``. So merging here is only visible to the loop **before the store
+    is seeded** — i.e. before ``run_adaptive_loop`` is called. Merging into a harvest after
+    that point updates the harvest and the rows but not the store, and no adaptive round
+    will see it; use ``VoteStore.add_vote`` for that case.
 
     Args:
         harvest: The pass harvest to update in place.
         axis: ``"presence"``, ``"identity"``, or ``"utterance"``.
-        votes_by_bucket: ``(start, end)`` → ``{source: payload}`` to merge. Buckets
-            are matched on their bounds within ``tol``; a bucket the harvest does not
-            have is skipped (and excluded from the return count) rather than added,
-            since a vote off the harvest grid has no row to attach to.
+        votes_by_bucket: ``(start, end)`` → ``{source: payload}`` to merge. Buckets are
+            matched on their bounds within ``tol``; one the harvest does not have is
+            skipped with a warning rather than added, since a vote off the harvest grid
+            has no row to attach to. Payload dicts are stored by reference, not copied.
         tol: Bucket-bound match tolerance in seconds.
 
     Returns:
-        The number of harvest buckets that received at least one voter.
+        The number of *distinct harvest buckets* that received at least one voter. Two
+        keys within ``tol`` of the same bucket therefore count once (the later one's
+        overlapping sources win, as with any ``dict.update``).
+
+    Warns:
+        UserWarning: If any key matched no harvest bucket. A merge that silently no-ops
+            is indistinguishable from one that worked, and the return count is easy to
+            ignore, so the mismatch is surfaced rather than left to the caller to notice.
 
     Raises:
         ValueError: If ``axis`` is not one of the three axis names.
     """
-    field = _HARVEST_VOTE_FIELDS.get(axis)
-    if field is None:
+    attr = _HARVEST_VOTE_FIELDS.get(axis)
+    if attr is None:
         raise ValueError(f"unknown axis {axis!r}; must be one of {sorted(_HARVEST_VOTE_FIELDS)}")
-    buckets: list[dict[str, Any]] = getattr(harvest, field)
-    updated = 0
+    buckets: list[dict[str, Any]] = getattr(harvest, attr)
+
+    # Exact-bounds index first: harvest bounds are canonicalized with round(x, 6) elsewhere
+    # (``aggregate_pass``, ``belief.bucket_key``), so the common case is a hit and the scan
+    # is only needed for bounds that differ within ``tol`` but round apart. Without this the
+    # merge is O(keys x buckets), which on a long file at a 0.5 s grid is millions of
+    # comparisons in a module whose contract is "milliseconds, not GPU time".
+    index: dict[tuple[float, float], dict[str, Any]] = {}
+    for bucket in buckets:
+        index.setdefault((round(float(bucket["start"]), 6), round(float(bucket["end"]), 6)), bucket)
+
+    touched: set[int] = set()
+    unmatched: list[tuple[float, float]] = []
     for (start, end), new_votes in votes_by_bucket.items():
         if not new_votes:
             continue
-        for bucket in buckets:
-            if abs(float(bucket["start"]) - start) <= tol and abs(float(bucket["end"]) - end) <= tol:
-                bucket["votes"].update(new_votes)
-                updated += 1
-                break
-    return updated
+        target = index.get((round(start, 6), round(end, 6)))
+        if target is None:
+            target = next(
+                (b for b in buckets if abs(float(b["start"]) - start) <= tol and abs(float(b["end"]) - end) <= tol),
+                None,
+            )
+        if target is None:
+            unmatched.append((start, end))
+            continue
+        target["votes"].update(new_votes)
+        touched.add(id(target))
+
+    if unmatched:
+        warnings.warn(
+            f"merge_votes_into_harvest: {len(unmatched)} of {len(votes_by_bucket)} bucket(s) "
+            f"matched no {axis} bucket in the harvest and were dropped "
+            f"(first: {unmatched[0]}). The votes are off the harvest grid, so they have no "
+            f"row to attach to — check that they were computed on the same grid.",
+            UserWarning,
+            stacklevel=2,
+        )
+    return len(touched)
 
 
 def aggregate_pass(harvest: PassHarvest, *, aggregator: str, params: dict[str, Any]) -> dict[str, AxisResult]:
@@ -230,7 +269,7 @@ def aggregate_pass(harvest: PassHarvest, *, aggregator: str, params: dict[str, A
         bkey = (round(bucket["start"], 6), round(bucket["end"], 6))
         quality = harvest.quality_by_bucket.get(bkey)
         source = harvest.source_by_bucket.get(bkey)
-        votes = dict(bucket["votes"])  # snapshot: rows must not alias the harvest
+        votes = dict(bucket["votes"])  # own the mapping; payloads stay shared (see aggregate_pass)
         if quality is not None:
             votes = {**votes, "__quality__": quality.get("_raw", {})}
         if source is not None:
@@ -307,7 +346,7 @@ def aggregate_pass(harvest: PassHarvest, *, aggregator: str, params: dict[str, A
                 axis="identity",
                 aggregated_uncertainty=u_raw,
                 contributing_models=sorted(bucket["votes"].keys()),
-                model_votes=dict(bucket["votes"]),  # snapshot, not the harvest dict
+                model_votes=dict(bucket["votes"]),  # own the mapping; payloads stay shared
                 comparison_status="ok" if u_raw is not None else "incomparable",
                 raw_aggregated_uncertainty=u_raw,
                 intensity_weight=mask,
@@ -344,7 +383,7 @@ def aggregate_pass(harvest: PassHarvest, *, aggregator: str, params: dict[str, A
         # Reported value carries the coupling (FR-019); the pre-coupling number stays
         # visible on raw_aggregated_uncertainty and in model_votes so the adjustment is
         # auditable rather than invisible.
-        votes = dict(bucket["votes"])  # snapshot: rows must not alias the harvest
+        votes = dict(bucket["votes"])  # own the mapping; payloads stay shared (see aggregate_pass)
         u_reported = u_raw
         if u_raw is not None:
             u_reported = max(0.0, min(1.0, u_raw * coupling))

--- a/src/tests/audio/workflows/audio_analysis/votes_test.py
+++ b/src/tests/audio/workflows/audio_analysis/votes_test.py
@@ -111,6 +111,35 @@ def test_rows_do_not_alias_the_harvest_vote_dicts() -> None:
         assert "injected/marker" not in votes[0]["votes"], f"{axis} row aliases the harvest vote dict"
 
 
+def test_rows_do_not_alias_the_harvest_without_scene_columns() -> None:
+    """The no-scene path is the one that actually aliased — cover it explicitly.
+
+    ``_harvest()`` gives its presence bucket quality/source columns and its utterance bucket
+    a non-1.0 coupling, so BOTH already rebuilt the vote dict via ``{**votes, ...}`` before
+    this fix; those arms of the test above pass even with the presence/utterance snapshots
+    reverted (verified). The aliasing only bit when there were no scene columns and coupling
+    was exactly 1.0 — i.e. a run with scene features skipped, the documented SC-008 path.
+    """
+    harvest = PassHarvest(
+        pass_label="raw_16k",
+        presence_votes=[{"start": 0.0, "end": 0.5, "votes": {"m1": {"speaks": True}}}],
+        identity_votes=[{"start": 0.0, "end": 1.0, "votes": {"__cross_diar_label_disagreement__": {"value": 0.4}}}],
+        utterance_votes=[{"start": 0.0, "end": 1.0, "votes": {"a": {"text": "hi", "avg_logprob": None}}}],
+        # no quality_by_bucket / source_by_bucket at all
+        grids={"presence": {"win_length": 0.5, "hop_length": 0.5}},
+    )
+    # w_q/w_s = 0 pins the utterance coupling to exactly 1.0, so no copy is made for it either.
+    results = aggregate_pass(harvest, aggregator="min", params={"utterance_scene_coupling": {"w_q": 0.0, "w_s": 0.0}})
+    for axis, votes in (
+        ("presence", harvest.presence_votes),
+        ("identity", harvest.identity_votes),
+        ("utterance", harvest.utterance_votes),
+    ):
+        assert "__quality__" not in results[axis].rows[0].model_votes  # confirms the no-scene path
+        results[axis].rows[0].model_votes["injected/marker"] = {"value": 1.0}
+        assert "injected/marker" not in votes[0]["votes"], f"{axis} row aliases the harvest vote dict"
+
+
 def test_merge_votes_into_harvest_is_visible_to_reaggregation() -> None:
     """An injected voter lands in the harvest and changes the re-derived rows.
 
@@ -140,9 +169,39 @@ def test_merge_votes_into_harvest_is_visible_to_reaggregation() -> None:
 def test_merge_votes_into_harvest_ignores_unknown_buckets() -> None:
     """A bucket the harvest doesn't have is reported as unmerged, not silently dropped."""
     harvest = _harvest()
-    n = merge_votes_into_harvest(harvest, "identity", {(99.0, 100.0): {"x": {"value": 1.0}}})
+    with pytest.warns(UserWarning):
+        n = merge_votes_into_harvest(harvest, "identity", {(99.0, 100.0): {"x": {"value": 1.0}}})
     assert n == 0
     assert all("x" not in b["votes"] for b in harvest.identity_votes)
+
+
+def test_merge_votes_into_harvest_warns_when_a_bucket_matches_nothing() -> None:
+    """A merge that silently no-ops looks identical to one that worked, so it warns.
+
+    The return count is easy to ignore; votes computed on a different grid than the harvest
+    would otherwise vanish with no signal at all.
+    """
+    harvest = _harvest()
+    with pytest.warns(UserWarning, match="matched no identity bucket"):
+        n = merge_votes_into_harvest(harvest, "identity", {(99.0, 100.0): {"x": {"value": 1.0}}})
+    assert n == 0
+
+
+def test_merge_votes_into_harvest_counts_distinct_buckets_not_keys() -> None:
+    """Two keys inside ``tol`` of one bucket count once — the documented return is buckets."""
+    harvest = _harvest()
+    start, end = harvest.identity_votes[0]["start"], harvest.identity_votes[0]["end"]
+    n = merge_votes_into_harvest(
+        harvest,
+        "identity",
+        {
+            (start, end): {"src/a": {"same_label_uncertainty": 0.1}},
+            (start + 5e-7, end): {"src/b": {"same_label_uncertainty": 0.2}},  # within tol of the same bucket
+        },
+    )
+    assert n == 1, "two keys resolving to one bucket must not be counted twice"
+    votes = harvest.identity_votes[0]["votes"]
+    assert "src/a" in votes and "src/b" in votes  # both still merged
 
 
 def test_merge_votes_into_harvest_rejects_unknown_axis() -> None:

--- a/src/tests/audio/workflows/audio_analysis/votes_test.py
+++ b/src/tests/audio/workflows/audio_analysis/votes_test.py
@@ -11,6 +11,7 @@ from senselab.audio.workflows.audio_analysis.votes import (
     compute_pass_deltas,
     intensity_mask,
     mask_from_pvoice,
+    merge_votes_into_harvest,
 )
 
 
@@ -86,6 +87,68 @@ def test_aggregate_pass_matches_pure_aggregators_and_columns() -> None:
     assert utt.aggregated_uncertainty == pytest.approx(utt_raw * expected_coupling)
     assert results["presence"].provenance["scene_quality"] == {"enabled": True}
     assert results["utterance"].provenance["grid"] == {"win_length": 1.0, "hop_length": 1.0}
+
+
+# ── vote-dict ownership (rows must not alias the harvest) ─────────────
+#     ``aggregate_pass`` is documented as *pure*, but it used to hand the harvest's
+#     own vote dict to each row. Callers that mutated ``row.model_votes`` therefore
+#     silently rewrote the harvest the adaptive loop is later handed. Rows are
+#     snapshots; adding a voter to the harvest is an explicit operation
+#     (``merge_votes_into_harvest``).
+
+
+def test_rows_do_not_alias_the_harvest_vote_dicts() -> None:
+    """Mutating a row's model_votes must not reach back into the harvest."""
+    harvest = _harvest()
+    results = aggregate_pass(harvest, aggregator="min", params={})
+    for axis, votes in (
+        ("presence", harvest.presence_votes),
+        ("identity", harvest.identity_votes),
+        ("utterance", harvest.utterance_votes),
+    ):
+        row = results[axis].rows[0]
+        row.model_votes["injected/marker"] = {"value": 1.0}
+        assert "injected/marker" not in votes[0]["votes"], f"{axis} row aliases the harvest vote dict"
+
+
+def test_merge_votes_into_harvest_is_visible_to_reaggregation() -> None:
+    """An injected voter lands in the harvest and changes the re-derived rows.
+
+    This is the property the adaptive loop depends on: it is handed the
+    ``PassHarvest``, not the rows, so a voter that only reached the rows would be
+    invisible to every round.
+    """
+    harvest = _harvest()
+    before = aggregate_pass(harvest, aggregator="min", params={})["identity"].rows[0]
+    assert before.aggregated_uncertainty == pytest.approx(0.8)
+
+    bucket = (harvest.identity_votes[0]["start"], harvest.identity_votes[0]["end"])
+    n = merge_votes_into_harvest(
+        harvest,
+        "identity",
+        {bucket: {"newdiar/newemb": {"same_label_uncertainty": 1.0}}},
+    )
+    assert n == 1
+    assert "newdiar/newemb" in harvest.identity_votes[0]["votes"]
+
+    after = aggregate_pass(harvest, aggregator="min", params={})["identity"].rows[0]
+    # "min" keeps the worst sub-signal, so a fully-doubtful new voter dominates 0.8.
+    assert after.aggregated_uncertainty == pytest.approx(1.0)
+    assert "newdiar/newemb" in after.contributing_models
+
+
+def test_merge_votes_into_harvest_ignores_unknown_buckets() -> None:
+    """A bucket the harvest doesn't have is reported as unmerged, not silently dropped."""
+    harvest = _harvest()
+    n = merge_votes_into_harvest(harvest, "identity", {(99.0, 100.0): {"x": {"value": 1.0}}})
+    assert n == 0
+    assert all("x" not in b["votes"] for b in harvest.identity_votes)
+
+
+def test_merge_votes_into_harvest_rejects_unknown_axis() -> None:
+    """A typo'd axis name must fail loudly rather than merge nothing."""
+    with pytest.raises(ValueError, match="unknown axis"):
+        merge_votes_into_harvest(_harvest(), "identiy", {})  # codespell:ignore
 
 
 def test_intensity_mask_ramp_and_overlap_average() -> None:


### PR DESCRIPTION
## The bug

`aggregate_pass` is documented as **pure** — "same harvest + same aggregator ⇒ identical rows (bit-for-bit)". But it handed each `UncertaintyRow` the harvest's *own* vote dict rather than a copy:

```python
model_votes=bucket["votes"],   # the harvest's dict, not a snapshot
```

So a caller doing `row.model_votes[...] = ...` silently rewrote the `PassHarvest` too.

That matters because the two are consumed by different halves of the pipeline. `analyze_audio` passes the **harvests** to the adaptive loop (`run_adaptive_loop(harvests=...)`), and the belief store builds from `model_votes` there. The rows go to parquet. So:

- a post-harvest voter written onto the **rows** reaches the adaptive loop **only** through this aliasing
- and "fixing" `aggregate_pass` to actually be pure — the obvious cleanup, given its docstring — would silently disconnect that voter from every adaptive round, with no error and no test failure

Either way round it's a trap: the current behavior contradicts the documented contract, and honoring the contract breaks a real data path.

It was also **inconsistent per axis**. Presence and utterance copy the dict *conditionally* — only when a quality or source column exists:

```python
votes = bucket["votes"]
if quality is not None:
    votes = {**votes, "__quality__": ...}   # copy
if source is not None:
    votes = {**votes, "__sources__": ...}   # copy
```

With scene columns present they were snapshots; with `--skip` scene features or a pass where the estimators failed, they aliased. Identity aliased unconditionally. So whether a mutation propagated depended on which optional signals a given run happened to produce.

## The fix

1. **Rows carry a shallow snapshot** of the bucket's votes on all three axes, so `aggregate_pass` matches its docstring and no axis behaves differently from another.

2. **`merge_votes_into_harvest(harvest, axis, votes_by_bucket)`** is the explicit, supported way to introduce a voter after harvest. It targets the harvest — what the loop actually reads — and callers re-derive rows by calling `aggregate_pass` again, so rows cannot drift from the harvest. Buckets are matched on bounds within a tolerance; a bucket the harvest doesn't have is reported as unmerged rather than invented, since a vote off the harvest grid has no row to attach to.

The copies are deliberately **shallow**. Adding or removing a voter — the failure mode that existed — can no longer reach the harvest. Mutating a payload dict in place still could; nothing does that today, and deep-copying every bucket would be real overhead for a hazard nobody exercises.

## Tests

Five, written before the fix (they failed on a collection error, then passed):

- rows do not alias the harvest on **any** of the three axes
- a merged voter is visible to re-aggregation and changes the folded result
- an unknown bucket is counted as unmerged rather than silently dropped
- a typo'd axis name raises instead of merging nothing

## Scope

Two files, library-only. No behavior change for any current caller — nothing on `alpha` mutates `row.model_votes` today, so this is pre-emptive: it makes the contract true before someone relies on the accident. Splitting it out of a feature branch so it can be reviewed on its own.

## Not fixed here

The `raw_vs_enhanced` identity delta is computed inside `compute_uncertainty_axes`, before any post-harvest voter could be merged, so it does not reflect one. Pre-existing and orthogonal — worth an explicit decision rather than a silent side effect of this change.

## Verification

`pre-commit run --files` over both files — all 18 hooks pass. 255 passed across `audio_analysis` + `analyze_audio_test`.

`stage_context_test::test_stage_context_import_stays_light` fails on this branch and on `alpha` alike under Python 3.14 — `senselab/__init__.py` prints to stdout when `asyncio.get_event_loop()` raises, and the test parses all of stdout rather than the last line. Pre-existing, unrelated, passes on CI's 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
