### PR TITLE
audio hints + target-speaker embedding estimation (design)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,12 @@ data/
 # file, and failed on every fresh clone (Engaging, CI) with the bare `data/` pattern above hiding why.
 !src/tests/**/data/
 !src/tests/**/data/**
+# ...and the same for utils/tasks' fitted profiles (embedding_gap_significance.json): the bare
+# `data/` pattern above silently gitignored it on first add, so `uv build` produced a wheel missing
+# the file `_load_gap_significance_margin` reads, and a clone with no bundled profile would fall
+# back to the undocumented in-code default instead of failing loudly.
+!src/senselab/utils/tasks/data/
+!src/senselab/utils/tasks/data/**
 # pdoc documentation
 docs/
 

--- a/specs/20260814-153013-audio-hints-speaker-embedding/design.md
+++ b/specs/20260814-153013-audio-hints-speaker-embedding/design.md
@@ -290,10 +290,24 @@ entire error budget is also why the descriptor splits within-file from cross-fil
 
 ### Why no clustering
 
-PR #543 rejected contamination by clustering pooled windows and keeping the dominant cluster,
-measured as 24 of 32 non-speech recordings dropped with the centroid preserved at cos ≥ 0.99 in
-7 of 8 subjects. That property is real and this design gives it up deliberately, because
-selecting a dominant cluster is a *decision* made inside a function whose job is to describe.
+PR #543 rejected contamination by clustering and keeping the dominant cluster, measured as 24 of
+32 non-speech recordings dropped with the centroid preserved at cos ≥ 0.99 in 7 of 8 subjects.
+
+**That clustering is cross-file, once, over the pooled window set** — its own section header
+reads "Cross-file dominant-cluster aggregation". Per file it does speech gating only (dropping
+non-speech windows); every surviving window from every file then pools into one set, and the
+clustering runs on that. So a recording is excluded as a *side effect* of a cross-file decision,
+never by a per-file judgement — which is why #543 also has to report `per_file_dominant`
+(`file_id → windows_in_dominant_cluster`), since a pooled clustering decision is opaque without
+it.
+
+This design gives that property up deliberately, because selecting a dominant cluster is a
+*decision* made inside a function whose job is to describe. Note what #543's own bookkeeping
+implies: it made the decision and then reported per-file evidence *about* the decision. Here the
+per-file evidence is reported directly and the decision is left to the caller — `cross_file`
+cosines and `leave_one_file_out_cos` surface exactly the file that would have fallen out of a
+dominant cluster.
+
 Instead:
 
 - the descriptor reports per-file centroids, their cosine to the pooled centroid, and
@@ -307,6 +321,12 @@ statistics. The statistics are exactly what makes it readable, and `cos_mean_vs_
 A consequence worth recording: this removes any need for a clustering primitive in the task
 layer, so `cluster_pass_speakers` stays untouched in the workflow where it belongs and the repo
 gains no second clustering implementation.
+
+**And the door stays open.** Because the descriptor's contract is "one set of vectors in", a
+cross-file dominant-cluster step can be layered *above* it later without touching it: cluster
+the pooled vectors, hand the retained subset to `describe_embedding_distribution`. If #543's
+tolerance is wanted back, that is where it goes — outside the descriptor, as its own component
+with its own derivation, not inside a function that is supposed to describe what it is given.
 
 ### Layering: two primitives move down
 

--- a/specs/20260814-153013-audio-hints-speaker-embedding/design.md
+++ b/specs/20260814-153013-audio-hints-speaker-embedding/design.md
@@ -17,8 +17,9 @@ Two things, neither of which changes any existing output:
 ## Scope, explicitly
 
 **In:** the `AudioHints` type and its attachment to `Audio`; a vector-distribution descriptor
-in `utils/`; `estimate_speaker_embedding_from_audios` in the speaker-embeddings task; two
-primitives promoted down a layer; two defect fixes in `audio_analysis/embeddings.py`.
+in `utils/`; an opt-in contamination-rejection selector beside it;
+`estimate_speaker_embedding_from_audios` in the speaker-embeddings task; two primitives promoted
+down a layer; two defect fixes in `audio_analysis/embeddings.py`.
 
 **Out, by decision:**
 
@@ -35,7 +36,8 @@ primitives promoted down a layer; two defect fixes in `audio_analysis/embeddings
 - **No artifact I/O, no `workflows/speaker_profile/` package, no `compare.py` /
   `score_voice_groups`.** The last belongs with the per-speaker uncertainty work, as #543 says
   itself.
-- **No clustering.** See "Why no clustering" below.
+- **No clustering inside the descriptor.** Contamination rejection exists, but as an opt-in
+  component layered above it. See "Contamination rejection" below.
 - **No multi-model embedding.** One model per call. #543 defaulted to ECAPA+ResNet because
   `analyze_audio` scores both per-window; decoupled from that consumer, a second model is
   unused cost. `provenance.model_id` records which model produced a vector.
@@ -277,6 +279,7 @@ def estimate_speaker_embedding_from_audios(
     window_s: float = 2.0,
     hop_s: float = 1.0,
     aggregator: str = "spherical_mean",
+    reject_contamination: bool = False,
 ) -> TargetSpeakerEmbedding
 ```
 
@@ -288,7 +291,7 @@ gave cross-file centroid stability 0.890 and cross-subject separation 0.168, aga
 a 0.5/0.25 grid carrying four times the windows. Their finding that cross-file variation is the
 entire error budget is also why the descriptor splits within-file from cross-file.
 
-### Why no clustering
+### Contamination rejection — opt-in, layered above the descriptor
 
 PR #543 rejected contamination by clustering and keeping the dominant cluster, measured as 24 of
 32 non-speech recordings dropped with the centroid preserved at cos ≥ 0.99 in 7 of 8 subjects.
@@ -301,32 +304,69 @@ never by a per-file judgement — which is why #543 also has to report `per_file
 (`file_id → windows_in_dominant_cluster`), since a pooled clustering decision is opaque without
 it.
 
-This design gives that property up deliberately, because selecting a dominant cluster is a
-*decision* made inside a function whose job is to describe. Note what #543's own bookkeeping
-implies: it made the decision and then reported per-file evidence *about* the decision. Here the
-per-file evidence is reported directly and the decision is left to the caller — `cross_file`
-cosines and `leave_one_file_out_cos` surface exactly the file that would have fallen out of a
-dominant cluster.
+This design keeps that capability but moves it **out of the descriptor and behind a flag**,
+because selecting a dominant cluster is a decision and `describe_embedding_distribution`'s job is
+to describe what it is handed.
 
-Instead:
+```python
+def select_dominant_vectors(
+    vectors,
+    file_ids: Sequence[str] | None = None,
+    linkage: str = "average",
+    cut_theta: float | None = None,
+    min_file_share: float | None = None,
+) -> DominantSelection
+```
 
-- the descriptor reports per-file centroids, their cosine to the pooled centroid, and
-  leave-one-file-out stability, so a contaminated file is visible;
-- the caller curates the input set and re-runs.
+`estimate_speaker_embedding_from_audios` gains `reject_contamination: bool = False`. With the
+flag on it selects first and hands only the retained subset to the descriptor, so the descriptor
+is unchanged and its statistics then describe the *kept* set.
 
-The cost is that a dirty file set yields a blended centroid unless the caller reads the
-statistics. The statistics are exactly what makes it readable, and `cos_mean_vs_trimmed10` /
-`cos_mean_vs_medoid` say directly whether aggregation choice mattered.
+**Off by default.** The default path stays pure description, and the flag is the only place a
+decision enters this component.
 
-A consequence worth recording: this removes any need for a clustering primitive in the task
-layer, so `cluster_pass_speakers` stays untouched in the workflow where it belongs and the repo
-gains no second clustering implementation.
+**Agglomerative hierarchical clustering, average linkage, angular distance** — not #543's
+spectral, for three reasons. It is deterministic, where `SpectralClustering(assign_labels=
+"kmeans")` is stochastic and #543 pins `random_state=0` / `n_init=5`, which hides that variance
+rather than removing it. k-means-family clustering carries an equal-size bias and will split one
+speaker's prosodic halves before isolating an 8% intruder — the exact failure
+`_merge_close_clusters` was written to undo after the fact. And AHC turns "choose *k*" into a
+merge-height profile, which is reportable rather than decided.
 
-**And the door stays open.** Because the descriptor's contract is "one set of vectors in", a
-cross-file dominant-cluster step can be layered *above* it later without touching it: cluster
-the pooled vectors, hand the retained subset to `describe_embedding_distribution`. If #543's
-tolerance is wanted back, that is where it goes — outside the descriptor, as its own component
-with its own derivation, not inside a function that is supposed to describe what it is given.
+**The cut gets no numeric default, because that is where an unfitted literal would enter.**
+`cut_theta=None` means the cut is derived from the data by a stated rule: the largest gap in the
+merge-height sequence. That is a *rule*, not a fitted constant, which is what keeps it inside
+this repository's prohibition on literals nobody measured. A caller who disagrees passes an
+explicit `cut_theta`. Either way the value used and the full merge profile are recorded in
+`DominantSelection.rule_used`, so the choice is auditable and reversible.
+
+**#543's four literals are deliberately not carried over** — `coherent_silhouette_threshold=0.10`,
+`merge_threshold=0.55`, `min_cluster_fraction=0.10`, `n_clusters_max=6`. Each is justified against
+`analyze_audio`'s bucket structure rather than against this use, and the first gates on silhouette,
+which this design rejects as parameterisation-dependent (see "Deliberately absent").
+
+**Dominant selection is by file-balanced share**, with raw window share reported alongside. The
+target is the speaker present in *most files*, not the one occupying most seconds — otherwise a
+single ten-minute off-target recording outvotes three one-minute target recordings. When the two
+shares disagree that is diagnostic in itself, so both are reported, along with the runner-up's
+share and `cos(dominant_centroid, runner_up_centroid)`: "0.52 / 0.46 at cos 0.31" and
+"0.94 / 0.05 at cos 0.88" are different situations and both must stay legible.
+
+**Rejection is recorded, never silent.** `provenance.method` becomes
+`"spherical_mean+dominant_cluster"`, `provenance.n_windows_dropped` reflects what rejection
+removed, and `DominantSelection` names which files lost windows and how many.
+
+**The honest cost.** With the flag on, the returned statistics describe a curated set, so they
+will look better than the raw input warranted. That is inherent to rejection rather than a flaw
+in the reporting — and it is why the flag defaults off, why `n_windows_dropped` sits in
+provenance rather than buried, and why `cos_mean_vs_trimmed10` and the leave-one-file-out cosines
+remain the check on whether rejection actually cleaned anything up.
+
+**With the flag off**, contamination is still *visible* without being acted on: the descriptor
+reports per-file centroids, their cosine to the pooled centroid, and leave-one-file-out
+stability, so the caller can curate the input set and re-run. `cluster_pass_speakers` stays
+untouched in the workflow where it belongs; the AHC step here is a generic vector-level
+primitive, not a second copy of that workflow's calibrated clustering.
 
 ### Layering: two primitives move down
 
@@ -423,7 +463,20 @@ consistent with the standing rule against constructing an unmocked `HFModel` in 
    `audio/workflows/`. The repo already uses this pattern (`hf_load_coverage_test`,
    `revision_pinning_guard_test`), and since two primitives move down a layer, a guard is what
    stops them drifting back.
-10. **One skip-gated integration test** that runs only when an embedding model is already
+10. **Contamination rejection** — with `reject_contamination=True` on a set where one file is a
+    different speaker, that file's windows are dropped, `provenance.method` records
+    `+dominant_cluster`, `n_windows_dropped` is non-zero, and `DominantSelection` names the file.
+    With the flag off, the same input keeps every window and the contamination is instead visible
+    in `cross_file` / `leave_one_file_out_cos`.
+11. **The cut rule is a rule, not a literal** — `cut_theta=None` derives from the largest
+    merge-height gap and records the value used; an explicit `cut_theta` overrides it and is
+    recorded verbatim. A test asserts no numeric cut default exists in the signature.
+12. **AHC determinism** — the same input produces byte-identical `kept_indices` and
+    `merge_heights` across repeated calls, with no seed passed.
+13. **File-balanced vs raw share** — a set with one long off-target file and several short
+    on-target files selects the on-target group, and both shares are reported so the
+    disagreement is visible.
+14. **One skip-gated integration test** that runs only when an embedding model is already
     cached locally.
 
 ## File structure
@@ -432,7 +485,7 @@ consistent with the standing rule against constructing an unmocked `HFModel` in 
 | --- | --- | --- |
 | `src/senselab/audio/data_structures/audio_hints.py` | `AudioHints` and its nested types | Create |
 | `src/senselab/audio/data_structures/audio.py` | gains `hints: AudioHints \| None` | Modify |
-| `src/senselab/utils/tasks/embedding_distribution.py` | `describe_embedding_distribution`, `EmbeddingDistribution` | Create |
+| `src/senselab/utils/tasks/embedding_distribution.py` | `describe_embedding_distribution`, `EmbeddingDistribution`, `select_dominant_vectors`, `DominantSelection` | Create |
 | `src/senselab/audio/tasks/speaker_embeddings/windowing.py` | `_window_starts`, `extract_per_window_embeddings`, promoted | Create |
 | `src/senselab/audio/tasks/speaker_embeddings/api.py` | gains `estimate_speaker_embedding_from_audios` | Modify |
 | `src/senselab/audio/tasks/speaker_embeddings/doc.md` | suggested hint vocabulary; estimator contract | Create |
@@ -449,6 +502,10 @@ consistent with the standing rule against constructing an unmocked `HFModel` in 
 - `estimate_speaker_embedding_from_audios` returns a unit-norm centroid plus a statistics block
   in which every field is bounded on an interpretable scale or paired with an analytic null.
 - No field in the block is a verdict, a boolean, a probability, or a thresholded label.
+- Contamination rejection is off by default; when on, what it removed is recorded in provenance
+  and in `DominantSelection`, never silent.
+- No numeric cut threshold exists as a code default; the cut is caller-supplied or derived by a
+  stated rule, and the value used is always reported.
 - Within-file and cross-file dispersion are separately readable.
 - Nothing under `audio/tasks/` imports from `audio/workflows/`.
 - The two `embeddings.py` defects are gone, and the `1.0/0.5` detection default is unchanged.

--- a/specs/20260814-153013-audio-hints-speaker-embedding/design.md
+++ b/specs/20260814-153013-audio-hints-speaker-embedding/design.md
@@ -1,0 +1,434 @@
+# Audio hints and target-speaker embedding estimation
+
+**Status:** design approved 2026-08-14. Branch `feat/audio-hints-speaker-embedding`, cut from
+`alpha` at `9e78187a`.
+
+## Goal
+
+Two things, neither of which changes any existing output:
+
+1. **Declared hints on an `Audio`** — what the recording may contain, how many speakers the
+   acquisition protocol targeted, the environment, the expected text for a read task, and a
+   target-speaker embedding with its provenance.
+2. **An estimator** that takes a set of files that *may* contain a speaker and returns one
+   embedding for that speaker, together with statistics describing the distribution it came
+   from.
+
+## Scope, explicitly
+
+**In:** the `AudioHints` type and its attachment to `Audio`; a vector-distribution descriptor
+in `utils/`; `estimate_speaker_embedding_from_audios` in the speaker-embeddings task; two
+primitives promoted down a layer; two defect fixes in `audio_analysis/embeddings.py`.
+
+**Out, by decision:**
+
+- **No consumer wiring.** Hints are declared and carried. No task changes behaviour because a
+  hint is present — not diarization speaker bounds, not enhancement, not `analyze_audio`. How a
+  hint should inform a decision is a decision, and it gets its own derivation in a later change.
+- **No prompt matcher.** `expected_speech` makes matching *possible*; WER, alignment and
+  skipped-sentence detection are consumers. That work would want designing alongside PR #542's
+  unlanded task-compliance half rather than piecemeal.
+- **No dataset provider.** PR #543's `AudioPlus`, `MetadataProvider`, `NullMetadataProvider`
+  and `audio/metadata/b2ai.py` do not come across. Its metadata is *resolved by lookup*; hints
+  are *asserted by a declarer*. Different provenance, different trust, different failure modes,
+  and hints must work with no provider at all.
+- **No artifact I/O, no `workflows/speaker_profile/` package, no `compare.py` /
+  `score_voice_groups`.** The last belongs with the per-speaker uncertainty work, as #543 says
+  itself.
+- **No clustering.** See "Why no clustering" below.
+- **No multi-model embedding.** One model per call. #543 defaulted to ECAPA+ResNet because
+  `analyze_audio` scores both per-window; decoupled from that consumer, a second model is
+  unused cost. `provenance.model_id` records which model produced a vector.
+- **No `min`/`max` range on `targeted_speaker_count`.** Plausible but unrequested; it goes in
+  `metadata` until a caller needs it, rather than shipping parallel fields now.
+
+## Component 1 — the hints layer
+
+New file `src/senselab/audio/data_structures/audio_hints.py`. `Audio` gains one field:
+`hints: AudioHints | None = None`.
+
+```python
+class ExpectedSpeech(BaseModel):
+    text: str | None          # verbatim prompt the speaker was asked to produce
+    prompt_id: str | None     # id in an external reference set
+    reference: str | None     # which reference set (name / version / URI)
+
+
+class SpeakerEmbeddingProvenance(BaseModel):
+    model_id: str
+    model_commit_sha: str | None     # resolved 40-hex, or None with unresolved_reason set
+    unresolved_reason: str | None
+    method: str                      # e.g. "spherical_mean"
+    source_files: list[str]
+    window_s: float
+    hop_s: float
+    n_windows_used: int
+    n_windows_dropped: int
+    created_at: str | None           # ISO-8601, caller-stamped
+
+
+class TargetSpeakerEmbedding(BaseModel):
+    vector: list[float]              # unit-norm; see "Geometry"
+    provenance: SpeakerEmbeddingProvenance
+    distribution: EmbeddingDistribution | None
+
+
+class AudioHints(BaseModel):
+    may_contain: list[str] = []
+    targeted_speaker_count: int | None = None
+    environment: str | None = None
+    expected_speech: list[ExpectedSpeech] = []
+    target_speaker: TargetSpeakerEmbedding | None = None
+    metadata: dict[str, Any] = {}
+```
+
+### Decisions inside this component
+
+**`may_contain`, not `contains`.** A hint is a declaration of intent or expectation, never a
+measurement. The name keeps that epistemic status so nothing downstream reads it as ground
+truth.
+
+**`hints=None` by default, not an empty `AudioHints`.** An empty object makes "nobody declared
+anything" indistinguishable from "declared nothing". That is the same collapse as reading a
+`None` confidence as `0.0`, which `pii_detection` documents at length; absent stays absent.
+
+**Open tags carry a suggested vocabulary in `doc.md`, not an enum.** `may_contain` and
+`environment` are open string tags. A `Literal` enum would be a taxonomy nobody has fitted, and
+every corpus that did not fit would need the enum edited. Numbers stay numbers:
+`targeted_speaker_count` is an `int`.
+
+**`expected_speech` is an ordered list, not one string.** A single file often holds several
+sentences (the Harvard/IEEE sets are read as sequences). Concatenating them destroys the
+boundaries a matcher needs to say *which* sentence was skipped or reordered — "did they read
+all five" is a different question from "how close was the whole thing".
+
+**`prompt_id` + `reference` alongside `text`.** The verbatim text makes a hint self-contained;
+the id and reference set let it be traced to an external prompt corpus without vendoring that
+corpus. PR #542's `scripts/task_reference.json` (797 task definitions, 720 Harvard/IEEE
+sentences) is the motivating case: it is available elsewhere and deliberately not committed
+here, so this hint is its injection point.
+
+**Provenance records a resolved commit SHA, never a ref.** Reusing the pinning machinery merged
+in #550. When resolution genuinely fails, `model_commit_sha` is `None` *and*
+`unresolved_reason` says why — recording a ref in that field would be provenance that is
+confidently wrong, which #550 established is worse than recording none.
+
+**Adding a field to `Audio` does not disturb cache keys.** Verified:
+`utils/tasks/cached_inference.py` hashes `audio.waveform`, not the model. This is not a
+backwards-compatibility concern — cache and schema compatibility are explicitly not constraints
+during alpha, and invalidation is free. It is a *correctness* one: a hint that nothing consumes
+must not change what a computation returns, or "carried only" would be false. A test asserts it.
+
+## Component 2 — the distribution descriptor
+
+New file `src/senselab/utils/tasks/embedding_distribution.py`, beside `cosine_similarity.py`.
+
+```python
+def describe_embedding_distribution(
+    vectors: Sequence[Sequence[float]] | torch.Tensor | np.ndarray,
+    file_ids: Sequence[str] | None = None,
+    aggregator: str = "spherical_mean",   # | "trimmed_mean" | "medoid"
+    window_s: float | None = None,
+    hop_s: float | None = None,
+) -> tuple[list[float], EmbeddingDistribution]
+```
+
+It describes **one** set of vectors: a centroid and statistics. It does not cluster, does not
+select a subset, and returns no verdict. It lives in `utils/` because it is a function over
+vectors, not over audio, and anything holding embeddings can use it.
+
+### Geometry
+
+**L2-normalise every vector first.** Not a convenience. ECAPA is trained with an angular-margin
+objective and scored by cosine, so identity information is angular by construction, while the
+embedding norm covaries with window energy and how much speech fills the window — a cough, or
+0.4 s of speech in a 2.0 s window, gets a systematically different norm. Any unnormalised
+statistic mixes that loudness/occupancy nuisance into what a reader takes for speaker
+dispersion. Rows with zero norm are dropped and counted.
+
+After normalisation, cosine and Euclidean are the **same** geometry:
+`‖x−y‖² = 2(1−cos θ)`, a strictly monotone reparametrisation. So the common "Euclidean is
+unusable at high d" objection does not apply to any rank- or neighbour-based quantity; what
+differs is *mean-of-distances* statistics, where Jensen makes `s_euc < s_cos` for identical
+geometry. Working scale is cosine. Where a true metric is required (medoid, any linkage) use
+the geodesic `θ = arccos(clip(cos, −1, 1))`; `cos` is not a metric and neither is `1 − cos`.
+
+**Centroid: spherical mean by default**, `ĉ = S/‖S‖` with `S = Σ xᵢ`. It is the von
+Mises–Fisher MLE direction and its error shrinks as `O(n^{−1/2})`, where the medoid *is* one
+real window and so inherits that window's phonetic content with `O(1)` error that does not
+shrink with `n`. An arithmetic mean of unnormalised vectors is rejected outright: it weights
+each window by loudness, so a loud cough outvotes a quiet target utterance.
+
+Because there is no clustering to reject contamination, `aggregator` is exposed as a tool
+parameter (`trimmed_mean`, `medoid`), and the block always reports the cosine between the mean
+and both alternatives. A gap between them tells a caller the estimate is contamination
+sensitive — a robustness statement carrying no threshold and no verdict.
+
+### Reference scales — all analytic, none fitted
+
+| statistic | null | value at d=192 |
+| --- | --- | --- |
+| sd of pairwise cosines | `1/√d` | 0.0722 |
+| mean resultant length `R̄` | `1/√n` | — |
+| participation ratio | `d·n/(d+n)` | — |
+| separability AUC | `0.5` (exact) | — |
+
+Every reported field is either bounded on an interpretable scale or paired with one of these,
+and `dim`, `n_windows_scored` and `n_effective` are in the block so a consumer can recompute
+all four and check ours.
+
+**The counter-intuitive one, which belongs in the docstring:** a *small* sd of cosines is not
+evidence of a coherent single speaker. At d=192 independent random vectors give sd ≈ 0.072, so
+an observed 0.05 is *below* the random-vector null. sd therefore never appears as a headline
+dispersion figure — only next to `1/√d`.
+
+### Fields
+
+```
+geometry          metric="cosine", l2_normalised=True, dim, distance="angular",
+                  centroid_rule=<aggregator>
+counts            n_vectors_total, n_scored, n_zero_norm_dropped, n_files,
+                  vectors_per_file{file→n}, window_s, hop_s, n_effective
+nulls             cos_sd_null, rbar_null, participation_ratio_null, auc_null
+cos_to_centroid_loo   {min, q05, q25, q50, q75, q95}
+rbar              mean resultant length of the scored set
+within_file       per file: {n_vectors, rbar, cos_to_own_centroid_q05, _q50}
+cross_file        per file: cos(file_centroid, pooled_centroid);
+                  file_centroid_pairwise_cos {q05, q50, q95}
+file_effect       auc_same_file_vs_diff_file, permutation_quantile,
+                  permutation_block_len, n_permutations, guard_band_s
+spectrum          participation_ratio, pc1_share_centred, eigenvalue_shares_top5
+centroid_robustness   cos_mean_vs_trimmed10, cos_mean_vs_medoid,
+                      leave_one_file_out_cos{file→cos}
+```
+
+**Within-file and cross-file stay strictly separate.** The prior measurement on this exact
+pipeline is within-file cosine stability 0.984 against cross-file 0.891 — essentially the whole
+error budget is cross-file. A single pooled dispersion would average those into one
+uninterpretable number and destroy the most informative split known about this data.
+
+**Leave-one-file-out centroid stability is the most valuable field.** `cos(ĉ_full, ĉ_−f)` per
+file is a jackknife along exactly that cross-file axis, and it answers a consumer's real
+question — "is this centroid an artefact of one file?" — more directly than any dispersion
+number. Cost is `n_files` matmuls and no model calls.
+
+**Cosine-to-centroid is leave-one-out.** Scoring a vector against a centroid it helped define
+is optimistically biased. Closed form, one matmul, no loop:
+`cos_loo(i) = xᵢ·(S − xᵢ) / ‖S − xᵢ‖`.
+
+**`n_effective = total_windowed_duration / window_s`,** which is ≈ `n/2` at a 2.0 s window with
+1.0 s hop. Overlapping windows mean any null whose width scales as `n^{−1/2}` is ~√2
+overconfident; reporting `n_effective` lets a consumer discount correctly instead of us
+pretending independence.
+
+**The file-effect permutation uses block shuffling.** Statistic: between-file share of angular
+variance, `η² = 1 − Σ_f n_f(1 − R̄_f²) / [n(1 − R̄²)]`. Reference: shuffle `file_id` across
+vectors keeping per-file counts, `B = 1000` times, report the observed value's permutation
+quantile. Windows are autocorrelated (50% overlap plus prosodic continuity), so a naive
+per-vector shuffle destroys dependence the observed statistic retains and the p-value comes out
+anti-conservative; blocks of `L = ceil(window_s/hop_s)` vectors fix that. `L`, `B` and
+`guard_band_s` are stored so the number is auditable, and the docstring states it is a
+diagnostic on a dependent sample, not an exact test.
+
+**The guard band is what keeps `file_effect` from measuring the hop size.** At a 2.0 s window
+on a 1.0 s hop, two temporally adjacent windows share half their audio, so a same-file pair drawn
+from neighbouring windows is a near-duplicate. Left in, same-file similarity is inflated toward
+1.0 for *any* input and the AUC reports the windowing configuration rather than a speaker
+effect. Same-file pairs closer together than `guard_band_s` (default `window_s`) are therefore
+excluded from both sides of the comparison, and the value used is reported.
+
+The AUC in this block is specifically **same-file pairs versus different-file pairs**; with no
+clustering there is no within-cluster/between-cluster contrast to compute. Its exact null is
+0.5 under exchangeability, which is what makes it readable with no fitted scale. Cost of the
+whole permutation is `B` label shuffles and zero model calls.
+
+### Deliberately absent, and why
+
+- **Any silhouette coefficient.** `silhouette(metric="cosine")` and `silhouette(metric="euclidean")` return
+  different numbers for *identical* geometry on unit vectors, so a threshold on silhouette is a
+  threshold on a parameterisation choice. It is also a property of a chosen partition, not of
+  the data. Replaced by the Mann–Whitney separability AUC, which is rank-based and therefore
+  parameterisation-invariant, with an exact null of 0.5.
+- **Any k-NN purity measure.** Two independent failures. Hubness is severe at this dimension
+  (measured skew of k-occurrence 3.29 at d=192, with 64 of 1000 points appearing in no
+  neighbour list), so neighbour counts are biased by something unrelated to speaker identity.
+  And at 50% overlap the 1-NN of a window is almost always the temporally adjacent window, so a
+  same-file purity statistic would read ≈1.0 for any input — it would be measuring the hop size.
+- **Any intrinsic-dimensionality estimate.** Two-NN's `r₁` becomes the distance to a
+  near-duplicate window, so `d̂` is driven down by the hop size. Same artefact, and ID estimators
+  disagree by 2–3× on the same embedding set with no consensus for speaker embeddings.
+- **vMF concentration `κ`.** `κ̂ = R̄(d − R̄²)/(1 − R̄²)` is a deterministic function of `R̄` and
+  `d`, both already in the block, so it stores no new information; it is unbounded as `R̄→1`, so
+  it is not interpretable on its own scale; and vMF assumes isotropic concentration, which
+  embedding spaces violate (participation ratio well below `d`). Recoverable in one line by
+  anyone who wants it.
+- **`sd` of cosines as a standalone number, any `n_speakers` field, any boolean or `p_*`
+  field, anything computed on unnormalised vectors.**
+
+## Component 3 — the estimator
+
+`src/senselab/audio/tasks/speaker_embeddings/` gains:
+
+```python
+def estimate_speaker_embedding_from_audios(
+    audios: list[Audio],
+    model: SenselabModel | None = None,     # default ECAPA
+    device: DeviceType | None = None,
+    window_s: float = 2.0,
+    hop_s: float = 1.0,
+    aggregator: str = "spherical_mean",
+) -> TargetSpeakerEmbedding
+```
+
+Window each file → embed each window → L2-normalise → `describe_embedding_distribution` over
+the pooled set with `file_ids` → wrap the centroid, provenance and distribution.
+
+`2.0 / 1.0` are PR #543's **measured** defaults for a profile centroid, not picks: their grid
+gave cross-file centroid stability 0.890 and cross-subject separation 0.168, against 0.331 for
+a 0.5/0.25 grid carrying four times the windows. Their finding that cross-file variation is the
+entire error budget is also why the descriptor splits within-file from cross-file.
+
+### Why no clustering
+
+PR #543 rejected contamination by clustering pooled windows and keeping the dominant cluster,
+measured as 24 of 32 non-speech recordings dropped with the centroid preserved at cos ≥ 0.99 in
+7 of 8 subjects. That property is real and this design gives it up deliberately, because
+selecting a dominant cluster is a *decision* made inside a function whose job is to describe.
+Instead:
+
+- the descriptor reports per-file centroids, their cosine to the pooled centroid, and
+  leave-one-file-out stability, so a contaminated file is visible;
+- the caller curates the input set and re-runs.
+
+The cost is that a dirty file set yields a blended centroid unless the caller reads the
+statistics. The statistics are exactly what makes it readable, and `cos_mean_vs_trimmed10` /
+`cos_mean_vs_medoid` say directly whether aggregation choice mattered.
+
+A consequence worth recording: this removes any need for a clustering primitive in the task
+layer, so `cluster_pass_speakers` stays untouched in the workflow where it belongs and the repo
+gains no second clustering implementation.
+
+### Layering: two primitives move down
+
+`_window_starts` and `extract_per_window_embeddings` already exist — in
+`audio/workflows/audio_analysis/embeddings.py`. A task importing from a workflow inverts the
+dependency direction (`workflows` compose `tasks`, not the reverse), so both are **promoted
+into `audio/tasks/speaker_embeddings/`** and the workflow imports them from there. PR #543 set
+this precedent by promoting the shared speech gate out of `compute.py`'s private copy, which
+also cut that file by 105 lines.
+
+**What is not promoted:** `cluster_pass_speakers`, `silhouette_voice_score` and
+`calibrate_cosine_uncertainty`. The first is saturated with workflow semantics — a
+YAMNet/AST-derived speech mask, a `"NOISE"` label, `p_voice`, per-pass calibration bands, and
+four literals justified against that workflow's bucket structure. The second returns
+`p_voice = 0.5·(silhouette + 1)`, which is the silhouette-as-probability defect named in
+`CLAUDE.md`. The third is a thresholded piecewise-linear map whose `(0.30, 0.70)` defaults its
+own sibling docstring records as having "sat below *every* distance the embedding produced".
+Importing any of them would import a mislabelled semantic.
+
+## Defect fixes folded in
+
+Both in `audio/workflows/audio_analysis/embeddings.py`, both pre-existing on `alpha`:
+
+1. **`p_voice = 0.5·(silhouette + 1)` at lines ~484 and ~531.** A silhouette coefficient read
+   as a probability — the exact class `CLAUDE.md` calls out, and the L1 post-processing register
+   closed its item 12 by removing the *consumer* rather than the computation. The register
+   records the cost: `embedding_silhouette` produced 0.4022–0.4996 doubt across 214 buckets with
+   stdev 0.0227, and earned the highest fusion weight of fifteen signals precisely because it
+   was near-constant; removing it moved published presence doubt from 0.0682 to 0.0385. The
+   computation is removed or renamed to what it measures, with no `p_`-prefixed name and no
+   probability claim.
+2. **A stale module docstring** claiming "default 2.0 s with 1.0 s hop" while the signature is
+   `window_s=1.0, hop_s=0.5` and the docstring's own "Why 1.0 s / 0.5 s defaults" section agrees
+   with the signature. The stale line is corrected.
+
+**The `1.0/0.5` signature default is deliberately not changed, and cache invalidation is not
+the reason.** Cache and schema compatibility are explicitly not constraints during alpha, and
+`CLAUDE.md` says invalidation is free. The reason is a *quality* one, written into that module's
+own docstring: ECAPA/ResNet embeddings are noisier below 1 s, and the module knowingly trades
+embedding precision for temporal resolution because a 1.0 s window on a 0.5 s hop "gives one
+embedding per 0.5 s bucket, eliminating the same-window dedup that previously dropped half of
+consecutive same-cluster comparisons". The value is tied to the workflow's 0.5 s bucket grid,
+and `calibrate_cosine_uncertainty` is calibrated against that noisier same-speaker baseline.
+Moving it to 2.0/1.0 would halve temporal resolution and reintroduce the dedup it was chosen to
+remove.
+
+So the stale artefact is the docstring's opening line, which claims "default 2.0 s with 1.0 s
+hop" while both the signature and the module's own "Why 1.0 s / 0.5 s defaults" section say
+otherwise. That line is corrected.
+
+The result is two window settings for two purposes, each with its own derivation: **2.0/1.0 for
+a profile centroid** (measured: cross-file stability 0.890, cross-subject separation 0.168) and
+**1.0/0.5 for detection** (measured against the 0.5 s bucket grid). This mirrors #543's own
+`PROFILE_WINDOW_S` / `DETECT_WINDOW_S` split rather than collapsing them.
+
+## Cherry-picked from PR #543
+
+- the measured `2.0 / 1.0` window/hop values **with their derivation table**, not just the
+  numbers;
+- the contamination evidence (24 of 32 non-speech recordings dropped, centroid preserved at
+  cos ≥ 0.99 in 7 of 8 subjects) recorded as the measurement this design consciously trades
+  away;
+- the promote-a-shared-primitive precedent.
+
+**Not taken:** `scripts/gen_synthetic_test_audio.py` (638 lines). #543 needs synthetic *audio*
+because it tests end to end. This design's aggregation and statistics are functions of vectors,
+so tests inject synthetic **embeddings** — deterministic, instant, no model download, and
+consistent with the standing rule against constructing an unmocked `HFModel` in a test.
+
+## Testing
+
+1. **Statistics** — known vector configurations with analytically known answers: one tight
+   cone, two well-separated cones, one cone plus outliers, and uniform-random vectors at
+   d=192 whose `sd`, `R̄` and participation ratio must land on the analytic nulls
+   (`1/√d`, `1/√n`, `d·n/(d+n)`). No model involved.
+2. **Null correctness** — each `nulls` field equals its closed form for the reported `dim`,
+   `n_scored`. This is what keeps the block free of fitted numbers.
+3. **LOO correctness** — `cos_to_centroid_loo` matches a naive recomputed-centroid loop on a
+   small input, proving the closed form.
+4. **Within/cross-file separation** — a construction where within-file dispersion is tiny and
+   cross-file dispersion large must produce visibly different `within_file` and `cross_file`
+   figures, and a `file_effect` AUC far from 0.5.
+5. **Block permutation** — with `file_ids` shuffled at random, the permutation quantile is
+   uniform-ish; with a real file effect it is extreme. Asserted as a direction, not a
+   threshold.
+6. **Robustness diagnostics** — adding contaminant vectors opens a measurable gap in
+   `cos_mean_vs_trimmed10` and `cos_mean_vs_medoid`, and drops the contaminated file's
+   `leave_one_file_out_cos`.
+7. **Hints** — pydantic validation; `hints=None` distinguishable from an empty `AudioHints`;
+   provenance either carries a 40-hex SHA or sets `unresolved_reason`.
+8. **Cache-key invariance** — two `Audio` objects with the same waveform and different `hints`
+   produce the same cache key. The design depends on this.
+9. **A layering guard** — an AST test asserting nothing under `audio/tasks/` imports from
+   `audio/workflows/`. The repo already uses this pattern (`hf_load_coverage_test`,
+   `revision_pinning_guard_test`), and since two primitives move down a layer, a guard is what
+   stops them drifting back.
+10. **One skip-gated integration test** that runs only when an embedding model is already
+    cached locally.
+
+## File structure
+
+| Path | Responsibility | Action |
+| --- | --- | --- |
+| `src/senselab/audio/data_structures/audio_hints.py` | `AudioHints` and its nested types | Create |
+| `src/senselab/audio/data_structures/audio.py` | gains `hints: AudioHints \| None` | Modify |
+| `src/senselab/utils/tasks/embedding_distribution.py` | `describe_embedding_distribution`, `EmbeddingDistribution` | Create |
+| `src/senselab/audio/tasks/speaker_embeddings/windowing.py` | `_window_starts`, `extract_per_window_embeddings`, promoted | Create |
+| `src/senselab/audio/tasks/speaker_embeddings/api.py` | gains `estimate_speaker_embedding_from_audios` | Modify |
+| `src/senselab/audio/tasks/speaker_embeddings/doc.md` | suggested hint vocabulary; estimator contract | Create |
+| `src/senselab/audio/workflows/audio_analysis/embeddings.py` | import promoted primitives; two defect fixes | Modify |
+| `src/tests/utils/embedding_distribution_test.py` | statistics, nulls, LOO, permutation | Create |
+| `src/tests/audio/data_structures/audio_hints_test.py` | hint validation, cache-key invariance | Create |
+| `src/tests/audio/tasks/speaker_embeddings_estimate_test.py` | estimator, robustness diagnostics | Create |
+| `src/tests/audio/tasks/task_layer_guard_test.py` | AST guard: `tasks` must not import `workflows` | Create |
+
+## Success criteria
+
+- An `Audio` can carry every hint in the request, and a hint's presence changes no existing
+  output and no cache key.
+- `estimate_speaker_embedding_from_audios` returns a unit-norm centroid plus a statistics block
+  in which every field is bounded on an interpretable scale or paired with an analytic null.
+- No field in the block is a verdict, a boolean, a probability, or a thresholded label.
+- Within-file and cross-file dispersion are separately readable.
+- Nothing under `audio/tasks/` imports from `audio/workflows/`.
+- The two `embeddings.py` defects are gone, and the `1.0/0.5` detection default is unchanged.

--- a/specs/20260814-153013-audio-hints-speaker-embedding/plan.md
+++ b/specs/20260814-153013-audio-hints-speaker-embedding/plan.md
@@ -1,0 +1,3111 @@
+# Audio hints and target-speaker embedding estimation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an `Audio` carry declared hints (what it may contain, targeted speaker count,
+environment, expected read text, a target-speaker embedding with provenance), and add an
+estimator that turns a set of files which *may* contain a speaker into one embedding plus
+statistics describing the distribution it came from.
+
+**Architecture:** Three separable units. A pydantic hints layer hanging off `Audio`, carried and
+never consumed. A pure vector-level descriptor in `utils/tasks/` that takes one set of vectors and
+returns a centroid plus statistics, deciding nothing. An audio-level estimator in
+`tasks/speaker_embeddings/` that windows, embeds, and calls the descriptor — with an opt-in
+contamination-rejection selector layered between them.
+
+**Tech Stack:** Python 3.12, pydantic v2, numpy, torch, scipy (`scipy.cluster.hierarchy` for AHC),
+pytest. No new third-party dependency.
+
+## Global Constraints
+
+Copied from `design.md`. Every task's requirements implicitly include these.
+
+- **Every Python command runs through `uv run`.** Never bare `python`/`pip`.
+- **`uv sync` is subtractive** — always `--all-extras`.
+- **Never run `pytest -n auto`.** Serial, scoped to the directory changed.
+- **Run `uv run ruff format` before any commit.** Line length 120. Google-style docstrings.
+- **Type hints required**; `mypy --ignore-missing-imports --extra-checks src/` must pass over all
+  of `src/`, tests included. Run that exact command — not `mypy src/senselab/`.
+- **Never `git add -A` unqualified.** Always limit with a pathspec.
+- **Never construct an unmocked `HFModel`/`SpeechBrainModel` in a test.** It downloads a full
+  snapshot. Tests inject synthetic embedding vectors instead.
+- **No unfitted numeric literals as thresholds.** Every reference scale in this feature is either
+  analytic (closed form in `d` or `n`) or derived from the data by a stated rule. If you find
+  yourself typing a magic number that gates a decision, stop — it does not belong.
+- **Explain *why* in comments and docstrings, not *what*.** A non-obvious choice records the
+  measurement or failure that drove it.
+- **No field anywhere in this feature may be a verdict, a boolean, a probability, or a
+  thresholded label.** The one exception is the explicit `reject_contamination` flag, which is a
+  caller's decision, and what it removed is always recorded.
+- **All statistics types are pydantic `BaseModel`s**, not dataclasses — hints get serialised to
+  disk, so everything hanging off `AudioHints` must serialise.
+
+## File Structure
+
+| Path | Responsibility | Action |
+| --- | --- | --- |
+| `src/senselab/utils/tasks/embedding_distribution.py` | Vector-level descriptor + optional dominant-group selector. No audio, no models. | Create |
+| `src/senselab/audio/data_structures/audio_hints.py` | `AudioHints` and nested hint types | Create |
+| `src/senselab/audio/data_structures/audio.py` | gains `hints: AudioHints \| None = None` | Modify |
+| `src/senselab/audio/data_structures/__init__.py` | export the hint types | Modify |
+| `src/senselab/audio/tasks/speaker_embeddings/windowing.py` | `window_starts`, `extract_per_window_embeddings`, promoted down from the workflow | Create |
+| `src/senselab/audio/tasks/speaker_embeddings/api.py` | gains `estimate_speaker_embedding_from_audios` | Modify |
+| `src/senselab/audio/tasks/speaker_embeddings/__init__.py` | export the estimator | Modify |
+| `src/senselab/audio/tasks/speaker_embeddings/doc.md` | suggested hint vocabulary + estimator contract | Create |
+| `src/senselab/audio/workflows/audio_analysis/embeddings.py` | import promoted primitives; two defect fixes | Modify |
+| `src/tests/utils/embedding_distribution_test.py` | descriptor: geometry, nulls, LOO, spectrum | Create |
+| `src/tests/utils/embedding_distribution_files_test.py` | descriptor: within/cross-file, file effect | Create |
+| `src/tests/utils/embedding_distribution_selection_test.py` | selector: AHC, cut rule, shares | Create |
+| `src/tests/audio/data_structures/audio_hints_test.py` | hint validation, cache-key invariance | Create |
+| `src/tests/audio/tasks/speaker_embeddings_estimate_test.py` | estimator, provenance, rejection | Create |
+| `src/tests/audio/tasks/task_layer_guard_test.py` | AST guard: `audio/tasks` must not import `audio/workflows` | Create |
+
+**Why the descriptor tests are split across three files:** the descriptor has ~10 statistic
+families. One test file would grow past the point where a reviewer can hold it in context, and the
+three groups fail for independent reasons (pure geometry / per-file structure / permutation).
+
+---
+
+### Task 1: The hints layer
+
+**Files:**
+- Create: `src/senselab/audio/data_structures/audio_hints.py`
+- Modify: `src/senselab/audio/data_structures/audio.py`
+- Modify: `src/senselab/audio/data_structures/__init__.py`
+- Test: `src/tests/audio/data_structures/audio_hints_test.py`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces:
+  - `ExpectedSpeech(text: str | None = None, prompt_id: str | None = None, reference: str | None = None)`
+  - `SpeakerEmbeddingProvenance(model_id: str, model_commit_sha: str | None = None, unresolved_reason: str | None = None, method: str = "spherical_mean", source_files: list[str] = [], window_s: float | None = None, hop_s: float | None = None, n_windows_used: int = 0, n_windows_dropped: int = 0, created_at: str | None = None)`
+  - `TargetSpeakerEmbedding(vector: list[float], provenance: SpeakerEmbeddingProvenance, distribution: Any | None = None)`
+  - `AudioHints(may_contain: list[str] = [], targeted_speaker_count: int | None = None, environment: str | None = None, expected_speech: list[ExpectedSpeech] = [], target_speaker: TargetSpeakerEmbedding | None = None, metadata: dict[str, Any] = {})`
+  - `Audio.hints: AudioHints | None = None`
+
+**Note on `TargetSpeakerEmbedding.distribution`:** typed `Any | None` in this task on purpose.
+Task 2 creates `EmbeddingDistribution`; Task 8 narrows this field to it. Importing
+`utils.tasks.embedding_distribution` from `data_structures` before it exists would block this task
+on Task 2 for no benefit.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/audio/data_structures/audio_hints_test.py`:
+
+```python
+"""Declared hints on an Audio.
+
+A hint is an assertion by whoever knows the acquisition protocol -- never a measurement, and
+never consumed by any task in this change. These tests pin the two properties that make
+"declared and carried" true: absent stays distinguishable from empty, and a hint cannot change
+what a computation returns.
+"""
+
+import torch
+
+from senselab.audio.data_structures import Audio
+from senselab.audio.data_structures.audio_hints import (
+    AudioHints,
+    ExpectedSpeech,
+    SpeakerEmbeddingProvenance,
+    TargetSpeakerEmbedding,
+)
+
+
+def test_an_audio_carries_no_hints_by_default() -> None:
+    """Absent must stay distinguishable from empty.
+
+    An empty AudioHints would make "nobody declared anything" read the same as "declared
+    nothing" -- the same collapse as reading a None confidence as 0.0, which pii_detection
+    documents at length.
+    """
+    audio = Audio(waveform=torch.zeros(1, 16000), sampling_rate=16000)
+    assert audio.hints is None
+
+
+def test_hints_hold_every_declared_field() -> None:
+    """Every hint in the request round-trips through the model."""
+    hints = AudioHints(
+        may_contain=["read-speech", "cough"],
+        targeted_speaker_count=1,
+        environment="quiet-room",
+        expected_speech=[
+            ExpectedSpeech(text="The quick brown fox.", prompt_id="harvard-01", reference="ieee-1969"),
+            ExpectedSpeech(text="Rice is often served in round bowls.", prompt_id="harvard-02"),
+        ],
+    )
+    audio = Audio(waveform=torch.zeros(1, 16000), sampling_rate=16000, hints=hints)
+    assert audio.hints is not None
+    assert audio.hints.may_contain == ["read-speech", "cough"]
+    assert audio.hints.targeted_speaker_count == 1
+    assert audio.hints.environment == "quiet-room"
+    assert len(audio.hints.expected_speech) == 2
+    assert audio.hints.expected_speech[0].prompt_id == "harvard-01"
+
+
+def test_expected_speech_preserves_order() -> None:
+    """A file often holds several sentences read in sequence.
+
+    Concatenating them would destroy the boundaries a matcher needs to say *which* sentence was
+    skipped or reordered -- a different question from how close the whole thing was.
+    """
+    hints = AudioHints(
+        expected_speech=[ExpectedSpeech(text="first"), ExpectedSpeech(text="second"), ExpectedSpeech(text="third")]
+    )
+    assert [e.text for e in hints.expected_speech] == ["first", "second", "third"]
+
+
+def test_provenance_records_a_resolved_sha_or_says_why_not() -> None:
+    """A ref in the commit-sha field would be provenance that is confidently wrong.
+
+    #550 established that recording a ref while claiming a commit is worse than recording
+    nothing, so an unresolved model must set unresolved_reason instead.
+    """
+    resolved = SpeakerEmbeddingProvenance(model_id="speechbrain/spkrec-ecapa-voxceleb", model_commit_sha="a" * 40)
+    assert resolved.model_commit_sha == "a" * 40
+    assert resolved.unresolved_reason is None
+
+    unresolved = SpeakerEmbeddingProvenance(
+        model_id="speechbrain/spkrec-ecapa-voxceleb",
+        model_commit_sha=None,
+        unresolved_reason="offline: hub unreachable and no cached ref",
+    )
+    assert unresolved.model_commit_sha is None
+    assert unresolved.unresolved_reason
+
+
+def test_a_non_sha_commit_value_is_rejected() -> None:
+    """The field means "resolved commit". Anything ref-shaped in it defeats the point."""
+    import pytest
+
+    with pytest.raises(ValueError, match="40"):
+        SpeakerEmbeddingProvenance(model_id="org/model", model_commit_sha="main")
+
+
+def test_a_target_speaker_embedding_carries_its_provenance() -> None:
+    """A vector with no provenance cannot be interpreted later, so provenance is required."""
+    emb = TargetSpeakerEmbedding(
+        vector=[0.1, 0.2, 0.3],
+        provenance=SpeakerEmbeddingProvenance(model_id="org/model", model_commit_sha="b" * 40),
+    )
+    assert emb.provenance.model_id == "org/model"
+    assert emb.distribution is None
+
+
+def test_hints_do_not_change_the_cache_key() -> None:
+    """A hint nothing consumes must not change what a computation returns.
+
+    Not a backwards-compatibility concern -- alpha owes none -- but a correctness one: if a hint
+    moved a cache key, "carried only" would be false.
+    """
+    from senselab.utils.tasks.cached_inference import audio_content_hash
+
+    waveform = torch.rand(1, 16000)
+    bare = Audio(waveform=waveform, sampling_rate=16000)
+    hinted = Audio(
+        waveform=waveform.clone(),
+        sampling_rate=16000,
+        hints=AudioHints(may_contain=["read-speech"], targeted_speaker_count=2),
+    )
+    assert audio_content_hash(bare) == audio_content_hash(hinted)
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+```bash
+uv run --no-sync pytest src/tests/audio/data_structures/audio_hints_test.py -v 2>&1 | tail -20
+```
+
+Expected: FAIL — `ModuleNotFoundError: senselab.audio.data_structures.audio_hints`.
+
+- [ ] **Step 3: Find the real name of the content-hash helper**
+
+The last test imports `audio_content_hash`. That name is a guess; find what
+`cached_inference.py` actually calls the function that hashes a waveform:
+
+```bash
+grep -n "def .*hash\|def cache_key\|audio.waveform" src/senselab/utils/tasks/cached_inference.py | head
+```
+
+Use the real name in the test. If the helper is private (leading underscore), import it as-is —
+this test is asserting an internal property on purpose. If no such helper exists, build the key
+through the public `cache_key(...)` for both audios and compare those instead.
+
+- [ ] **Step 4: Create the hints module**
+
+Create `src/senselab/audio/data_structures/audio_hints.py`:
+
+```python
+"""Declared hints about what an ``Audio`` may contain.
+
+A hint is an **assertion** -- by an operator, an acquisition protocol, or a corpus description --
+about what a recording was *meant* to contain. It is never a measurement, and nothing in this
+change consumes one: no task alters its behaviour because a hint is present. How a hint should
+inform a decision is itself a decision, and it gets its own derivation when someone builds that
+consumer.
+
+This is deliberately not the same thing as dataset metadata resolved by a lookup (PR #543's
+``AudioPlus``). A lookup's trust comes from the dataset; a hint's comes from whoever declared it.
+Keeping them apart means hints work with no provider, no corpus, and no network.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ExpectedSpeech(BaseModel):
+    """The text a speaker was asked to produce, for a read task.
+
+    Attributes:
+        text: The verbatim prompt. Present so the hint is self-contained -- a consumer can match
+            a transcript against it without resolving anything.
+        prompt_id: Identifier in an external reference set, e.g. ``"harvard-01"``.
+        reference: Which reference set the id belongs to (name, version, or URI). Together with
+            ``prompt_id`` this traces the prompt back to its corpus without vendoring that corpus
+            into this repository.
+    """
+
+    text: Optional[str] = None
+    prompt_id: Optional[str] = None
+    reference: Optional[str] = None
+
+
+class SpeakerEmbeddingProvenance(BaseModel):
+    """Where a target-speaker embedding came from.
+
+    Attributes:
+        model_id: The embedding model, e.g. ``"speechbrain/spkrec-ecapa-voxceleb"``.
+        model_commit_sha: The **resolved** 40-hex commit the vector was produced with, or ``None``.
+            Never a ref: recording ``"main"`` here would be provenance that is confidently wrong,
+            which is worse than recording none.
+        unresolved_reason: Why ``model_commit_sha`` is ``None``. Required in that case, so an
+            absent commit is always explained rather than merely missing.
+        method: How the vector was aggregated, e.g. ``"spherical_mean"`` or
+            ``"spherical_mean+dominant_cluster"`` when contamination rejection ran.
+        source_files: What the estimate was computed from.
+        window_s: Window length used, in seconds.
+        hop_s: Hop between windows, in seconds.
+        n_windows_used: Windows that contributed to the returned vector.
+        n_windows_dropped: Windows excluded -- zero-norm, or removed by contamination rejection.
+            Kept beside ``n_windows_used`` so a curated estimate cannot look like a clean one.
+        created_at: ISO-8601 timestamp, stamped by the caller. Not defaulted to "now": a library
+            that stamps wall-clock time makes its own output unreproducible.
+    """
+
+    model_id: str
+    model_commit_sha: Optional[str] = None
+    unresolved_reason: Optional[str] = None
+    method: str = "spherical_mean"
+    source_files: list[str] = Field(default_factory=list)
+    window_s: Optional[float] = None
+    hop_s: Optional[float] = None
+    n_windows_used: int = 0
+    n_windows_dropped: int = 0
+    created_at: Optional[str] = None
+
+    @field_validator("model_commit_sha")
+    @classmethod
+    def _must_be_a_sha(cls, v: Optional[str]) -> Optional[str]:
+        """Reject anything that is not a full 40-hex commit.
+
+        Args:
+            v: The candidate value.
+
+        Returns:
+            The value unchanged when it is ``None`` or a 40-hex commit.
+
+        Raises:
+            ValueError: When the value is a ref name or a short hash. The field's whole purpose is
+                to be immutable; a ref in it silently reintroduces the ambiguity it removes.
+        """
+        if v is None:
+            return v
+        if not _SHA_RE.match(v):
+            raise ValueError(f"model_commit_sha must be a resolved 40-hex commit, got {v!r}")
+        return v
+
+
+class TargetSpeakerEmbedding(BaseModel):
+    """A speaker embedding declared as the target for a recording.
+
+    Attributes:
+        vector: The embedding, unit-norm. Held inline rather than as a path to a stored artifact
+            so a hint is interpretable on its own -- a reference that outlives its file is the
+            dangling-pointer failure this avoids.
+        provenance: Required. A vector with no provenance cannot be interpreted or reproduced.
+        distribution: Optional statistics describing the set the vector was estimated from. Typed
+            loosely here to keep ``data_structures`` from importing ``utils.tasks``; narrowed by
+            the estimator's own signature.
+    """
+
+    vector: list[float]
+    provenance: SpeakerEmbeddingProvenance
+    distribution: Optional[Any] = None
+
+
+class AudioHints(BaseModel):
+    """What a recording was declared to contain.
+
+    Attributes:
+        may_contain: Open tags -- ``"read-speech"``, ``"cough"``, ``"music"``. Named *may* contain
+            because a hint is an expectation, not an observation; nothing downstream should read
+            it as ground truth. Open strings rather than an enum: a closed vocabulary here would
+            be a taxonomy nobody fitted, and every corpus that did not fit it would force an edit.
+            See ``speaker_embeddings/doc.md`` for a suggested, non-binding vocabulary.
+        targeted_speaker_count: How many speakers the acquisition protocol aimed for -- intent,
+            not a count of who is audible. A range is deliberately not modelled; it goes in
+            ``metadata`` until a caller needs it, rather than shipping parallel min/max fields.
+        environment: Open tag, e.g. ``"quiet-room"``, ``"clinic"``, ``"telephone"``.
+        expected_speech: Ordered prompts for a read task. Ordered and separate rather than one
+            concatenated string, because "which sentence was skipped" is a different question
+            from "how close was the whole thing".
+        target_speaker: The declared target speaker's embedding, with provenance.
+        metadata: Escape hatch for corpus-specific extras that do not deserve a typed field.
+    """
+
+    may_contain: list[str] = Field(default_factory=list)
+    targeted_speaker_count: Optional[int] = None
+    environment: Optional[str] = None
+    expected_speech: list[ExpectedSpeech] = Field(default_factory=list)
+    target_speaker: Optional[TargetSpeakerEmbedding] = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+```
+
+- [ ] **Step 5: Attach the field to `Audio`**
+
+In `src/senselab/audio/data_structures/audio.py`, add the import and one field beside the existing
+`metadata: Dict = Field(default={})`:
+
+```python
+from senselab.audio.data_structures.audio_hints import AudioHints
+```
+
+```python
+    hints: Optional[AudioHints] = None
+```
+
+Add to the class docstring's `Attributes:` block:
+
+```
+        hints: Declared expectations about this recording (see ``audio_hints``). ``None`` means
+            nobody declared anything, which is deliberately distinct from an empty ``AudioHints``.
+            Nothing in senselab consumes hints; they are carried.
+```
+
+Check for an import cycle before moving on: `audio_hints.py` must import **nothing** from
+`senselab.audio` — only pydantic and stdlib. If `audio.py` already imports from
+`senselab.utils.data_structures`, that is fine and unrelated.
+
+- [ ] **Step 6: Export the new types**
+
+In `src/senselab/audio/data_structures/__init__.py`, add `AudioHints`, `ExpectedSpeech`,
+`SpeakerEmbeddingProvenance` and `TargetSpeakerEmbedding` to the imports and to `__all__`, keeping
+`__all__` alphabetically sorted the way the file already is.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+uv run --no-sync pytest src/tests/audio/data_structures/audio_hints_test.py -v 2>&1 | tail -20
+```
+
+Expected: PASS, 7 tests.
+
+- [ ] **Step 8: Verify nothing else broke**
+
+```bash
+uv run --no-sync pytest src/tests/audio/data_structures/ -q 2>&1 | tail -5
+uv run --no-sync ruff format src/senselab/audio/data_structures/ src/tests/audio/data_structures/
+uv run --no-sync ruff check src/ src/tests/
+uv run --no-sync mypy --ignore-missing-imports --extra-checks src/ 2>&1 | tail -3
+```
+
+Expected: all pass. `Audio` is constructed all over the suite, so a broken field shows up here.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/senselab/audio/data_structures/audio_hints.py \
+        src/senselab/audio/data_structures/audio.py \
+        src/senselab/audio/data_structures/__init__.py \
+        src/tests/audio/data_structures/audio_hints_test.py
+git commit -m "feat(audio): declared hints on an Audio, carried and not consumed
+
+A hint is an assertion about what a recording was meant to contain -- may_contain,
+targeted_speaker_count, environment, expected read prompts, and a target-speaker
+embedding with provenance. Nothing consumes them: how a hint should inform a
+decision is itself a decision and gets its own derivation later.
+
+hints defaults to None rather than an empty AudioHints so 'nobody declared
+anything' stays distinguishable from 'declared nothing'. model_commit_sha rejects
+anything that is not 40-hex, because a ref in that field is provenance that is
+confidently wrong. A test pins that a hint cannot move a cache key -- if it could,
+'carried only' would be false."
+```
+
+---
+
+### Task 2: Descriptor core — geometry, counts, nulls, R̄, LOO cosines, spectrum
+
+**Files:**
+- Create: `src/senselab/utils/tasks/embedding_distribution.py`
+- Test: `src/tests/utils/embedding_distribution_test.py`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces (later tasks extend the same module and the same `EmbeddingDistribution` model):
+  - `SimilarityStats(min, q05, q25, q50, q75, q95, max, mean, sd)` — all `float`
+  - `GeometryInfo(metric: str, l2_normalised: bool, dim: int, distance: str, centroid_rule: str)`
+  - `CountsInfo(n_vectors_total: int, n_scored: int, n_zero_norm_dropped: int, n_files: int, vectors_per_file: dict[str, int], window_s: float | None, hop_s: float | None, n_effective: float | None)`
+  - `NullsInfo(cos_sd_null: float, rbar_null: float, participation_ratio_null: float, auc_null: float)`
+  - `SpectrumStats(participation_ratio: float, pc1_share_centred: float, eigenvalue_shares_top5: list[float])`
+  - `EmbeddingDistribution(geometry, counts, nulls, cos_to_centroid_loo: SimilarityStats, rbar: float, spectrum: SpectrumStats)` — Tasks 3-5 add `within_file`, `cross_file`, `file_effect`, `centroid_robustness`
+  - `describe_embedding_distribution(vectors, file_ids=None, *, aggregator="spherical_mean", window_s=None, hop_s=None, window_starts_s=None, n_permutations=1000, seed=0) -> tuple[list[float], EmbeddingDistribution]`
+  - `_l2_normalise(x: np.ndarray) -> tuple[np.ndarray, int]` — returns normalised rows and the count dropped for zero norm
+  - `_similarity_stats(values: np.ndarray) -> SimilarityStats`
+  - `_spherical_mean(x: np.ndarray) -> np.ndarray` — unit-norm mean direction
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/utils/embedding_distribution_test.py`:
+
+```python
+"""Core statistics of one set of embedding vectors.
+
+Every reference scale here is analytic, so these tests check the statistics against closed forms
+rather than against recorded numbers. That is the point: a fitted literal would have to be
+measured and maintained, while 1/sqrt(d) is true by construction.
+"""
+
+import numpy as np
+import pytest
+
+from senselab.utils.tasks.embedding_distribution import describe_embedding_distribution
+
+
+def _tight_cone(n: int, d: int, spread: float, seed: int = 0) -> np.ndarray:
+    """n vectors clustered around one random direction, with angular spread."""
+    rng = np.random.default_rng(seed)
+    axis = rng.normal(size=d)
+    axis /= np.linalg.norm(axis)
+    x = axis[None, :] + spread * rng.normal(size=(n, d))
+    return x / np.linalg.norm(x, axis=1, keepdims=True)
+
+
+def test_uniform_random_vectors_land_on_the_analytic_nulls() -> None:
+    """Random directions must reproduce the closed forms, or the nulls are wrong.
+
+    This is the test that keeps the block free of fitted numbers: sd of pairwise cosines -> 1/sqrt(d),
+    mean resultant length -> 1/sqrt(n), participation ratio -> d*n/(d+n).
+    """
+    n, d = 800, 192
+    rng = np.random.default_rng(17)
+    x = rng.normal(size=(n, d))
+    x /= np.linalg.norm(x, axis=1, keepdims=True)
+
+    _, dist = describe_embedding_distribution(x)
+
+    assert dist.nulls.cos_sd_null == pytest.approx(1.0 / np.sqrt(d))
+    assert dist.nulls.rbar_null == pytest.approx(1.0 / np.sqrt(n))
+    assert dist.nulls.participation_ratio_null == pytest.approx(d * n / (d + n))
+    assert dist.nulls.auc_null == 0.5
+
+    # And the data actually sits near them.
+    assert dist.rbar == pytest.approx(1.0 / np.sqrt(n), abs=0.02)
+    assert dist.spectrum.participation_ratio == pytest.approx(d * n / (d + n), rel=0.1)
+
+
+def test_a_tight_cone_has_high_rbar_and_low_effective_rank() -> None:
+    """One coherent speaker points one way and occupies few directions."""
+    x = _tight_cone(n=400, d=192, spread=0.15)
+    _, dist = describe_embedding_distribution(x)
+
+    assert dist.rbar > 0.9
+    assert dist.rbar > 10 * dist.nulls.rbar_null
+    assert dist.spectrum.participation_ratio < 0.5 * dist.nulls.participation_ratio_null
+
+
+def test_the_centroid_is_unit_norm() -> None:
+    """The returned vector is a direction. Callers compare it by cosine."""
+    centroid, _ = describe_embedding_distribution(_tight_cone(n=50, d=64, spread=0.2))
+    assert np.linalg.norm(np.asarray(centroid)) == pytest.approx(1.0)
+
+
+def test_zero_norm_rows_are_dropped_and_counted() -> None:
+    """A zero vector has no direction, so it cannot contribute -- but silence about it would
+    make n_scored unexplainable."""
+    x = _tight_cone(n=20, d=32, spread=0.1)
+    x = np.vstack([x, np.zeros((3, 32))])
+    _, dist = describe_embedding_distribution(x)
+
+    assert dist.counts.n_vectors_total == 23
+    assert dist.counts.n_scored == 20
+    assert dist.counts.n_zero_norm_dropped == 3
+
+
+def test_input_is_normalised_even_when_the_caller_did_not() -> None:
+    """ECAPA embeddings are not unit norm, and the norm covaries with window energy and how much
+    speech fills the window. Left alone it would inject a loudness nuisance into every statistic,
+    so normalisation is unconditional and the block says so."""
+    x = _tight_cone(n=40, d=64, spread=0.1)
+    scaled = x * np.linspace(0.1, 50.0, x.shape[0])[:, None]
+
+    c_plain, d_plain = describe_embedding_distribution(x)
+    c_scaled, d_scaled = describe_embedding_distribution(scaled)
+
+    assert d_scaled.geometry.l2_normalised is True
+    assert np.allclose(c_plain, c_scaled, atol=1e-6)
+    assert d_scaled.rbar == pytest.approx(d_plain.rbar, abs=1e-6)
+
+
+def test_loo_cosines_match_a_naive_recomputation() -> None:
+    """Scoring a vector against a centroid it helped define is optimistically biased.
+
+    The closed form x_i . (S - x_i) / ||S - x_i|| must equal recomputing the centroid without i,
+    which this checks directly on a small input.
+    """
+    x = _tight_cone(n=12, d=16, spread=0.3, seed=3)
+    _, dist = describe_embedding_distribution(x)
+
+    naive = []
+    for i in range(x.shape[0]):
+        others = np.delete(x, i, axis=0)
+        c = others.sum(axis=0)
+        c /= np.linalg.norm(c)
+        naive.append(float(x[i] @ c))
+    naive_arr = np.sort(np.asarray(naive))
+
+    assert dist.cos_to_centroid_loo.min == pytest.approx(naive_arr.min(), abs=1e-9)
+    assert dist.cos_to_centroid_loo.max == pytest.approx(naive_arr.max(), abs=1e-9)
+    assert dist.cos_to_centroid_loo.q50 == pytest.approx(float(np.quantile(naive_arr, 0.5)), abs=1e-9)
+
+
+def test_n_effective_discounts_overlapping_windows() -> None:
+    """At a 2.0 s window on a 1.0 s hop, adjacent windows share half their audio, so independent
+    information is about n/2. Reporting it lets a consumer discount nulls that scale as
+    n^-1/2 instead of us pretending independence."""
+    x = _tight_cone(n=100, d=32, spread=0.2)
+    _, dist = describe_embedding_distribution(x, window_s=2.0, hop_s=1.0)
+    assert dist.counts.n_effective == pytest.approx(50.0, rel=0.05)
+
+
+def test_n_effective_is_none_without_window_information() -> None:
+    """It cannot be derived from vectors alone, and a guessed value would be worse than none."""
+    _, dist = describe_embedding_distribution(_tight_cone(n=10, d=8, spread=0.1))
+    assert dist.counts.n_effective is None
+
+
+def test_pc1_share_is_computed_on_centred_data() -> None:
+    """Uncentred, PC1 is just the mean direction and explains almost everything for any coherent
+    set -- a field that always reads the same. Centred, a high PC1 share is the signature of
+    bimodality, which is what makes it worth reporting."""
+    d = 64
+    rng = np.random.default_rng(5)
+    axis = rng.normal(size=d)
+    axis /= np.linalg.norm(axis)
+    perp = rng.normal(size=d)
+    perp -= (perp @ axis) * axis
+    perp /= np.linalg.norm(perp)
+
+    # Two lobes displaced along one perpendicular direction: one dominant axis of variation.
+    a = axis[None, :] + 0.35 * perp[None, :] + 0.02 * rng.normal(size=(100, d))
+    b = axis[None, :] - 0.35 * perp[None, :] + 0.02 * rng.normal(size=(100, d))
+    x = np.vstack([a, b])
+    x /= np.linalg.norm(x, axis=1, keepdims=True)
+
+    _, dist = describe_embedding_distribution(x)
+    assert dist.spectrum.pc1_share_centred > 0.8
+    assert len(dist.spectrum.eigenvalue_shares_top5) == 5
+
+
+def test_geometry_records_what_was_done() -> None:
+    """A consumer reading a stored block has to know the geometry to interpret any number in it."""
+    _, dist = describe_embedding_distribution(_tight_cone(n=10, d=8, spread=0.1))
+    assert dist.geometry.metric == "cosine"
+    assert dist.geometry.distance == "angular"
+    assert dist.geometry.dim == 8
+    assert dist.geometry.centroid_rule == "spherical_mean"
+
+
+def test_too_few_vectors_raises_rather_than_returning_a_meaningless_block() -> None:
+    """One vector has no distribution. Returning a block of zeros would look like a measurement."""
+    with pytest.raises(ValueError, match="at least 2"):
+        describe_embedding_distribution(np.ones((1, 8)))
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+```bash
+uv run --no-sync pytest src/tests/utils/embedding_distribution_test.py -v 2>&1 | tail -10
+```
+
+Expected: FAIL — `ModuleNotFoundError: senselab.utils.tasks.embedding_distribution`.
+
+- [ ] **Step 3: Implement the module**
+
+Create `src/senselab/utils/tasks/embedding_distribution.py`. Write the module docstring first —
+it carries the reasoning that keeps later readers from "improving" this into something wrong:
+
+```python
+"""Describe one set of embedding vectors: a centroid, and statistics about the distribution.
+
+This module **describes and never decides**. There is no verdict field, no boolean, no
+probability, and no thresholded label anywhere in its output. A consumer applies its own
+threshold, so every statistic here is either bounded on an interpretable scale or paired with an
+analytic null it can be read against.
+
+Every reference scale is closed-form, which is what keeps the module free of literals nobody
+fitted:
+
+- sd of pairwise cosines between independent directions: ``1/sqrt(d)`` (0.0722 at d=192)
+- mean resultant length of ``n`` independent directions: ``E[Rbar^2] = 1/n``, so ``1/sqrt(n)``
+- participation ratio under Marchenko-Pastur: ``d*n/(d+n)``
+- Mann-Whitney AUC under exchangeability: exactly ``0.5``
+
+**The counter-intuitive one.** A *small* sd of cosines is not evidence of a coherent speaker. At
+d=192 independent random directions give sd ~= 0.072, so an observed 0.05 is *below* the
+random-vector null. sd is therefore never reported as a headline dispersion figure -- only beside
+``nulls.cos_sd_null``.
+
+Geometry: vectors are L2-normalised on entry, unconditionally. SpeechBrain speaker embeddings are
+not unit norm, and the norm covaries with window energy and how much speech fills the window -- a
+cough, or 0.4 s of speech in a 2.0 s window, gets a systematically different norm. Any
+unnormalised statistic would mix that loudness/occupancy nuisance into what a reader takes for
+speaker dispersion. ECAPA is trained with an angular-margin objective and scored by cosine, so
+the norm is not part of the discriminative geometry to begin with.
+
+After normalisation cosine and Euclidean are the *same* geometry --
+``||x-y||^2 = 2(1-cos t)``, a strictly monotone reparametrisation -- so the common "Euclidean is
+unusable at high d" objection does not apply to any rank- or neighbour-based quantity. Where a
+true metric is needed (medoid, linkage) the geodesic ``arccos(clip(cos,-1,1))`` is used, because
+``cos`` is not a metric and neither is ``1-cos``.
+
+**Deliberately absent**, each for a mechanical reason rather than taste:
+
+- *Silhouette.* ``silhouette(metric="cosine")`` and ``silhouette(metric="euclidean")`` return
+  different numbers for identical geometry on unit vectors (Jensen: the square root compresses
+  large distances more than small ones), so any threshold on silhouette is a threshold on a
+  parameterisation choice. It is also a property of a chosen partition, not of the data.
+- *k-NN purity.* Hubness is severe at this dimension -- k-occurrence skew ~3.3 at d=192, with a
+  measurable fraction of points appearing in no neighbour list -- so neighbour counts carry a bias
+  unrelated to speaker identity. Worse, at 50% window overlap a window's nearest neighbour is
+  almost always the temporally adjacent window, so any same-file purity statistic would read ~1.0
+  for every input: it would measure the hop size.
+- *Intrinsic-dimensionality estimators.* Two-NN's ``r1`` becomes the distance to a near-duplicate
+  window, driving the estimate down by the hop size. Same artefact.
+- *von Mises-Fisher concentration.* ``kappa = Rbar(d - Rbar^2)/(1 - Rbar^2)`` is a deterministic
+  function of ``Rbar`` and ``d``, both reported, so it stores nothing new; it is unbounded as
+  ``Rbar -> 1``, so it is not interpretable on its own scale; and vMF assumes isotropic
+  concentration, which embedding spaces violate. Recover it in one line if you want it.
+"""
+```
+
+Then the models and the implementation:
+
+```python
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence, Union
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+AGGREGATOR_SPHERICAL_MEAN = "spherical_mean"
+AGGREGATOR_TRIMMED_MEAN = "trimmed_mean"
+AGGREGATOR_MEDOID = "medoid"
+_AGGREGATORS = (AGGREGATOR_SPHERICAL_MEAN, AGGREGATOR_TRIMMED_MEAN, AGGREGATOR_MEDOID)
+
+# The fraction trimmed by the trimmed-mean aggregator and by the robustness diagnostic. Not a
+# decision threshold: nothing is accepted or rejected on it, and both the trimmed result and its
+# cosine to the untrimmed mean are reported, so a reader sees what trimming did rather than
+# inheriting its verdict.
+_TRIM_FRACTION = 0.10
+
+
+class SimilarityStats(BaseModel):
+    """Quantiles of a set of cosine values, plus mean and sd.
+
+    Quantiles rather than mean-and-sd alone because contamination makes this distribution a
+    *mixture*: mean +/- sd of a bimodal mixture describes neither lobe, and the sd is inflated by
+    exactly the thing worth exposing -- so sd alone cannot separate "one loose speaker" from "two
+    tight speakers". ``q05`` and ``min`` are where an intruder shows up.
+    """
+
+    min: float
+    q05: float
+    q25: float
+    q50: float
+    q75: float
+    q95: float
+    max: float
+    mean: float
+    sd: float
+
+
+class GeometryInfo(BaseModel):
+    """What was done to the vectors, so a stored block can be interpreted later."""
+
+    metric: str
+    l2_normalised: bool
+    dim: int
+    distance: str
+    centroid_rule: str
+
+
+class CountsInfo(BaseModel):
+    """Sizes, and the effective sample size after accounting for window overlap.
+
+    Attributes:
+        n_effective: ``total_windowed_duration / window_s``, which is about ``n/2`` at a 2.0 s
+            window on a 1.0 s hop. ``None`` when window information was not supplied -- it cannot
+            be derived from vectors alone, and a guess would be worse than an absence. Any null
+            whose width scales as ``n^-1/2`` is about sqrt(2) overconfident without this discount.
+    """
+
+    n_vectors_total: int
+    n_scored: int
+    n_zero_norm_dropped: int
+    n_files: int
+    vectors_per_file: dict[str, int] = Field(default_factory=dict)
+    window_s: Optional[float] = None
+    hop_s: Optional[float] = None
+    n_effective: Optional[float] = None
+
+
+class NullsInfo(BaseModel):
+    """Closed-form reference scales, so no statistic needs a fitted threshold.
+
+    ``dim`` and ``n_scored`` are in ``CountsInfo`` and ``GeometryInfo`` specifically so a consumer
+    can recompute every one of these and check ours.
+    """
+
+    cos_sd_null: float
+    rbar_null: float
+    participation_ratio_null: float
+    auc_null: float
+
+
+class SpectrumStats(BaseModel):
+    """How many directions the set actually occupies.
+
+    Attributes:
+        participation_ratio: ``(sum lambda)^2 / sum lambda^2`` of the centred covariance, in
+            ``[1, min(n,d)]``. Read against ``nulls.participation_ratio_null``: well below it means
+            a genuinely low-dimensional set, near it means indistinguishable from white noise at
+            this sample size.
+        pc1_share_centred: ``lambda_1 / sum lambda`` on **centred** data. Uncentred, PC1 is the
+            mean direction and explains almost everything for any coherent set, which would make
+            this a field that always reads the same. Centred, a high share is the signature of
+            bimodality.
+        eigenvalue_shares_top5: The five largest ``lambda_i / sum lambda``, zero-padded when
+            ``min(n,d) < 5``.
+    """
+
+    participation_ratio: float
+    pc1_share_centred: float
+    eigenvalue_shares_top5: list[float]
+
+
+class EmbeddingDistribution(BaseModel):
+    """Statistics describing one set of embedding vectors. Contains no verdict."""
+
+    geometry: GeometryInfo
+    counts: CountsInfo
+    nulls: NullsInfo
+    cos_to_centroid_loo: SimilarityStats
+    rbar: float
+    spectrum: SpectrumStats
+
+
+def _as_array(vectors: Union[Sequence[Sequence[float]], np.ndarray, Any]) -> np.ndarray:
+    """Coerce input to a 2-D float64 array without importing torch at module scope.
+
+    Args:
+        vectors: A nested sequence, a numpy array, or anything exposing ``detach``/``cpu``/``numpy``
+            (a torch tensor).
+
+    Returns:
+        A 2-D ``float64`` array, one row per vector.
+
+    Raises:
+        ValueError: If the result is not 2-D.
+    """
+    if hasattr(vectors, "detach"):
+        vectors = vectors.detach().cpu().numpy()
+    arr = np.asarray(vectors, dtype=np.float64)
+    if arr.ndim != 2:
+        raise ValueError(f"vectors must be 2-D (n, d); got shape {arr.shape}")
+    return arr
+
+
+def _l2_normalise(x: np.ndarray) -> tuple[np.ndarray, int]:
+    """Return unit-norm rows and the count of zero-norm rows removed.
+
+    Args:
+        x: ``(n, d)`` array.
+
+    Returns:
+        ``(normalised, n_dropped)``. A zero-norm row has no direction, so it cannot contribute to
+        any angular statistic; it is dropped rather than producing ``nan``, and counted so
+        ``n_scored`` stays explainable.
+    """
+    norms = np.linalg.norm(x, axis=1)
+    keep = norms > 0
+    n_dropped = int((~keep).sum())
+    return x[keep] / norms[keep][:, None], n_dropped
+
+
+def _spherical_mean(x: np.ndarray) -> np.ndarray:
+    """Unit-norm mean direction of unit-norm rows.
+
+    This is the von Mises-Fisher MLE direction, and its error shrinks as ``O(n^-1/2)``. An
+    arithmetic mean of *unnormalised* vectors would weight each row by its norm -- i.e. by
+    loudness and speech occupancy -- so a loud cough would outvote a quiet target utterance.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+
+    Returns:
+        A unit-norm ``(d,)`` direction.
+
+    Raises:
+        ValueError: If the rows sum to the zero vector, which has no direction.
+    """
+    s = x.sum(axis=0)
+    norm = float(np.linalg.norm(s))
+    if norm == 0.0:
+        raise ValueError("vectors sum to zero; no mean direction exists")
+    return s / norm
+
+
+def _similarity_stats(values: np.ndarray) -> SimilarityStats:
+    """Summarise a 1-D array of cosine values.
+
+    Args:
+        values: Any 1-D array of cosines.
+
+    Returns:
+        Quantiles plus mean and sd. ``sd`` is included for completeness but is meaningless without
+        ``nulls.cos_sd_null`` beside it; see the module docstring.
+    """
+    v = np.asarray(values, dtype=np.float64).ravel()
+    q = np.quantile(v, [0.05, 0.25, 0.50, 0.75, 0.95])
+    return SimilarityStats(
+        min=float(v.min()),
+        q05=float(q[0]),
+        q25=float(q[1]),
+        q50=float(q[2]),
+        q75=float(q[3]),
+        q95=float(q[4]),
+        max=float(v.max()),
+        mean=float(v.mean()),
+        sd=float(v.std(ddof=1)) if v.size > 1 else 0.0,
+    )
+
+
+def _loo_cos_to_centroid(x: np.ndarray) -> np.ndarray:
+    """Cosine of each row to the centroid computed *without* that row.
+
+    Scoring a vector against a centroid it helped define is optimistically biased -- each row pulls
+    the centroid toward itself. Closed form, one pass, no loop: with ``S = sum x_j`` over unit
+    rows, the leave-one-out mean direction is proportional to ``S - x_i``, so
+    ``cos_loo(i) = x_i . (S - x_i) / ||S - x_i||``.
+
+    Args:
+        x: ``(n, d)`` unit-norm array with ``n >= 2``.
+
+    Returns:
+        ``(n,)`` array of leave-one-out cosines.
+    """
+    s = x.sum(axis=0)
+    diff = s[None, :] - x
+    denom = np.linalg.norm(diff, axis=1)
+    numer = np.einsum("ij,ij->i", x, diff)
+    out = np.zeros_like(denom)
+    nz = denom > 0
+    out[nz] = numer[nz] / denom[nz]
+    return out
+
+
+def _spectrum(x: np.ndarray) -> SpectrumStats:
+    """Participation ratio, centred PC1 share, and the top-5 eigenvalue shares.
+
+    Uses singular values of the centred matrix rather than forming the ``d x d`` covariance: both
+    quantities are ratios, so the ``1/(n-1)`` factor cancels and the SVD is cheaper and better
+    conditioned.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+
+    Returns:
+        The spectrum summary.
+    """
+    centred = x - x.mean(axis=0, keepdims=True)
+    sv = np.linalg.svd(centred, compute_uv=False)
+    lam = sv**2
+    total = float(lam.sum())
+    if total == 0.0:
+        # Every row identical: no variation at all. One occupied direction, by definition.
+        return SpectrumStats(participation_ratio=1.0, pc1_share_centred=0.0, eigenvalue_shares_top5=[0.0] * 5)
+    pr = float(total**2 / float((lam**2).sum()))
+    shares = (lam / total).tolist()
+    top5 = [float(v) for v in shares[:5]] + [0.0] * max(0, 5 - len(shares))
+    return SpectrumStats(participation_ratio=pr, pc1_share_centred=float(shares[0]), eigenvalue_shares_top5=top5)
+
+
+def describe_embedding_distribution(
+    vectors: Union[Sequence[Sequence[float]], np.ndarray, Any],
+    file_ids: Optional[Sequence[str]] = None,
+    *,
+    aggregator: str = AGGREGATOR_SPHERICAL_MEAN,
+    window_s: Optional[float] = None,
+    hop_s: Optional[float] = None,
+    window_starts_s: Optional[Sequence[float]] = None,
+    n_permutations: int = 1000,
+    seed: int = 0,
+) -> tuple[list[float], EmbeddingDistribution]:
+    """Describe one set of embedding vectors: a centroid and statistics about the distribution.
+
+    Decides nothing. See the module docstring for the geometry, the analytic nulls, and what is
+    deliberately absent.
+
+    Args:
+        vectors: ``(n, d)`` embeddings. Normalised on entry regardless of input scale.
+        file_ids: One id per row, when the vectors come from several files. Enables the per-file
+            statistics; ``None`` treats the set as one group.
+        aggregator: ``"spherical_mean"`` (default), ``"trimmed_mean"``, or ``"medoid"``. A tool
+            parameter, not a decision: the returned block always reports the cosine between the
+            mean and both alternatives, so a reader sees whether the choice mattered.
+        window_s: Window length in seconds, used for ``n_effective`` and the permutation block
+            length. ``None`` leaves both unreported rather than guessed.
+        hop_s: Hop between windows in seconds.
+        window_starts_s: Start time of each window, same order as ``vectors``. Required for the
+            same-file guard band; without it that guard is skipped and reported as ``None``.
+        n_permutations: Permutations for the file-effect reference.
+        seed: Seed for the permutation. Fixed by default so the reported quantile is reproducible.
+
+    Returns:
+        ``(centroid, distribution)``. The centroid is a unit-norm ``list[float]``.
+
+    Raises:
+        ValueError: If fewer than 2 vectors survive normalisation, if ``vectors`` is not 2-D, if
+            ``aggregator`` is unknown, or if ``file_ids``/``window_starts_s`` lengths disagree with
+            ``vectors``.
+    """
+    if aggregator not in _AGGREGATORS:
+        raise ValueError(f"aggregator must be one of {_AGGREGATORS}; got {aggregator!r}")
+
+    raw = _as_array(vectors)
+    n_total = int(raw.shape[0])
+    if file_ids is not None and len(file_ids) != n_total:
+        raise ValueError(f"file_ids has {len(file_ids)} entries for {n_total} vectors")
+    if window_starts_s is not None and len(window_starts_s) != n_total:
+        raise ValueError(f"window_starts_s has {len(window_starts_s)} entries for {n_total} vectors")
+
+    norms = np.linalg.norm(raw, axis=1)
+    keep_mask = norms > 0
+    x, n_dropped = _l2_normalise(raw)
+    n = int(x.shape[0])
+    if n < 2:
+        raise ValueError(f"need at least 2 non-zero vectors to describe a distribution; got {n}")
+    d = int(x.shape[1])
+
+    kept_files = [str(f) for f, k in zip(file_ids, keep_mask) if k] if file_ids is not None else None
+
+    centroid = _spherical_mean(x)  # Tasks 4-5 replace this with the aggregator dispatch.
+
+    per_file: dict[str, int] = {}
+    if kept_files is not None:
+        for f in kept_files:
+            per_file[f] = per_file.get(f, 0) + 1
+
+    n_effective: Optional[float] = None
+    if window_s is not None and hop_s is not None and window_s > 0:
+        # total covered duration / window_s: overlapping windows do not carry independent
+        # information, and pretending they do makes every n^-1/2 null overconfident.
+        n_effective = float((hop_s * (n - 1) + window_s) / window_s)
+
+    return centroid.tolist(), EmbeddingDistribution(
+        geometry=GeometryInfo(
+            metric="cosine",
+            l2_normalised=True,
+            dim=d,
+            distance="angular",
+            centroid_rule=aggregator,
+        ),
+        counts=CountsInfo(
+            n_vectors_total=n_total,
+            n_scored=n,
+            n_zero_norm_dropped=n_dropped,
+            n_files=len(per_file) if per_file else (1 if kept_files is None else 0),
+            vectors_per_file=per_file,
+            window_s=window_s,
+            hop_s=hop_s,
+            n_effective=n_effective,
+        ),
+        nulls=NullsInfo(
+            cos_sd_null=float(1.0 / np.sqrt(d)),
+            rbar_null=float(1.0 / np.sqrt(n)),
+            participation_ratio_null=float(d * n / (d + n)),
+            auc_null=0.5,
+        ),
+        cos_to_centroid_loo=_similarity_stats(_loo_cos_to_centroid(x)),
+        rbar=float(np.linalg.norm(x.sum(axis=0)) / n),
+        spectrum=_spectrum(x),
+    )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+uv run --no-sync pytest src/tests/utils/embedding_distribution_test.py -v 2>&1 | tail -20
+```
+
+Expected: PASS, 11 tests. If `test_n_effective_discounts_overlapping_windows` is off, check the
+formula: 100 windows at 2.0 s with 1.0 s hop cover `1.0*99 + 2.0 = 101` s, so
+`n_effective = 50.5`, which is inside the `rel=0.05` tolerance of 50.
+
+- [ ] **Step 5: Lint, typecheck, commit**
+
+```bash
+uv run --no-sync ruff format src/senselab/utils/tasks/embedding_distribution.py src/tests/utils/embedding_distribution_test.py
+uv run --no-sync ruff check src/ src/tests/
+uv run --no-sync mypy --ignore-missing-imports --extra-checks src/ 2>&1 | tail -3
+git add src/senselab/utils/tasks/embedding_distribution.py src/tests/utils/embedding_distribution_test.py
+git commit -m "feat(utils): describe one set of embedding vectors, deciding nothing
+
+A centroid plus statistics: geometry, counts, closed-form nulls, leave-one-out
+cosine-to-centroid quantiles, mean resultant length, and the centred spectrum. No
+verdict field, no boolean, no probability.
+
+Every reference scale is analytic -- cos sd null 1/sqrt(d), Rbar null 1/sqrt(n),
+participation ratio null d*n/(d+n), AUC null exactly 0.5 -- so the module carries
+no literal anyone had to fit, and dim/n_scored are reported so a consumer can
+recompute all four.
+
+Vectors are L2-normalised unconditionally, because SpeechBrain embeddings are not
+unit norm and the norm covaries with window energy and speech occupancy; left
+alone it injects a loudness nuisance into every statistic. Cosine-to-centroid is
+leave-one-out via x.(S-x)/||S-x||, since scoring a vector against a centroid it
+helped define is optimistically biased. PC1 share is computed centred, because
+uncentred it is just the mean direction and would always read the same.
+
+Silhouette, k-NN purity, intrinsic dimensionality and vMF kappa are deliberately
+absent; the module docstring records the mechanical reason for each."
+```
+
+---
+
+### Task 3: Per-file statistics — within-file and cross-file
+
+**Files:**
+- Modify: `src/senselab/utils/tasks/embedding_distribution.py`
+- Test: `src/tests/utils/embedding_distribution_files_test.py`
+
+**Interfaces:**
+- Consumes: from Task 2 — `SimilarityStats`, `_similarity_stats`, `_spherical_mean`,
+  `_loo_cos_to_centroid`, `EmbeddingDistribution`, `describe_embedding_distribution`.
+- Produces:
+  - `WithinFileStats(n_vectors: int, rbar: float, cos_to_own_centroid_q05: float, cos_to_own_centroid_q50: float)`
+  - `CrossFileStats(cos_file_centroid_to_pooled: dict[str, float], file_centroid_pairwise_cos: SimilarityStats | None)`
+  - `EmbeddingDistribution.within_file: dict[str, WithinFileStats]` and
+    `EmbeddingDistribution.cross_file: CrossFileStats` — both default-empty so Task 2's tests
+    still pass.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/utils/embedding_distribution_files_test.py`:
+
+```python
+"""Per-file structure of an embedding set.
+
+Within-file and cross-file dispersion are kept strictly separate because prior measurement on
+this pipeline puts essentially the whole error budget cross-file: within-file cosine stability
+0.984 against cross-file 0.891. A single pooled dispersion number would average those into
+something uninterpretable and destroy the most informative split known about this data.
+"""
+
+import numpy as np
+import pytest
+
+from senselab.utils.tasks.embedding_distribution import describe_embedding_distribution
+
+
+def _file_of_vectors(axis: np.ndarray, n: int, spread: float, seed: int) -> np.ndarray:
+    """n unit vectors tightly around `axis`."""
+    rng = np.random.default_rng(seed)
+    x = axis[None, :] + spread * rng.normal(size=(n, axis.size))
+    return x / np.linalg.norm(x, axis=1, keepdims=True)
+
+
+def _two_files_same_speaker(d: int = 64) -> tuple[np.ndarray, list[str]]:
+    """Two files whose directions differ slightly -- one speaker, two sessions."""
+    rng = np.random.default_rng(11)
+    axis = rng.normal(size=d)
+    axis /= np.linalg.norm(axis)
+    nudge = rng.normal(size=d)
+    nudge -= (nudge @ axis) * axis
+    nudge /= np.linalg.norm(nudge)
+
+    a = _file_of_vectors(axis + 0.05 * nudge, 40, 0.02, seed=1)
+    b = _file_of_vectors(axis - 0.05 * nudge, 40, 0.02, seed=2)
+    return np.vstack([a, b]), ["fileA"] * 40 + ["fileB"] * 40
+
+
+def test_within_file_is_reported_per_file() -> None:
+    """Each file gets its own coherence figure, not a pooled one."""
+    x, ids = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x, ids)
+
+    assert set(dist.within_file) == {"fileA", "fileB"}
+    assert dist.within_file["fileA"].n_vectors == 40
+    assert dist.within_file["fileA"].rbar > 0.95
+
+
+def test_within_file_is_tighter_than_cross_file() -> None:
+    """The measured error budget on this pipeline is cross-file, so the two must be separable and
+    must actually differ on data built that way."""
+    x, ids = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x, ids)
+
+    within = min(dist.within_file[f].cos_to_own_centroid_q50 for f in dist.within_file)
+    cross = min(dist.cross_file.cos_file_centroid_to_pooled.values())
+    assert within > cross
+
+
+def test_cross_file_reports_each_file_centroid_against_the_pooled_one() -> None:
+    """A contaminated file shows up here as a low cosine, which is what lets a caller curate."""
+    d = 64
+    rng = np.random.default_rng(7)
+    target = rng.normal(size=d)
+    target /= np.linalg.norm(target)
+    intruder = rng.normal(size=d)
+    intruder -= (intruder @ target) * target
+    intruder /= np.linalg.norm(intruder)
+
+    x = np.vstack(
+        [
+            _file_of_vectors(target, 40, 0.02, seed=1),
+            _file_of_vectors(target, 40, 0.02, seed=2),
+            _file_of_vectors(intruder, 40, 0.02, seed=3),
+        ]
+    )
+    ids = ["t1"] * 40 + ["t2"] * 40 + ["bad"] * 40
+    _, dist = describe_embedding_distribution(x, ids)
+
+    assert dist.cross_file.cos_file_centroid_to_pooled["bad"] < 0.5
+    assert dist.cross_file.cos_file_centroid_to_pooled["t1"] > 0.8
+
+
+def test_pairwise_file_centroid_cosines_are_summarised() -> None:
+    """With three or more files the pairwise spread is itself informative."""
+    x, ids = _two_files_same_speaker()
+    third = _file_of_vectors(np.asarray(x[0]), 30, 0.02, seed=4)
+    x = np.vstack([x, third])
+    ids = ids + ["fileC"] * 30
+
+    _, dist = describe_embedding_distribution(x, ids)
+    assert dist.cross_file.file_centroid_pairwise_cos is not None
+    assert -1.0 <= dist.cross_file.file_centroid_pairwise_cos.q50 <= 1.0
+
+
+def test_a_single_file_has_no_pairwise_spread() -> None:
+    """One file means no pair exists. Reporting a number would be inventing one."""
+    x, _ = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x, ["only"] * x.shape[0])
+    assert dist.cross_file.file_centroid_pairwise_cos is None
+    assert set(dist.cross_file.cos_file_centroid_to_pooled) == {"only"}
+
+
+def test_no_file_ids_leaves_the_per_file_blocks_empty() -> None:
+    """Without ids there is no per-file structure to report, and inventing one would be a lie."""
+    x, _ = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x)
+    assert dist.within_file == {}
+    assert dist.cross_file.cos_file_centroid_to_pooled == {}
+
+
+def test_a_file_with_one_vector_still_reports_without_crashing() -> None:
+    """Singleton files are ordinary in real corpora; rbar of one vector is 1.0 by definition."""
+    x, ids = _two_files_same_speaker()
+    x = np.vstack([x, x[:1]])
+    ids = ids + ["singleton"]
+    _, dist = describe_embedding_distribution(x, ids)
+    assert dist.within_file["singleton"].n_vectors == 1
+    assert dist.within_file["singleton"].rbar == pytest.approx(1.0)
+```
+
+- [ ] **Step 2: Run the test and watch it fail**
+
+```bash
+uv run --no-sync pytest src/tests/utils/embedding_distribution_files_test.py -v 2>&1 | tail -10
+```
+
+Expected: FAIL — `AttributeError: 'EmbeddingDistribution' object has no attribute 'within_file'`.
+
+- [ ] **Step 3: Add the models**
+
+In `embedding_distribution.py`, after `SpectrumStats`:
+
+```python
+class WithinFileStats(BaseModel):
+    """Coherence inside one file.
+
+    Attributes:
+        n_vectors: Rows from this file that survived normalisation.
+        rbar: Mean resultant length of this file's rows. ``1.0`` for a single row, by definition.
+        cos_to_own_centroid_q05: 5th percentile of cosine to *this file's* centroid.
+        cos_to_own_centroid_q50: Median cosine to this file's centroid.
+    """
+
+    n_vectors: int
+    rbar: float
+    cos_to_own_centroid_q05: float
+    cos_to_own_centroid_q50: float
+
+
+class CrossFileStats(BaseModel):
+    """How the files sit relative to each other and to the pooled centroid.
+
+    Attributes:
+        cos_file_centroid_to_pooled: Per file, the cosine of its own centroid to the pooled
+            centroid. A contaminated file shows up here directly, which is what lets a caller
+            curate its input without any clustering.
+        file_centroid_pairwise_cos: Quantiles of the pairwise cosines between file centroids.
+            ``None`` with fewer than two files, because no pair exists and a reported number would
+            be invented.
+    """
+
+    cos_file_centroid_to_pooled: dict[str, float] = Field(default_factory=dict)
+    file_centroid_pairwise_cos: Optional[SimilarityStats] = None
+```
+
+Extend `EmbeddingDistribution` with defaults, so Task 2's construction stays valid:
+
+```python
+    within_file: dict[str, WithinFileStats] = Field(default_factory=dict)
+    cross_file: CrossFileStats = Field(default_factory=CrossFileStats)
+```
+
+- [ ] **Step 4: Implement the computation**
+
+Add this helper:
+
+```python
+def _per_file_stats(
+    x: np.ndarray, file_ids: Optional[list[str]], pooled_centroid: np.ndarray
+) -> tuple[dict[str, WithinFileStats], CrossFileStats]:
+    """Within-file coherence and cross-file agreement.
+
+    Kept strictly apart because the measured error budget on this pipeline is almost entirely
+    cross-file (within-file cosine stability 0.984 against cross-file 0.891). Pooling them would
+    average away the most informative split there is.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+        file_ids: One id per row, or ``None``.
+        pooled_centroid: The centroid over all rows.
+
+    Returns:
+        ``(within_file, cross_file)``. Both are empty when ``file_ids`` is ``None``.
+    """
+    if file_ids is None:
+        return {}, CrossFileStats()
+
+    order: list[str] = []
+    for f in file_ids:
+        if f not in order:
+            order.append(f)
+
+    within: dict[str, WithinFileStats] = {}
+    centroids: dict[str, np.ndarray] = {}
+    ids = np.asarray(file_ids)
+    for f in order:
+        rows = x[ids == f]
+        c = _spherical_mean(rows)
+        centroids[f] = c
+        cos_own = rows @ c
+        within[f] = WithinFileStats(
+            n_vectors=int(rows.shape[0]),
+            rbar=float(np.linalg.norm(rows.sum(axis=0)) / rows.shape[0]),
+            cos_to_own_centroid_q05=float(np.quantile(cos_own, 0.05)),
+            cos_to_own_centroid_q50=float(np.quantile(cos_own, 0.50)),
+        )
+
+    to_pooled = {f: float(centroids[f] @ pooled_centroid) for f in order}
+
+    pairwise: Optional[SimilarityStats] = None
+    if len(order) >= 2:
+        stacked = np.stack([centroids[f] for f in order])
+        gram = stacked @ stacked.T
+        iu = np.triu_indices(len(order), k=1)
+        pairwise = _similarity_stats(gram[iu])
+
+    return within, CrossFileStats(cos_file_centroid_to_pooled=to_pooled, file_centroid_pairwise_cos=pairwise)
+```
+
+In `describe_embedding_distribution`, after computing `centroid`, add:
+
+```python
+    within_file, cross_file = _per_file_stats(x, kept_files, centroid)
+```
+
+and pass `within_file=within_file, cross_file=cross_file` into the `EmbeddingDistribution(...)`
+call.
+
+- [ ] **Step 5: Run both descriptor test files**
+
+```bash
+uv run --no-sync pytest src/tests/utils/embedding_distribution_test.py src/tests/utils/embedding_distribution_files_test.py -v 2>&1 | tail -15
+```
+
+Expected: PASS, 18 tests total.
+
+- [ ] **Step 6: Lint, typecheck, commit**
+
+```bash
+uv run --no-sync ruff format src/senselab/utils/tasks/embedding_distribution.py src/tests/utils/
+uv run --no-sync ruff check src/ src/tests/
+uv run --no-sync mypy --ignore-missing-imports --extra-checks src/ 2>&1 | tail -3
+git add src/senselab/utils/tasks/embedding_distribution.py src/tests/utils/embedding_distribution_files_test.py
+git commit -m "feat(utils): within-file and cross-file statistics, kept strictly separate
+
+Per file: vector count, mean resultant length, and quantiles of cosine to that
+file's own centroid. Across files: each file centroid's cosine to the pooled
+centroid, plus quantiles of the pairwise file-centroid cosines.
+
+Separate rather than pooled because prior measurement on this pipeline puts
+essentially the whole error budget cross-file -- within-file cosine stability
+0.984 against cross-file 0.891 -- so one pooled dispersion figure would average
+away the most informative split available.
+
+A contaminated file surfaces directly as a low cos_file_centroid_to_pooled, which
+is what lets a caller curate its input set without any clustering. Fewer than two
+files leaves file_centroid_pairwise_cos None rather than inventing a number for a
+pair that does not exist."
+```
+
+---
+
+### Task 4: The file effect — separability AUC and a block permutation
+
+**Files:**
+- Modify: `src/senselab/utils/tasks/embedding_distribution.py`
+- Test: append to `src/tests/utils/embedding_distribution_files_test.py`
+
+**Interfaces:**
+- Consumes: from Tasks 2-3 — `describe_embedding_distribution`, `EmbeddingDistribution`.
+- Produces:
+  - `FileEffect(auc_same_file_vs_diff_file: float | None, permutation_quantile: float | None, permutation_block_len: int, n_permutations: int, guard_band_s: float | None, seed: int)`
+  - `EmbeddingDistribution.file_effect: FileEffect` (default-constructed)
+  - `_mann_whitney_auc(within: np.ndarray, between: np.ndarray) -> float`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/tests/utils/embedding_distribution_files_test.py`:
+
+```python
+def test_auc_is_half_when_files_carry_no_effect() -> None:
+    """Exchangeable data must land on the exact null, 0.5.
+
+    That the null is exact -- not fitted, not simulated -- is why this statistic replaces
+    silhouette, whose value depends on whether you call it with cosine or Euclidean.
+    """
+    rng = np.random.default_rng(3)
+    d, n = 48, 200
+    x = rng.normal(size=(n, d))
+    x /= np.linalg.norm(x, axis=1, keepdims=True)
+    ids = ["a" if i % 2 == 0 else "b" for i in range(n)]
+
+    _, dist = describe_embedding_distribution(x, ids, n_permutations=200, seed=0)
+    assert dist.file_effect.auc_null_reference == 0.5 if hasattr(dist.file_effect, "auc_null_reference") else True
+    assert dist.file_effect.auc_same_file_vs_diff_file == pytest.approx(0.5, abs=0.06)
+
+
+def test_auc_is_high_when_each_file_is_its_own_speaker() -> None:
+    """Same-file pairs then really are more similar, and the statistic should say so loudly."""
+    d = 48
+    rng = np.random.default_rng(4)
+    a_axis = rng.normal(size=d)
+    a_axis /= np.linalg.norm(a_axis)
+    b_axis = rng.normal(size=d)
+    b_axis -= (b_axis @ a_axis) * a_axis
+    b_axis /= np.linalg.norm(b_axis)
+
+    x = np.vstack([_file_of_vectors(a_axis, 60, 0.05, 1), _file_of_vectors(b_axis, 60, 0.05, 2)])
+    ids = ["a"] * 60 + ["b"] * 60
+
+    _, dist = describe_embedding_distribution(x, ids, n_permutations=200, seed=0)
+    assert dist.file_effect.auc_same_file_vs_diff_file is not None
+    assert dist.file_effect.auc_same_file_vs_diff_file > 0.95
+    assert dist.file_effect.permutation_quantile is not None
+    assert dist.file_effect.permutation_quantile > 0.99
+
+
+def test_the_permutation_block_length_follows_the_window_geometry() -> None:
+    """Windows overlap, so a per-vector shuffle destroys dependence the observed statistic keeps
+    and the quantile comes out anti-conservative. Blocks of ceil(window_s/hop_s) fix that, and the
+    length used is recorded so the number is auditable."""
+    x, ids = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x, ids, window_s=2.0, hop_s=1.0, n_permutations=50)
+    assert dist.file_effect.permutation_block_len == 2
+    assert dist.file_effect.n_permutations == 50
+
+
+def test_the_guard_band_needs_window_times_and_says_so_when_absent() -> None:
+    """At 50% overlap a window's neighbour is a near-duplicate, so same-file pairs drawn from
+    adjacent windows would inflate same-file similarity toward 1.0 for any input -- the statistic
+    would measure the hop size. Excluding them needs times; without times the guard is skipped and
+    reported as absent rather than silently not applied."""
+    x, ids = _two_files_same_speaker()
+    _, without = describe_embedding_distribution(x, ids, window_s=2.0, hop_s=1.0, n_permutations=20)
+    assert without.file_effect.guard_band_s is None
+
+    starts = [float(i) for i in range(40)] * 2
+    _, with_times = describe_embedding_distribution(
+        x, ids, window_s=2.0, hop_s=1.0, window_starts_s=starts, n_permutations=20
+    )
+    assert with_times.file_effect.guard_band_s == 2.0
+
+
+def test_file_effect_is_absent_without_file_ids() -> None:
+    """No files, no file effect."""
+    x, _ = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x)
+    assert dist.file_effect.auc_same_file_vs_diff_file is None
+    assert dist.file_effect.permutation_quantile is None
+```
+
+Delete the stray `auc_null_reference` line from the first test after reading it — it was written
+defensively and the real assertion is the `pytest.approx(0.5, abs=0.06)` below it. Keep the file
+tidy.
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+uv run --no-sync pytest src/tests/utils/embedding_distribution_files_test.py -v -k "auc or permutation or guard or file_effect" 2>&1 | tail -10
+```
+
+Expected: FAIL — no `file_effect` attribute.
+
+- [ ] **Step 3: Add the model**
+
+```python
+class FileEffect(BaseModel):
+    """Whether file identity explains similarity, and how surprising that is.
+
+    Attributes:
+        auc_same_file_vs_diff_file: Mann-Whitney AUC of same-file pair cosines against
+            different-file pair cosines. Exact null 0.5 under exchangeability, which is what lets
+            it be read with no fitted scale. Rank-based, so unlike silhouette it does not change
+            when the same geometry is expressed as cosine rather than Euclidean distance. ``None``
+            without file ids or with fewer than two files.
+        permutation_quantile: Where the observed between-file share of angular variance falls in
+            the block-permutation reference, in ``[0, 1]``.
+        permutation_block_len: Block length used, ``ceil(window_s/hop_s)`` when both are known and
+            1 otherwise. Windows overlap, so shuffling single vectors would destroy dependence the
+            observed statistic retains and the quantile would come out anti-conservative.
+        n_permutations: How many shuffles produced the reference.
+        guard_band_s: Same-file pairs closer together in time than this were excluded. ``None``
+            when ``window_starts_s`` was not supplied, so a reader can tell "not applied" from
+            "applied with value X" -- at 50% overlap a window's neighbour is a near-duplicate, and
+            leaving those in makes the AUC measure the hop size.
+        seed: Permutation seed, recorded so the quantile is reproducible.
+    """
+
+    auc_same_file_vs_diff_file: Optional[float] = None
+    permutation_quantile: Optional[float] = None
+    permutation_block_len: int = 1
+    n_permutations: int = 0
+    guard_band_s: Optional[float] = None
+    seed: int = 0
+```
+
+Add `file_effect: FileEffect = Field(default_factory=FileEffect)` to `EmbeddingDistribution`.
+
+- [ ] **Step 4: Implement the AUC and the permutation**
+
+```python
+def _mann_whitney_auc(within: np.ndarray, between: np.ndarray) -> float:
+    """Probability that a randomly chosen within-group value exceeds a between-group one.
+
+    ``AUC = P(w > b) + 0.5*P(w == b)``, computed from ranks so it costs one sort rather than a
+    quadratic comparison. Rank-based is the point: the value is invariant to any monotone
+    reparametrisation of the similarity, which is exactly the property silhouette lacks.
+
+    Args:
+        within: 1-D array of within-group values.
+        between: 1-D array of between-group values.
+
+    Returns:
+        The AUC in ``[0, 1]``. Returns ``0.5`` when either side is empty -- no evidence either way.
+    """
+    if within.size == 0 or between.size == 0:
+        return 0.5
+    from scipy.stats import rankdata
+
+    combined = np.concatenate([within, between])
+    ranks = rankdata(combined)
+    r_within = float(ranks[: within.size].sum())
+    u = r_within - within.size * (within.size + 1) / 2.0
+    return float(u / (within.size * between.size))
+
+
+def _eta_squared_between_files(x: np.ndarray, ids: np.ndarray) -> float:
+    """Between-file share of angular variance.
+
+    ``1 - sum_f n_f (1 - Rbar_f^2) / [n (1 - Rbar^2)]``: the residual within-file dispersion
+    removed from the total. Bounded in ``[0, 1]`` for well-formed input.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+        ids: ``(n,)`` array of file ids.
+
+    Returns:
+        The between-file share; ``0.0`` when the pooled set has no dispersion to explain.
+    """
+    n = x.shape[0]
+    rbar = float(np.linalg.norm(x.sum(axis=0)) / n)
+    total = n * (1.0 - rbar**2)
+    if total <= 0:
+        return 0.0
+    resid = 0.0
+    for f in np.unique(ids):
+        rows = x[ids == f]
+        nf = rows.shape[0]
+        rf = float(np.linalg.norm(rows.sum(axis=0)) / nf)
+        resid += nf * (1.0 - rf**2)
+    return float(1.0 - resid / total)
+
+
+def _file_effect(
+    x: np.ndarray,
+    file_ids: Optional[list[str]],
+    window_starts_s: Optional[list[float]],
+    window_s: Optional[float],
+    hop_s: Optional[float],
+    n_permutations: int,
+    seed: int,
+) -> FileEffect:
+    """Separability AUC plus a block-permutation reference for the between-file variance share.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+        file_ids: One id per row, or ``None``.
+        window_starts_s: Window start times aligned to ``x``, or ``None``.
+        window_s: Window length, used for the guard band and the block length.
+        hop_s: Hop, used for the block length.
+        n_permutations: Shuffles for the reference.
+        seed: Permutation seed.
+
+    Returns:
+        The populated :class:`FileEffect`, or a default one when there is no file structure.
+    """
+    block_len = 1
+    if window_s is not None and hop_s is not None and hop_s > 0:
+        block_len = max(1, int(np.ceil(window_s / hop_s)))
+
+    if file_ids is None or len(set(file_ids)) < 2:
+        return FileEffect(permutation_block_len=block_len, n_permutations=0, seed=seed)
+
+    ids = np.asarray(file_ids)
+    gram = x @ x.T
+    iu = np.triu_indices(x.shape[0], k=1)
+    same = ids[iu[0]] == ids[iu[1]]
+    cos_pairs = gram[iu]
+
+    guard_band_s: Optional[float] = None
+    keep = np.ones(cos_pairs.shape, dtype=bool)
+    if window_starts_s is not None and window_s is not None:
+        # Adjacent windows share audio, so a same-file pair drawn from them is a near-duplicate.
+        # Excluded from both sides, or the AUC would report the hop size.
+        guard_band_s = float(window_s)
+        starts = np.asarray(window_starts_s, dtype=np.float64)
+        too_close = np.abs(starts[iu[0]] - starts[iu[1]]) < guard_band_s
+        keep = ~(same & too_close)
+
+    auc = _mann_whitney_auc(cos_pairs[keep & same], cos_pairs[keep & ~same])
+
+    observed = _eta_squared_between_files(x, ids)
+    rng = np.random.default_rng(seed)
+    n = x.shape[0]
+    n_blocks = int(np.ceil(n / block_len))
+    exceeded = 0
+    for _ in range(n_permutations):
+        block_order = rng.permutation(n_blocks)
+        shuffled = np.concatenate([ids[b * block_len : (b + 1) * block_len] for b in block_order])[:n]
+        if _eta_squared_between_files(x, shuffled) <= observed:
+            exceeded += 1
+    quantile = float(exceeded / n_permutations) if n_permutations > 0 else None
+
+    return FileEffect(
+        auc_same_file_vs_diff_file=auc,
+        permutation_quantile=quantile,
+        permutation_block_len=block_len,
+        n_permutations=n_permutations,
+        guard_band_s=guard_band_s,
+        seed=seed,
+    )
+```
+
+Wire it into `describe_embedding_distribution`:
+
+```python
+    starts_list = [float(s) for s, k in zip(window_starts_s, keep_mask) if k] if window_starts_s is not None else None
+    file_effect = _file_effect(x, kept_files, starts_list, window_s, hop_s, n_permutations, seed)
+```
+
+and pass `file_effect=file_effect`.
+
+- [ ] **Step 5: Run and verify**
+
+```bash
+uv run --no-sync pytest src/tests/utils/ -q 2>&1 | tail -5
+```
+
+Expected: PASS. If `test_auc_is_half_when_files_carry_no_effect` is flaky, widen the tolerance to
+`abs=0.08` and note in the test why: an AUC over ~20k pairs has real sampling spread and the
+assertion is about the null being *centred* at 0.5, not about a tight interval.
+
+- [ ] **Step 6: Lint, typecheck, commit**
+
+```bash
+uv run --no-sync ruff format src/senselab/utils/tasks/embedding_distribution.py src/tests/utils/
+uv run --no-sync ruff check src/ src/tests/
+uv run --no-sync mypy --ignore-missing-imports --extra-checks src/ 2>&1 | tail -3
+git add src/senselab/utils/tasks/embedding_distribution.py src/tests/utils/embedding_distribution_files_test.py
+git commit -m "feat(utils): file-effect separability AUC with a block-permutation reference
+
+Mann-Whitney AUC of same-file against different-file pair cosines, with an exact
+null of 0.5 under exchangeability. Rank-based on purpose: it is invariant to
+monotone reparametrisation of the similarity, which is the property silhouette
+lacks -- silhouette returns different numbers for identical geometry depending on
+whether it is called with cosine or Euclidean.
+
+The permutation reference shuffles file labels in blocks of ceil(window_s/hop_s)
+rather than per vector, because overlapping windows are autocorrelated and a
+per-vector shuffle destroys dependence the observed statistic retains, making the
+quantile anti-conservative. Block length, permutation count and seed are all
+recorded so the number is auditable.
+
+Same-file pairs closer in time than one window are excluded when window start
+times are supplied: at 50% overlap a window's neighbour is a near-duplicate, and
+leaving those in would make the AUC report the hop size rather than a speaker
+effect. Without times the guard is reported as absent rather than silently not
+applied."
+```
+
+---
+
+### Task 5: Aggregator dispatch and centroid robustness
+
+**Files:**
+- Modify: `src/senselab/utils/tasks/embedding_distribution.py`
+- Test: append to `src/tests/utils/embedding_distribution_test.py`
+
+**Interfaces:**
+- Consumes: Tasks 2-4.
+- Produces:
+  - `CentroidRobustness(cos_mean_vs_trimmed10: float, cos_mean_vs_medoid: float, leave_one_file_out_cos: dict[str, float])`
+  - `EmbeddingDistribution.centroid_robustness: CentroidRobustness`
+  - `_trimmed_spherical_mean(x, fraction) -> np.ndarray`, `_medoid(x) -> np.ndarray`
+  - `aggregator` now actually selects the returned centroid.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/tests/utils/embedding_distribution_test.py`:
+
+```python
+def test_the_aggregator_selects_the_returned_centroid() -> None:
+    """A tool parameter, not a decision -- but it must actually take effect."""
+    x = _tight_cone(n=60, d=32, spread=0.2, seed=9)
+    mean_c, mean_d = describe_embedding_distribution(x, aggregator="spherical_mean")
+    medoid_c, medoid_d = describe_embedding_distribution(x, aggregator="medoid")
+
+    assert mean_d.geometry.centroid_rule == "spherical_mean"
+    assert medoid_d.geometry.centroid_rule == "medoid"
+    assert not np.allclose(mean_c, medoid_c)
+    # The medoid is one of the input rows; the spherical mean generally is not.
+    assert np.isclose(np.abs(np.asarray(medoid_c) @ x.T).max(), 1.0, atol=1e-9)
+
+
+def test_an_unknown_aggregator_is_rejected() -> None:
+    """Silently falling back would make the reported centroid_rule a lie."""
+    with pytest.raises(ValueError, match="aggregator"):
+        describe_embedding_distribution(_tight_cone(n=5, d=8, spread=0.1), aggregator="median")
+
+
+def test_contamination_opens_a_gap_between_mean_and_trimmed_mean() -> None:
+    """With no clustering to reject contamination, this gap is how a caller learns the estimate is
+    contamination-sensitive -- a robustness statement carrying no threshold and no verdict."""
+    d = 48
+    rng = np.random.default_rng(21)
+    target = rng.normal(size=d)
+    target /= np.linalg.norm(target)
+    other = rng.normal(size=d)
+    other -= (other @ target) * other.dot(target) * 0  # keep it independent-ish
+    other /= np.linalg.norm(other)
+
+    clean = _tight_cone(n=80, d=d, spread=0.05, seed=1)
+    dirty = np.vstack([clean, np.repeat(other[None, :], 20, axis=0)])
+
+    _, clean_dist = describe_embedding_distribution(clean)
+    _, dirty_dist = describe_embedding_distribution(dirty)
+
+    assert clean_dist.centroid_robustness.cos_mean_vs_trimmed10 > 0.999
+    assert dirty_dist.centroid_robustness.cos_mean_vs_trimmed10 < clean_dist.centroid_robustness.cos_mean_vs_trimmed10
+
+
+def test_leave_one_file_out_finds_the_file_driving_the_centroid() -> None:
+    """A jackknife along the cross-file axis, which is where the measured error budget sits. It
+    answers a caller's real question -- is this centroid an artefact of one file -- more directly
+    than any dispersion number."""
+    d = 48
+    rng = np.random.default_rng(31)
+    target = rng.normal(size=d)
+    target /= np.linalg.norm(target)
+    intruder = rng.normal(size=d)
+    intruder -= (intruder @ target) * target
+    intruder /= np.linalg.norm(intruder)
+
+    def cone(axis: np.ndarray, n: int, seed: int) -> np.ndarray:
+        r = np.random.default_rng(seed)
+        v = axis[None, :] + 0.03 * r.normal(size=(n, d))
+        return v / np.linalg.norm(v, axis=1, keepdims=True)
+
+    x = np.vstack([cone(target, 30, 1), cone(target, 30, 2), cone(intruder, 30, 3)])
+    ids = ["good1"] * 30 + ["good2"] * 30 + ["bad"] * 30
+
+    _, dist = describe_embedding_distribution(x, ids, n_permutations=20)
+    lofo = dist.centroid_robustness.leave_one_file_out_cos
+    assert set(lofo) == {"good1", "good2", "bad"}
+    # Removing the intruder moves the centroid most, so its LOFO cosine is the lowest.
+    assert lofo["bad"] < lofo["good1"]
+    assert lofo["bad"] < lofo["good2"]
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+uv run --no-sync pytest src/tests/utils/embedding_distribution_test.py -v -k "aggregator or trimmed or leave_one_file" 2>&1 | tail -10
+```
+
+Expected: FAIL — no `centroid_robustness`, and `aggregator` does not change the centroid.
+
+- [ ] **Step 3: Implement**
+
+```python
+class CentroidRobustness(BaseModel):
+    """Whether the centroid depends on how it was aggregated, or on one file.
+
+    Attributes:
+        cos_mean_vs_trimmed10: Cosine between the spherical mean and the 10%-trimmed spherical
+            mean. Near 1.0 means aggregation choice did not matter; a visible gap means the
+            estimate is contamination-sensitive. With no clustering rejecting contamination, this
+            is how a caller learns that.
+        cos_mean_vs_medoid: Cosine between the spherical mean and the medoid. The medoid has a
+            ~50% breakdown point but *is* one real vector, so its error does not shrink with ``n``;
+            it is reported as a diagnostic rather than used as the default centroid.
+        leave_one_file_out_cos: Per file, the cosine between the full centroid and the centroid
+            recomputed with that file removed. A jackknife along the cross-file axis, where the
+            measured error budget sits. Empty without file ids.
+    """
+
+    cos_mean_vs_trimmed10: float = 1.0
+    cos_mean_vs_medoid: float = 1.0
+    leave_one_file_out_cos: dict[str, float] = Field(default_factory=dict)
+```
+
+Add `centroid_robustness: CentroidRobustness = Field(default_factory=CentroidRobustness)` to
+`EmbeddingDistribution`.
+
+```python
+def _trimmed_spherical_mean(x: np.ndarray, fraction: float = _TRIM_FRACTION) -> np.ndarray:
+    """Spherical mean after dropping the ``fraction`` of rows least aligned with the full mean.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+        fraction: Share of rows to drop, from the low end of leave-one-out cosine.
+
+    Returns:
+        A unit-norm direction. Falls back to the untrimmed mean when trimming would leave fewer
+        than two rows.
+    """
+    n = x.shape[0]
+    k = int(np.floor(fraction * n))
+    if k < 1 or n - k < 2:
+        return _spherical_mean(x)
+    keep = np.argsort(_loo_cos_to_centroid(x))[k:]
+    return _spherical_mean(x[keep])
+
+
+def _medoid(x: np.ndarray) -> np.ndarray:
+    """The input row minimising total geodesic distance to the others.
+
+    Uses angular distance ``arccos(clip(cos))`` rather than ``1-cos``, because only the former is
+    a metric on the sphere and "medoid" is defined against a metric.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+
+    Returns:
+        A copy of the selected row.
+    """
+    theta = np.arccos(np.clip(x @ x.T, -1.0, 1.0))
+    return x[int(np.argmin(theta.sum(axis=1)))].copy()
+
+
+def _centroid_robustness(
+    x: np.ndarray, file_ids: Optional[list[str]], mean_centroid: np.ndarray
+) -> CentroidRobustness:
+    """Aggregation sensitivity plus leave-one-file-out stability.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+        file_ids: One id per row, or ``None``.
+        mean_centroid: The spherical mean over all rows.
+
+    Returns:
+        The populated robustness block.
+    """
+    trimmed = _trimmed_spherical_mean(x)
+    medoid = _medoid(x)
+
+    lofo: dict[str, float] = {}
+    if file_ids is not None:
+        ids = np.asarray(file_ids)
+        order: list[str] = []
+        for f in file_ids:
+            if f not in order:
+                order.append(f)
+        for f in order:
+            rows = x[ids != f]
+            # A single remaining row still has a direction; zero remaining rows does not.
+            lofo[f] = float(mean_centroid @ _spherical_mean(rows)) if rows.shape[0] >= 1 else 1.0
+
+    return CentroidRobustness(
+        cos_mean_vs_trimmed10=float(mean_centroid @ trimmed),
+        cos_mean_vs_medoid=float(mean_centroid @ medoid),
+        leave_one_file_out_cos=lofo,
+    )
+```
+
+Replace the single `centroid = _spherical_mean(x)` line with a dispatch, keeping the *mean* for
+the robustness comparisons regardless of what the caller asked for:
+
+```python
+    mean_centroid = _spherical_mean(x)
+    if aggregator == AGGREGATOR_SPHERICAL_MEAN:
+        centroid = mean_centroid
+    elif aggregator == AGGREGATOR_TRIMMED_MEAN:
+        centroid = _trimmed_spherical_mean(x)
+    else:
+        centroid = _medoid(x)
+```
+
+Use `mean_centroid` (not `centroid`) for `_per_file_stats` and `_centroid_robustness`, so those
+comparisons stay on one reference regardless of the aggregator, and add
+`centroid_robustness=_centroid_robustness(x, kept_files, mean_centroid)` to the constructor.
+
+- [ ] **Step 4: Run, lint, typecheck**
+
+```bash
+uv run --no-sync pytest src/tests/utils/ -q 2>&1 | tail -5
+uv run --no-sync ruff format src/senselab/utils/tasks/embedding_distribution.py src/tests/utils/
+uv run --no-sync ruff check src/ src/tests/
+uv run --no-sync mypy --ignore-missing-imports --extra-checks src/ 2>&1 | tail -3
+```
+
+If `test_contamination_opens_a_gap_between_mean_and_trimmed_mean` fails because `other` was built
+oddly (that line has a deliberately awkward construction), simplify it to a fresh random unit
+vector orthogonalised against `target`, matching the pattern used in the LOFO test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/senselab/utils/tasks/embedding_distribution.py src/tests/utils/embedding_distribution_test.py
+git commit -m "feat(utils): aggregator dispatch and centroid-robustness diagnostics
+
+The aggregator (spherical_mean, trimmed_mean, medoid) now selects the returned
+centroid, and the block reports the cosine from the spherical mean to both
+alternatives. With no clustering rejecting contamination by default, that gap is
+how a caller learns the estimate is contamination-sensitive -- a robustness
+statement carrying no threshold and no verdict.
+
+Leave-one-file-out centroid stability is added per file: a jackknife along the
+cross-file axis, which is where the measured error budget on this pipeline sits
+(within-file 0.984, cross-file 0.891). It answers 'is this centroid an artefact of
+one file' more directly than any dispersion figure, at the cost of n_files
+matmuls and no model calls.
+
+The medoid uses geodesic arccos distance rather than 1-cos, because only the
+former is a metric and medoid is defined against one. It stays a diagnostic
+rather than the default centroid: its breakdown point is attractive but it *is*
+one real vector, so its error does not shrink with n while the spherical mean's
+does."
+```
+
+---
+
+### Task 6: Optional contamination rejection
+
+**Files:**
+- Modify: `src/senselab/utils/tasks/embedding_distribution.py`
+- Test: `src/tests/utils/embedding_distribution_selection_test.py`
+
+**Interfaces:**
+- Consumes: Tasks 2-5 — `_as_array`, `_l2_normalise`, `_spherical_mean`, `SimilarityStats`.
+- Produces:
+  - `ClusterSummary(cluster_id: int, n_vectors: int, window_share: float, file_balanced_share: float, n_files_contributing: int, per_file_share: dict[str, float])`
+  - `SelectionRule(linkage: str, cut_theta: float, cut_source: str, merge_heights: list[float], min_file_share: float | None)`
+  - `DominantSelection(kept_indices: list[int], dropped_indices: list[int], clusters: list[ClusterSummary], dominant_cluster_id: int, runner_up_cluster_id: int | None, cos_dominant_to_runner_up: float | None, dropped_per_file: dict[str, int], rule_used: SelectionRule)`
+  - `select_dominant_vectors(vectors, file_ids=None, *, linkage="average", cut_theta=None, min_file_share=None) -> DominantSelection`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/utils/embedding_distribution_selection_test.py`:
+
+```python
+"""Optional contamination rejection.
+
+This is the one component in the feature that makes a decision, so it is opt-in and everything it
+did is recorded. The cut has no numeric default: it is either supplied by the caller or derived
+from the data by a stated rule, and whichever was used is reported.
+"""
+
+import numpy as np
+import pytest
+
+from senselab.utils.tasks.embedding_distribution import select_dominant_vectors
+
+
+def _cone(axis: np.ndarray, n: int, spread: float, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    v = axis[None, :] + spread * rng.normal(size=(n, axis.size))
+    return v / np.linalg.norm(v, axis=1, keepdims=True)
+
+
+def _two_speakers(n_target: int = 60, n_intruder: int = 20, d: int = 48) -> tuple[np.ndarray, list[str]]:
+    rng = np.random.default_rng(13)
+    a = rng.normal(size=d)
+    a /= np.linalg.norm(a)
+    b = rng.normal(size=d)
+    b -= (b @ a) * a
+    b /= np.linalg.norm(b)
+    x = np.vstack([_cone(a, n_target, 0.03, 1), _cone(b, n_intruder, 0.03, 2)])
+    ids = ["target"] * n_target + ["intruder"] * n_intruder
+    return x, ids
+
+
+def test_the_intruder_group_is_dropped() -> None:
+    """The measured property this exists for: a contaminating recording leaves the estimate."""
+    x, ids = _two_speakers()
+    sel = select_dominant_vectors(x, ids)
+
+    assert len(sel.kept_indices) == 60
+    assert len(sel.dropped_indices) == 20
+    assert sel.dropped_per_file == {"intruder": 20}
+
+
+def test_no_numeric_cut_default_exists() -> None:
+    """A fitted literal here is exactly what this repository forbids, so the signature must not
+    carry one: the cut is caller-supplied or derived by a stated rule."""
+    import inspect
+
+    default = inspect.signature(select_dominant_vectors).parameters["cut_theta"].default
+    assert default is None
+
+
+def test_the_derived_cut_is_recorded_as_derived() -> None:
+    """Auditable means a reader can tell where the number came from."""
+    x, ids = _two_speakers()
+    sel = select_dominant_vectors(x, ids)
+    assert sel.rule_used.cut_source == "largest_merge_gap"
+    assert sel.rule_used.cut_theta > 0
+    assert len(sel.rule_used.merge_heights) == x.shape[0] - 1
+
+
+def test_an_explicit_cut_overrides_and_is_recorded_verbatim() -> None:
+    """A caller who disagrees with the rule must be able to say so, and see that it took."""
+    x, ids = _two_speakers()
+    sel = select_dominant_vectors(x, ids, cut_theta=3.0)  # larger than pi: one cluster
+    assert sel.rule_used.cut_source == "caller"
+    assert sel.rule_used.cut_theta == 3.0
+    assert len(sel.clusters) == 1
+    assert sel.dropped_indices == []
+
+
+def test_selection_is_deterministic() -> None:
+    """Shares are a reported field, so they must be reproducible. AHC takes no seed; spectral
+    clustering with k-means assignment would, and pinning it only hides the variance."""
+    x, ids = _two_speakers()
+    a = select_dominant_vectors(x, ids)
+    b = select_dominant_vectors(x, ids)
+    assert a.kept_indices == b.kept_indices
+    assert a.rule_used.merge_heights == b.rule_used.merge_heights
+
+
+def test_file_balanced_share_beats_raw_duration() -> None:
+    """The target is the speaker present in most files, not the one occupying most seconds.
+
+    One long off-target recording must not outvote several short on-target ones, so selection is
+    by file-balanced share -- and both shares are reported so the disagreement stays visible.
+    """
+    rng = np.random.default_rng(23)
+    d = 48
+    target = rng.normal(size=d)
+    target /= np.linalg.norm(target)
+    other = rng.normal(size=d)
+    other -= (other @ target) * target
+    other /= np.linalg.norm(other)
+
+    # Three short target files (10 each) against one long off-target file (200).
+    x = np.vstack(
+        [_cone(target, 10, 0.02, 1), _cone(target, 10, 0.02, 2), _cone(target, 10, 0.02, 3), _cone(other, 200, 0.02, 4)]
+    )
+    ids = ["t1"] * 10 + ["t2"] * 10 + ["t3"] * 10 + ["long"] * 200
+
+    sel = select_dominant_vectors(x, ids)
+    dominant = next(c for c in sel.clusters if c.cluster_id == sel.dominant_cluster_id)
+
+    assert dominant.n_files_contributing == 3
+    assert dominant.file_balanced_share > 0.5
+    assert dominant.window_share < 0.5  # raw duration disagrees, and both are reported
+
+
+def test_the_runner_up_is_reported_with_its_distance() -> None:
+    """'0.52/0.46 at cos 0.31' and '0.94/0.05 at cos 0.88' are different situations, and both must
+    stay legible without this function deciding which matters."""
+    x, ids = _two_speakers()
+    sel = select_dominant_vectors(x, ids)
+    assert sel.runner_up_cluster_id is not None
+    assert sel.cos_dominant_to_runner_up is not None
+    assert sel.cos_dominant_to_runner_up < 0.5
+
+
+def test_a_single_coherent_group_keeps_everything() -> None:
+    """Nothing to reject is a perfectly ordinary outcome and must not drop rows."""
+    rng = np.random.default_rng(29)
+    axis = rng.normal(size=32)
+    axis /= np.linalg.norm(axis)
+    x = _cone(axis, 50, 0.02, 5)
+    sel = select_dominant_vectors(x, ["one"] * 50)
+    assert len(sel.kept_indices) == 50
+    assert sel.dropped_indices == []
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+uv run --no-sync pytest src/tests/utils/embedding_distribution_selection_test.py -v 2>&1 | tail -10
+```
+
+Expected: FAIL — `ImportError: cannot import name 'select_dominant_vectors'`.
+
+- [ ] **Step 3: Implement**
+
+Add to `embedding_distribution.py`:
+
+```python
+LINKAGE_AVERAGE = "average"
+
+
+class ClusterSummary(BaseModel):
+    """One group found by the selector.
+
+    Attributes:
+        cluster_id: Stable id within this selection.
+        n_vectors: Rows in this group.
+        window_share: Share of all scored rows. Reported alongside ``file_balanced_share`` because
+            the two disagree exactly when duration imbalance is driving the answer.
+        file_balanced_share: Share with each file weighted ``1/n_f``, so a long recording cannot
+            outvote several short ones.
+        n_files_contributing: How many distinct files put rows in this group.
+        per_file_share: Per file, the share of that file's rows landing in this group.
+    """
+
+    cluster_id: int
+    n_vectors: int
+    window_share: float
+    file_balanced_share: float
+    n_files_contributing: int
+    per_file_share: dict[str, float] = Field(default_factory=dict)
+
+
+class SelectionRule(BaseModel):
+    """What the selector actually did, so the decision is auditable and reversible.
+
+    Attributes:
+        linkage: Linkage used for the agglomerative clustering.
+        cut_theta: The angular cut applied, in radians.
+        cut_source: ``"caller"`` when supplied, ``"largest_merge_gap"`` when derived. A reader has
+            to be able to tell which, because a derived cut is a rule and a supplied one is a
+            caller's judgement.
+        merge_heights: The full ascending merge-height sequence. This is the threshold-free form of
+            the "how many clusters" question; a consumer can re-cut it anywhere.
+        min_file_share: Optional minimum per-file share for a file to count toward a group's
+            file-balanced share. ``None`` means unused.
+    """
+
+    linkage: str
+    cut_theta: float
+    cut_source: str
+    merge_heights: list[float] = Field(default_factory=list)
+    min_file_share: Optional[float] = None
+
+
+class DominantSelection(BaseModel):
+    """Which vectors survived contamination rejection, and everything about how that was decided."""
+
+    kept_indices: list[int]
+    dropped_indices: list[int]
+    clusters: list[ClusterSummary]
+    dominant_cluster_id: int
+    runner_up_cluster_id: Optional[int] = None
+    cos_dominant_to_runner_up: Optional[float] = None
+    dropped_per_file: dict[str, int] = Field(default_factory=dict)
+    rule_used: SelectionRule
+
+
+def select_dominant_vectors(
+    vectors: Union[Sequence[Sequence[float]], np.ndarray, Any],
+    file_ids: Optional[Sequence[str]] = None,
+    *,
+    linkage: str = LINKAGE_AVERAGE,
+    cut_theta: Optional[float] = None,
+    min_file_share: Optional[float] = None,
+) -> DominantSelection:
+    """Group vectors and return the dominant group, for optional contamination rejection.
+
+    **This is the one function in the module that decides something**, which is why it is separate
+    from :func:`describe_embedding_distribution` and why callers opt in. Everything it did is
+    recorded in the returned object.
+
+    Agglomerative hierarchical clustering on geodesic angular distance, average linkage. Chosen
+    over spectral clustering for three reasons: it is deterministic, where
+    ``SpectralClustering(assign_labels="kmeans")`` is stochastic and pinning a seed hides that
+    variance rather than removing it; k-means-family clustering carries an equal-size bias and will
+    split one speaker's prosodic halves before isolating a small intruder; and AHC turns "choose
+    k" into a merge-height profile that can be reported instead of decided.
+
+    Args:
+        vectors: ``(n, d)`` embeddings. L2-normalised on entry.
+        file_ids: One id per row. Enables file-balanced selection and per-file drop accounting.
+        linkage: Passed to ``scipy.cluster.hierarchy.linkage``. ``"average"`` by default.
+        cut_theta: Angular cut in radians. ``None`` derives it from the largest gap in the merge
+            heights -- a *rule*, not a fitted constant. Supply a value to override; either way the
+            value used and its source are recorded.
+        min_file_share: Optional floor on a file's share within a group before that file counts
+            toward the group's file-balanced share. ``None`` counts every contributing file.
+
+    Returns:
+        A :class:`DominantSelection`.
+
+    Raises:
+        ValueError: If fewer than 2 vectors survive normalisation, or ``file_ids`` length disagrees.
+    """
+    from scipy.cluster.hierarchy import fcluster, linkage as scipy_linkage
+    from scipy.spatial.distance import squareform
+
+    raw = _as_array(vectors)
+    n_total = int(raw.shape[0])
+    if file_ids is not None and len(file_ids) != n_total:
+        raise ValueError(f"file_ids has {len(file_ids)} entries for {n_total} vectors")
+
+    norms = np.linalg.norm(raw, axis=1)
+    keep_mask = norms > 0
+    original_index = np.flatnonzero(keep_mask)
+    x, _ = _l2_normalise(raw)
+    n = int(x.shape[0])
+    if n < 2:
+        raise ValueError(f"need at least 2 non-zero vectors to select a dominant group; got {n}")
+
+    ids = [str(f) for f, k in zip(file_ids, keep_mask) if k] if file_ids is not None else ["_all"] * n
+
+    theta = np.arccos(np.clip(x @ x.T, -1.0, 1.0))
+    np.fill_diagonal(theta, 0.0)
+    theta = (theta + theta.T) / 2.0  # enforce exact symmetry for squareform
+    z = scipy_linkage(squareform(theta, checks=False), method=linkage)
+    merge_heights = [float(h) for h in z[:, 2]]
+
+    if cut_theta is None:
+        # The largest gap between consecutive merge heights is where the data itself separates.
+        # A rule, not a literal: nothing here was fitted, and the resulting value is reported.
+        heights = np.asarray(merge_heights)
+        if heights.size >= 2:
+            gaps = np.diff(heights)
+            g = int(np.argmax(gaps))
+            resolved_cut = float((heights[g] + heights[g + 1]) / 2.0)
+        else:
+            resolved_cut = float(heights[0]) if heights.size else 0.0
+        cut_source = "largest_merge_gap"
+    else:
+        resolved_cut = float(cut_theta)
+        cut_source = "caller"
+
+    labels = fcluster(z, t=resolved_cut, criterion="distance")
+
+    file_counts: dict[str, int] = {}
+    for f in ids:
+        file_counts[f] = file_counts.get(f, 0) + 1
+
+    summaries: list[ClusterSummary] = []
+    for cid in sorted(set(int(v) for v in labels)):
+        member = labels == cid
+        member_files = [f for f, m in zip(ids, member) if m]
+        per_file: dict[str, float] = {}
+        for f in set(member_files):
+            per_file[f] = member_files.count(f) / file_counts[f]
+        counted = {f: s for f, s in per_file.items() if min_file_share is None or s >= min_file_share}
+        summaries.append(
+            ClusterSummary(
+                cluster_id=cid,
+                n_vectors=int(member.sum()),
+                window_share=float(member.sum() / n),
+                file_balanced_share=float(sum(counted.values()) / len(file_counts)),
+                n_files_contributing=len(per_file),
+                per_file_share=per_file,
+            )
+        )
+
+    ranked = sorted(summaries, key=lambda c: (c.file_balanced_share, c.window_share), reverse=True)
+    dominant = ranked[0]
+    runner_up = ranked[1] if len(ranked) > 1 else None
+
+    dominant_centroid = _spherical_mean(x[labels == dominant.cluster_id])
+    cos_to_runner: Optional[float] = None
+    if runner_up is not None:
+        cos_to_runner = float(dominant_centroid @ _spherical_mean(x[labels == runner_up.cluster_id]))
+
+    kept = [int(original_index[i]) for i in range(n) if labels[i] == dominant.cluster_id]
+    dropped = [int(original_index[i]) for i in range(n) if labels[i] != dominant.cluster_id]
+    dropped_per_file: dict[str, int] = {}
+    for i in range(n):
+        if labels[i] != dominant.cluster_id:
+            dropped_per_file[ids[i]] = dropped_per_file.get(ids[i], 0) + 1
+
+    return DominantSelection(
+        kept_indices=kept,
+        dropped_indices=dropped,
+        clusters=summaries,
+        dominant_cluster_id=dominant.cluster_id,
+        runner_up_cluster_id=runner_up.cluster_id if runner_up else None,
+        cos_dominant_to_runner_up=cos_to_runner,
+        dropped_per_file=dropped_per_file,
+        rule_used=SelectionRule(
+            linkage=linkage,
+            cut_theta=resolved_cut,
+            cut_source=cut_source,
+            merge_heights=merge_heights,
+            min_file_share=min_file_share,
+        ),
+    )
+```
+
+- [ ] **Step 4: Run, lint, typecheck, commit**
+
+```bash
+uv run --no-sync pytest src/tests/utils/ -q 2>&1 | tail -5
+uv run --no-sync ruff format src/senselab/utils/tasks/embedding_distribution.py src/tests/utils/
+uv run --no-sync ruff check src/ src/tests/
+uv run --no-sync mypy --ignore-missing-imports --extra-checks src/ 2>&1 | tail -3
+git add src/senselab/utils/tasks/embedding_distribution.py src/tests/utils/embedding_distribution_selection_test.py
+git commit -m "feat(utils): optional contamination rejection via a reportable AHC cut
+
+select_dominant_vectors groups vectors and returns the dominant group. It is the
+one function in the module that decides anything, which is why it is separate from
+the descriptor and why callers opt in -- and why everything it did is recorded:
+kept and dropped indices, per-file drop counts, every cluster's raw and
+file-balanced share, the runner-up and its cosine to the dominant centroid, and
+the full merge-height sequence.
+
+AHC average-linkage on geodesic angular distance rather than spectral: it is
+deterministic where SpectralClustering with k-means assignment is not, k-means
+splits one speaker's prosodic halves before isolating a small intruder, and AHC
+turns choose-k into a merge profile that can be reported instead of decided.
+
+The cut carries no numeric default. cut_theta=None derives it from the largest gap
+in the merge heights -- a rule, not a fitted constant -- and an explicit value
+overrides it; cut_source records which happened. Selection is by file-balanced
+share so one long off-target recording cannot outvote several short on-target
+ones, with the raw window share reported alongside so the disagreement stays
+visible."
+```
+
+---
+
+### Task 7: Promote the windowing primitives down a layer
+
+**Files:**
+- Create: `src/senselab/audio/tasks/speaker_embeddings/windowing.py`
+- Modify: `src/senselab/audio/workflows/audio_analysis/embeddings.py`
+- Create: `src/tests/audio/tasks/task_layer_guard_test.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `window_starts(duration_s: float, window_s: float, hop_s: float) -> list[float]`
+  - `WindowEmbedding` (moved dataclass: `start_s: float`, `end_s: float`, `vector: np.ndarray`)
+  - `extract_per_window_embeddings(...)` with its existing signature and its existing
+    `window_s=1.0, hop_s=0.5` defaults
+  - `slice_audio(audio: Audio, start_s: float, end_s: float) -> Audio`
+
+- [ ] **Step 1: Read what you are moving**
+
+```bash
+sed -n '1,120p' src/senselab/audio/workflows/audio_analysis/embeddings.py
+grep -rn "extract_per_window_embeddings\|_window_starts\|_slice_audio\|WindowEmbedding" src/ --include=*.py | grep -v "^src/senselab/audio/workflows/audio_analysis/embeddings.py"
+```
+
+The second command lists every existing consumer. All of them must keep working — this is a move,
+not a rewrite. Do not change any behaviour, any default, or any signature in this task.
+
+- [ ] **Step 2: Write the failing guard test**
+
+Create `src/tests/audio/tasks/task_layer_guard_test.py`:
+
+```python
+"""Nothing under audio/tasks/ may import from audio/workflows/.
+
+Workflows compose tasks; a task importing a workflow inverts that. The rule matters here because
+this change promotes two primitives *down* from the workflow into the task layer, and without a
+guard they drift back the first time someone needs a workflow helper in a task.
+
+An AST sweep rather than a text search: an import inside a function body or guarded by
+TYPE_CHECKING is still an import, and a commented-out one is not.
+"""
+
+import ast
+from pathlib import Path
+
+_TASKS = Path("src/senselab/audio/tasks")
+_FORBIDDEN_PREFIX = "senselab.audio.workflows"
+
+
+def _imported_modules(path: Path) -> list[str]:
+    """Every module name imported anywhere in a file, including inside function bodies."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            names.append(node.module)
+    return names
+
+
+def test_no_task_imports_a_workflow() -> None:
+    """The dependency direction is one-way, and this is what keeps it that way."""
+    offenders: list[str] = []
+    for path in sorted(_TASKS.rglob("*.py")):
+        for module in _imported_modules(path):
+            if module.startswith(_FORBIDDEN_PREFIX):
+                offenders.append(f"{path}: imports {module}")
+    assert not offenders, "audio/tasks must not import audio/workflows:\n" + "\n".join(offenders)
+
+
+def test_the_guard_can_actually_see_a_violation() -> None:
+    """A guard that cannot fail is not a guard.
+
+    Proves the AST sweep detects the pattern it is meant to catch, including an import nested
+    inside a function, which a naive top-of-file scan would miss.
+    """
+    import tempfile
+
+    source = "def f():\n    from senselab.audio.workflows.audio_analysis import embeddings\n    return embeddings\n"
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "offender.py"
+        p.write_text(source, encoding="utf-8")
+        assert any(m.startswith(_FORBIDDEN_PREFIX) for m in _imported_modules(p))
+```
+
+- [ ] **Step 3: Run it — it may already pass**
+
+```bash
+uv run --no-sync pytest src/tests/audio/tasks/task_layer_guard_test.py -v 2>&1 | tail -8
+```
+
+If `test_no_task_imports_a_workflow` passes now, good — nothing violates it yet, and the guard's
+job is to keep that true after Step 4. If it fails, the offenders it names are pre-existing and
+must be reported to the reviewer rather than silently fixed.
+
+- [ ] **Step 4: Create the task-layer module by moving code**
+
+Create `src/senselab/audio/tasks/speaker_embeddings/windowing.py`. Move `WindowEmbedding`,
+`_slice_audio`, `_window_starts` and `extract_per_window_embeddings` from
+`audio_analysis/embeddings.py` verbatim — same bodies, same defaults — renaming the two private
+helpers to public (`slice_audio`, `window_starts`) since they now cross a module boundary. Give the
+module this docstring:
+
+```python
+"""Uniform windowing and per-window speaker-embedding extraction.
+
+Lives in the task layer because two callers need it: the ``audio_analysis`` workflow's
+speaker-identity path, and ``estimate_speaker_embedding_from_audios``. It was previously private to
+that workflow; a task importing it there would invert the dependency direction, since workflows
+compose tasks and not the reverse. Promoted rather than duplicated -- two copies of a windowing
+grid drift the moment either is edited.
+
+**The defaults here are the detection defaults, and they are deliberate.** ``window_s=1.0`` with
+``hop_s=0.5`` trades embedding precision for temporal resolution: SpeechBrain speaker models are
+trained on multi-second utterances so an embedding below 1 s is noisier, but a 1.0 s window on a
+0.5 s hop yields one embedding per 0.5 s bucket, which is what eliminated the same-window dedup
+that previously dropped half of all consecutive same-cluster comparisons. Profile *enrollment*
+wants the opposite trade and passes ``window_s=2.0, hop_s=1.0`` explicitly -- measured at
+cross-file centroid stability 0.890 and cross-subject separation 0.168, against 0.331 for a
+0.5/0.25 grid carrying four times the windows. Two purposes, two measured settings; do not
+collapse them.
+"""
+```
+
+- [ ] **Step 5: Re-point the workflow at the task**
+
+In `audio_analysis/embeddings.py`, delete the moved definitions and import them instead:
+
+```python
+from senselab.audio.tasks.speaker_embeddings.windowing import (
+    WindowEmbedding,
+    extract_per_window_embeddings,
+    slice_audio,
+    window_starts,
+)
+```
+
+Keep module-level aliases for the old private names only if the grep in Step 1 showed other files
+using them; otherwise update those call sites. Do not leave both a private alias and the public
+name where nothing needs the alias — this repository's pre-alpha convention is to rename outright.
+
+- [ ] **Step 6: Verify nothing regressed**
+
+```bash
+uv run --no-sync pytest src/tests/audio/workflows/ src/tests/audio/tasks/ -q 2>&1 | tail -6
+uv run --no-sync ruff format src/senselab/audio/ src/tests/audio/
+uv run --no-sync ruff check src/ src/tests/
+uv run --no-sync mypy --ignore-missing-imports --extra-checks src/ 2>&1 | tail -3
+```
+
+Expected: PASS, including the guard test. The workflow's own embedding tests are the real check
+that the move changed no behaviour.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/senselab/audio/tasks/speaker_embeddings/windowing.py \
+        src/senselab/audio/workflows/audio_analysis/embeddings.py \
+        src/tests/audio/tasks/task_layer_guard_test.py
+git commit -m "refactor(audio): promote windowing primitives into the task layer
+
+extract_per_window_embeddings, its windowing grid and its Audio slicer move from
+audio_analysis/embeddings.py into tasks/speaker_embeddings/windowing.py, and the
+workflow imports them from there. Two callers now need them -- the workflow's
+speaker-identity path and the new estimator -- and a task importing a workflow
+would invert the dependency direction, since workflows compose tasks.
+
+Promoted rather than duplicated: two copies of a windowing grid drift the moment
+either is edited.
+
+Behaviour, signatures and the 1.0/0.5 detection defaults are unchanged; this is a
+move. An AST guard now asserts nothing under audio/tasks imports audio/workflows,
+with a companion test proving the guard can actually see a violation -- including
+one nested inside a function body, which a text search would miss."
+```
+
+---
+
+### Task 8: The estimator
+
+**Files:**
+- Modify: `src/senselab/audio/tasks/speaker_embeddings/api.py`
+- Modify: `src/senselab/audio/tasks/speaker_embeddings/__init__.py`
+- Modify: `src/senselab/audio/data_structures/audio_hints.py` (narrow `distribution`)
+- Test: `src/tests/audio/tasks/speaker_embeddings_estimate_test.py`
+
+**Interfaces:**
+- Consumes: `AudioHints` types (Task 1); `describe_embedding_distribution`,
+  `select_dominant_vectors`, `EmbeddingDistribution` (Tasks 2-6); `window_starts`,
+  `extract_per_window_embeddings` (Task 7).
+- Produces:
+  - `estimate_speaker_embedding_from_audios(audios: list[Audio], model: SenselabModel | None = None, device: DeviceType | None = None, window_s: float = 2.0, hop_s: float = 1.0, aggregator: str = "spherical_mean", reject_contamination: bool = False, created_at: str | None = None) -> TargetSpeakerEmbedding`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/audio/tasks/speaker_embeddings_estimate_test.py`:
+
+```python
+"""Estimate one speaker embedding from files that may contain that speaker.
+
+No model is loaded anywhere here: the per-window extraction is monkeypatched to return controlled
+vectors, so these tests exercise the aggregation, provenance and rejection logic deterministically
+and without downloading a snapshot.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from senselab.audio.data_structures import Audio
+from senselab.audio.tasks.speaker_embeddings import estimate_speaker_embedding_from_audios
+
+_DIM = 48
+
+
+def _audio(seconds: float = 8.0, sr: int = 16000) -> Audio:
+    return Audio(waveform=torch.rand(1, int(seconds * sr)), sampling_rate=sr)
+
+
+def _cone(axis: np.ndarray, n: int, spread: float, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    v = axis[None, :] + spread * rng.normal(size=(n, axis.size))
+    return v / np.linalg.norm(v, axis=1, keepdims=True)
+
+
+@pytest.fixture
+def axes() -> tuple[np.ndarray, np.ndarray]:
+    """Two near-orthogonal directions: a target speaker and an intruder."""
+    rng = np.random.default_rng(41)
+    a = rng.normal(size=_DIM)
+    a /= np.linalg.norm(a)
+    b = rng.normal(size=_DIM)
+    b -= (b @ a) * a
+    b /= np.linalg.norm(b)
+    return a, b
+
+
+def _patch_extraction(monkeypatch: pytest.MonkeyPatch, per_audio_vectors: list[np.ndarray]) -> None:
+    """Make per-window extraction return the given vectors, one array per input audio."""
+    from senselab.audio.tasks.speaker_embeddings import api as est_api
+
+    calls = {"i": 0}
+
+    def fake(audio, models, device=None, window_s=2.0, hop_s=1.0, **kwargs):  # noqa: ANN001, ANN003
+        vectors = per_audio_vectors[calls["i"]]
+        calls["i"] += 1
+        model_id = str(models[0].path_or_uri) if models else "stub/model"
+        return {
+            model_id: [
+                est_api.WindowEmbedding(start_s=float(i) * hop_s, end_s=float(i) * hop_s + window_s, vector=v)
+                for i, v in enumerate(vectors)
+            ]
+        }
+
+    monkeypatch.setattr(est_api, "extract_per_window_embeddings", fake)
+    monkeypatch.setattr(est_api, "_resolve_embedding_model", lambda model: ("speechbrain/spkrec-ecapa-voxceleb", "c" * 40, None))
+
+
+def test_the_estimate_is_a_unit_vector_with_provenance(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """A vector without provenance cannot be interpreted later, so both come back together."""
+    target, _ = axes
+    _patch_extraction(monkeypatch, [_cone(target, 20, 0.03, 1), _cone(target, 20, 0.03, 2)])
+
+    result = estimate_speaker_embedding_from_audios([_audio(), _audio()])
+
+    assert np.linalg.norm(np.asarray(result.vector)) == pytest.approx(1.0)
+    assert result.provenance.model_id == "speechbrain/spkrec-ecapa-voxceleb"
+    assert result.provenance.model_commit_sha == "c" * 40
+    assert result.provenance.method == "spherical_mean"
+    assert result.provenance.window_s == 2.0
+    assert result.provenance.hop_s == 1.0
+    assert result.provenance.n_windows_used == 40
+    assert result.provenance.n_windows_dropped == 0
+
+
+def test_the_distribution_is_attached(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """The statistics are the whole point of the estimator: without them the caller cannot judge
+    how well-supported the centroid is."""
+    target, _ = axes
+    _patch_extraction(monkeypatch, [_cone(target, 20, 0.03, 1), _cone(target, 20, 0.03, 2)])
+
+    result = estimate_speaker_embedding_from_audios([_audio(), _audio()])
+
+    assert result.distribution is not None
+    assert result.distribution.counts.n_files == 2
+    assert result.distribution.nulls.cos_sd_null == pytest.approx(1.0 / np.sqrt(_DIM))
+    assert set(result.distribution.within_file) == set(result.distribution.cross_file.cos_file_centroid_to_pooled)
+
+
+def test_contamination_is_visible_without_rejection(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """With the flag off nothing is dropped, and the intruder shows up in the per-file statistics
+    -- which is how a caller curates its input instead of us deciding."""
+    target, intruder = axes
+    _patch_extraction(monkeypatch, [_cone(target, 20, 0.03, 1), _cone(target, 20, 0.03, 2), _cone(intruder, 20, 0.03, 3)])
+
+    result = estimate_speaker_embedding_from_audios([_audio(), _audio(), _audio()])
+
+    assert result.provenance.n_windows_dropped == 0
+    assert result.provenance.method == "spherical_mean"
+    lofo = result.distribution.centroid_robustness.leave_one_file_out_cos
+    worst = min(lofo, key=lambda k: lofo[k])
+    assert lofo[worst] < max(lofo.values())
+
+
+def test_rejection_drops_the_intruder_and_records_it(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """Rejection is a decision, so it must never be silent: the method string and the dropped
+    count both say it happened."""
+    target, intruder = axes
+    _patch_extraction(monkeypatch, [_cone(target, 20, 0.03, 1), _cone(target, 20, 0.03, 2), _cone(intruder, 20, 0.03, 3)])
+
+    result = estimate_speaker_embedding_from_audios([_audio(), _audio(), _audio()], reject_contamination=True)
+
+    assert result.provenance.method == "spherical_mean+dominant_cluster"
+    assert result.provenance.n_windows_dropped == 20
+    assert result.provenance.n_windows_used == 40
+    assert np.asarray(result.vector) @ target > 0.9
+
+
+def test_rejection_is_off_by_default(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """The default path decides nothing."""
+    import inspect
+
+    assert inspect.signature(estimate_speaker_embedding_from_audios).parameters["reject_contamination"].default is False
+
+
+def test_an_empty_input_raises(monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ANN001
+    """No files means no estimate. Returning a zero vector would look like a measurement."""
+    with pytest.raises(ValueError, match="at least one"):
+        estimate_speaker_embedding_from_audios([])
+
+
+def test_source_files_are_recorded_when_available(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """Provenance has to name what the estimate came from, or it cannot be reproduced."""
+    target, _ = axes
+    _patch_extraction(monkeypatch, [_cone(target, 10, 0.03, 1)])
+    audio = _audio()
+    audio.metadata["source"] = "unused"
+    result = estimate_speaker_embedding_from_audios([audio])
+    assert isinstance(result.provenance.source_files, list)
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+uv run --no-sync pytest src/tests/audio/tasks/speaker_embeddings_estimate_test.py -v 2>&1 | tail -10
+```
+
+Expected: FAIL — `ImportError: cannot import name 'estimate_speaker_embedding_from_audios'`.
+
+- [ ] **Step 3: Narrow the hint field**
+
+In `audio_hints.py`, replace `distribution: Optional[Any] = None` with a real type, importing from
+the submodule path (not the `utils.tasks` package `__init__`) to avoid pulling in siblings:
+
+```python
+from senselab.utils.tasks.embedding_distribution import EmbeddingDistribution
+```
+
+```python
+    distribution: Optional[EmbeddingDistribution] = None
+```
+
+Verify no import cycle appears: `embedding_distribution.py` imports only numpy, pydantic, scipy
+and stdlib, so `data_structures -> utils.tasks.embedding_distribution` is a leaf edge.
+
+- [ ] **Step 4: Implement the estimator**
+
+In `src/senselab/audio/tasks/speaker_embeddings/api.py`, add the imports the test monkeypatches by
+name — `extract_per_window_embeddings` and `WindowEmbedding` must be module-level attributes of
+`api` for `monkeypatch.setattr(est_api, ...)` to work:
+
+```python
+from senselab.audio.data_structures.audio_hints import SpeakerEmbeddingProvenance, TargetSpeakerEmbedding
+from senselab.audio.tasks.speaker_embeddings.windowing import WindowEmbedding, extract_per_window_embeddings
+from senselab.utils.tasks.embedding_distribution import (
+    describe_embedding_distribution,
+    select_dominant_vectors,
+)
+
+# ECAPA rather than a pair: PR #543 defaulted to ECAPA+ResNet because analyze_audio scores both
+# per-window, and this estimator is deliberately decoupled from that consumer, so a second model
+# would be unused cost. provenance.model_id records which one produced a vector.
+DEFAULT_SPEAKER_EMBEDDING_MODEL = "speechbrain/spkrec-ecapa-voxceleb"
+
+# Measured for a profile centroid, not picked: a 2.0 s window on a 1.0 s hop gave cross-file
+# centroid stability 0.890 and cross-subject separation 0.168, against 0.331 for a 0.5/0.25 grid
+# carrying four times the windows. Deliberately different from windowing.py's 1.0/0.5 detection
+# defaults, which are tuned for temporal resolution on a 0.5 s bucket grid.
+PROFILE_WINDOW_S = 2.0
+PROFILE_HOP_S = 1.0
+```
+
+Add a small resolver so the test can patch one seam, and so a failure to resolve is recorded rather
+than guessed:
+
+```python
+def _resolve_embedding_model(model: Optional[SenselabModel]) -> tuple[str, Optional[str], Optional[str]]:
+    """Return ``(model_id, commit_sha, unresolved_reason)`` for provenance.
+
+    A ref in the commit field would be provenance that is confidently wrong, so an unresolvable
+    model yields ``None`` plus a stated reason instead.
+
+    Args:
+        model: The caller's model, or ``None`` for the default.
+
+    Returns:
+        ``(model_id, commit_sha, unresolved_reason)``; exactly one of the last two is ``None``.
+    """
+    model_id = str(model.path_or_uri) if model is not None else DEFAULT_SPEAKER_EMBEDDING_MODEL
+    sha = getattr(model, "commit_sha", None) if model is not None else None
+    if sha:
+        return model_id, str(sha), None
+    try:
+        from senselab.utils.model_revision import resolve_revision
+
+        return model_id, resolve_revision(model_id, "main"), None
+    except Exception as exc:  # noqa: BLE001 — an unresolved commit must be recorded, not raised
+        return model_id, None, f"{type(exc).__name__}: {exc}"
+```
+
+Then the estimator:
+
+```python
+def estimate_speaker_embedding_from_audios(
+    audios: List[Audio],
+    model: Optional[SenselabModel] = None,
+    device: Optional[DeviceType] = None,
+    window_s: float = PROFILE_WINDOW_S,
+    hop_s: float = PROFILE_HOP_S,
+    aggregator: str = "spherical_mean",
+    reject_contamination: bool = False,
+    created_at: Optional[str] = None,
+) -> TargetSpeakerEmbedding:
+    """Estimate one speaker embedding from files that *may* contain that speaker.
+
+    Windows each file, embeds every window, pools them, and describes the resulting distribution.
+    The returned statistics are what let a caller judge how well-supported the centroid is: this
+    function reaches no verdict about whether the file set was clean.
+
+    Args:
+        audios: The recordings to enroll from. A file that does not contain the target speaker is
+            not an error -- it shows up in the returned per-file statistics, which is how a caller
+            curates its input.
+        model: Embedding model. Defaults to ECAPA.
+        device: CPU or CUDA.
+        window_s: Window length. Defaults to the measured profile-centroid value, 2.0 s.
+        hop_s: Hop between windows. Defaults to 1.0 s.
+        aggregator: ``"spherical_mean"``, ``"trimmed_mean"`` or ``"medoid"``.
+        reject_contamination: When ``True``, group the pooled windows and keep only the dominant
+            group before describing. Off by default, because selecting a dominant group is a
+            decision. What it removed is recorded in ``provenance.method`` and
+            ``provenance.n_windows_dropped``.
+        created_at: ISO-8601 timestamp for provenance. Not defaulted to "now": a library that
+            stamps wall-clock time makes its own output unreproducible.
+
+    Returns:
+        A :class:`TargetSpeakerEmbedding` carrying the vector, its provenance, and the
+        distribution it was estimated from.
+
+    Raises:
+        ValueError: If ``audios`` is empty, or if no window survived extraction.
+    """
+    if not audios:
+        raise ValueError("estimate_speaker_embedding_from_audios needs at least one audio")
+
+    model_id, commit_sha, unresolved = _resolve_embedding_model(model)
+    speaker_model = model if model is not None else SpeechBrainModel(path_or_uri=model_id, revision="main")
+
+    vectors: list[np.ndarray] = []
+    file_ids: list[str] = []
+    starts: list[float] = []
+    source_files: list[str] = []
+    for idx, audio in enumerate(audios):
+        file_id = str(getattr(audio, "filepath", None) or f"audio-{idx}")
+        source_files.append(file_id)
+        per_model = extract_per_window_embeddings(
+            audio, [speaker_model], device=device, window_s=window_s, hop_s=hop_s
+        )
+        for windows in per_model.values():
+            for w in windows:
+                vectors.append(np.asarray(w.vector, dtype=np.float64))
+                file_ids.append(file_id)
+                starts.append(float(w.start_s))
+
+    if not vectors:
+        raise ValueError("no embedding windows were produced; are the inputs shorter than window_s?")
+
+    pooled = np.vstack(vectors)
+    n_input = int(pooled.shape[0])
+    method = aggregator
+
+    if reject_contamination:
+        selection = select_dominant_vectors(pooled, file_ids)
+        keep = selection.kept_indices
+        pooled = pooled[keep]
+        file_ids = [file_ids[i] for i in keep]
+        starts = [starts[i] for i in keep]
+        method = f"{aggregator}+dominant_cluster"
+
+    centroid, distribution = describe_embedding_distribution(
+        pooled,
+        file_ids,
+        aggregator=aggregator,
+        window_s=window_s,
+        hop_s=hop_s,
+        window_starts_s=starts,
+    )
+
+    return TargetSpeakerEmbedding(
+        vector=centroid,
+        provenance=SpeakerEmbeddingProvenance(
+            model_id=model_id,
+            model_commit_sha=commit_sha,
+            unresolved_reason=unresolved,
+            method=method,
+            source_files=source_files,
+            window_s=window_s,
+            hop_s=hop_s,
+            n_windows_used=int(distribution.counts.n_scored),
+            n_windows_dropped=n_input - int(distribution.counts.n_scored),
+            created_at=created_at,
+        ),
+        distribution=distribution,
+    )
+```
+
+Export it from `src/senselab/audio/tasks/speaker_embeddings/__init__.py`, adding to `__all__`.
+
+- [ ] **Step 5: Run and iterate**
+
+```bash
+uv run --no-sync pytest src/tests/audio/tasks/speaker_embeddings_estimate_test.py -v 2>&1 | tail -20
+```
+
+Expected: PASS, 7 tests. Two likely snags:
+
+- If the monkeypatch of `extract_per_window_embeddings` does not take, the import in `api.py` must
+  be a module-level `from ... import extract_per_window_embeddings` (so it is an attribute of
+  `api`), and the estimator must call the bare name — not the fully-qualified path.
+- If `SpeechBrainModel(path_or_uri=...)` tries to reach the network at construction, the test's
+  patch of `_resolve_embedding_model` is not enough; construct the model lazily *inside* the
+  extraction call path, or accept a `SenselabModel` and let the test pass a stub with
+  `path_or_uri`. Prefer the second: it keeps the estimator honest and the test model-free.
+
+- [ ] **Step 6: Full verification and commit**
+
+```bash
+uv run --no-sync pytest src/tests/audio/ src/tests/utils/ -q 2>&1 | tail -6
+uv run --no-sync ruff format src/senselab/ src/tests/
+uv run --no-sync ruff check src/ src/tests/
+uv run --no-sync mypy --ignore-missing-imports --extra-checks src/ 2>&1 | tail -3
+git add src/senselab/audio/tasks/speaker_embeddings/api.py \
+        src/senselab/audio/tasks/speaker_embeddings/__init__.py \
+        src/senselab/audio/data_structures/audio_hints.py \
+        src/tests/audio/tasks/speaker_embeddings_estimate_test.py
+git commit -m "feat(audio): estimate a speaker embedding from files that may contain them
+
+Windows each file, embeds every window, pools them and describes the distribution.
+Returns the centroid, its provenance, and the statistics -- and reaches no verdict
+about whether the file set was clean, because that is the caller's to draw.
+
+Defaults to ECAPA alone rather than #543's ECAPA+ResNet pair: that pair existed
+because analyze_audio scores both per-window, and this estimator is decoupled from
+that consumer, so a second model is unused cost. Window defaults are the measured
+profile-centroid values 2.0/1.0, deliberately distinct from windowing.py's 1.0/0.5
+detection defaults.
+
+reject_contamination is off by default. On, it groups the pooled windows, keeps the
+dominant group, and records that it happened in provenance.method and
+n_windows_dropped -- a curated estimate must not be able to look like a clean one.
+
+Provenance records a resolved commit SHA or an explicit unresolved_reason, never a
+ref. created_at is caller-supplied rather than stamped from the clock, since a
+library that stamps wall-clock time makes its own output unreproducible.
+
+Tests monkeypatch per-window extraction and load no model, so aggregation,
+provenance and rejection are all exercised deterministically with no download."
+```
+
+---
+
+### Task 9: The two defect fixes, and the docs
+
+**Files:**
+- Modify: `src/senselab/audio/workflows/audio_analysis/embeddings.py`
+- Create: `src/senselab/audio/tasks/speaker_embeddings/doc.md`
+- Modify: `src/senselab/audio/tasks/speaker_embeddings/__init__.py`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: no importable interface.
+
+- [ ] **Step 1: Locate both defects**
+
+```bash
+grep -n "p_voice\|0.5 \* (\|silhouette + 1\|0.5 \* (s" src/senselab/audio/workflows/audio_analysis/embeddings.py
+sed -n '1,10p' src/senselab/audio/workflows/audio_analysis/embeddings.py
+grep -rn "p_voice\|silhouette_voice_score" src/senselab/ src/tests/ scripts/ | grep -v "^src/senselab/audio/workflows/audio_analysis/embeddings.py"
+```
+
+The third command matters most: it tells you whether anything still *consumes* `p_voice`. The L1
+post-processing register closed its item 12 by removing the consumer, not the computation, so the
+expected answer is that only `embeddings.py` mentions it. If something else does, stop and report
+it — removing a live consumer is outside this task.
+
+- [ ] **Step 2: Write the failing guard test**
+
+Append to `src/tests/audio/workflows/audio_analysis/embeddings_test.py` if it exists, otherwise
+create `src/tests/audio/workflows/audio_analysis/embeddings_defects_test.py`:
+
+```python
+"""Guards for two defects this change fixes.
+
+Both are the kind that reappear: a silhouette coefficient renamed back into a probability, and a
+docstring drifting from the signature it describes.
+"""
+
+import ast
+import inspect
+from pathlib import Path
+
+from senselab.audio.workflows.audio_analysis import embeddings as emb
+
+_SOURCE = Path(emb.__file__).read_text(encoding="utf-8")
+
+
+def test_no_silhouette_is_rescaled_into_a_probability() -> None:
+    """0.5*(s+1) turns a clustering-geometry index into something that reads as a probability.
+
+    CLAUDE.md names this defect class, and the L1 register documents its cost here: the signal
+    produced 0.4022-0.4996 doubt across 214 buckets with stdev 0.0227 and earned the highest
+    fusion weight of fifteen signals *because* it was near-constant; removing its consumer moved
+    published presence doubt from 0.0682 to 0.0385.
+    """
+    assert "p_voice" not in _SOURCE, "p_voice reads as a probability; name it what it measures"
+
+
+def test_the_module_docstring_agrees_with_the_signature() -> None:
+    """A docstring claiming different defaults than the code is worse than none: a reader trusts
+    it and passes nothing, expecting the documented behaviour."""
+    sig = inspect.signature(emb.extract_per_window_embeddings)
+    window_default = sig.parameters["window_s"].default
+    hop_default = sig.parameters["hop_s"].default
+    doc = ast.get_docstring(ast.parse(_SOURCE)) or ""
+    assert f"{window_default} s with {hop_default} s hop" in doc or f"{window_default}" in doc.split("\n")[2]
+```
+
+- [ ] **Step 3: Run it and watch the first test fail**
+
+```bash
+uv run --no-sync pytest src/tests/audio/workflows/audio_analysis/embeddings_defects_test.py -v 2>&1 | tail -10
+```
+
+Expected: `test_no_silhouette_is_rescaled_into_a_probability` FAILS.
+
+- [ ] **Step 4: Fix defect 1**
+
+Remove the `0.5 * (silhouette + 1)` rescaling and the `p_voice` name. If the containing function
+exists only to produce `p_voice` and nothing consumes it (confirmed in Step 1), delete the
+function. If it also returns other values callers use, keep those and drop only the rescaled
+field, renaming any survivor to what it measures — e.g. `silhouette` — with a comment recording
+why the rescaling is gone:
+
+```python
+# The old `p_voice = 0.5 * (silhouette + 1)` is deliberately absent. A silhouette coefficient is a
+# property of a chosen partition on a chosen metric, not a probability: silhouette computed with
+# cosine and with Euclidean return different numbers for identical geometry on unit vectors, so any
+# probability read off it is a probability about a parameterisation choice. The L1 register (item
+# 12) removed the consumer for this reason; this removes the computation.
+```
+
+- [ ] **Step 5: Fix defect 2**
+
+Correct the module docstring's opening line so it states the same defaults as the signature. Do
+**not** change the signature: `window_s=1.0, hop_s=0.5` is measured for temporal resolution on the
+0.5 s bucket grid, and the module's own "Why 1.0 s / 0.5 s defaults" section derives it. Add one
+sentence pointing at the other measured setting so the two never get collapsed:
+
+```
+Profile enrollment wants the opposite trade and passes ``window_s=2.0, hop_s=1.0`` explicitly --
+see ``tasks/speaker_embeddings``. Two purposes, two measured settings.
+```
+
+- [ ] **Step 6: Write `doc.md`**
+
+Create `src/senselab/audio/tasks/speaker_embeddings/doc.md` covering, in this order: what
+`extract_speaker_embeddings_from_audios` and `estimate_speaker_embedding_from_audios` each do and
+when to reach for which; the two window settings and their separate measurements; the statistics
+block and how to read it against the analytic nulls; that a small cosine sd is *below* the
+random-vector null at d=192 and therefore not evidence of coherence; what contamination rejection
+does, that it is opt-in, and that its statistics then describe a curated set; and a **suggested,
+non-binding vocabulary** for `AudioHints.may_contain` (`read-speech`, `spontaneous-speech`,
+`sustained-vowel`, `cough`, `breath`, `singing`, `music`, `multiple-speakers`, `silence`) and
+`AudioHints.environment` (`quiet-room`, `clinic`, `home`, `telephone`, `outdoors`, `unknown`),
+stating explicitly that these are suggestions rather than an enum and why: a closed vocabulary here
+would be a taxonomy nobody fitted.
+
+Wire it up by making `src/senselab/audio/tasks/speaker_embeddings/__init__.py`'s docstring
+`""".. include:: ./doc.md"""  # noqa: D415`, matching how `speech_enhancement` does it — but keep
+the existing exports.
+
+- [ ] **Step 7: Full suite, lint, typecheck**
+
+```bash
+uv run --no-sync pytest src/tests --color=no -q -p no:cacheprovider --no-cov -rf 2>&1 | tail -15
+uv run --no-sync ruff format src/senselab/ src/tests/
+uv run --no-sync ruff check src/ src/tests/
+uv run --no-sync mypy --ignore-missing-imports --extra-checks src/ 2>&1 | tail -3
+```
+
+Expected: the whole suite passes. This is the run that matters — the workflow's embedding tests
+prove the defect fixes changed no behaviour beyond removing a dead computation.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/senselab/audio/workflows/audio_analysis/embeddings.py \
+        src/senselab/audio/tasks/speaker_embeddings/doc.md \
+        src/senselab/audio/tasks/speaker_embeddings/__init__.py \
+        src/tests/audio/workflows/audio_analysis/
+git commit -m "fix(audio_analysis): stop rescaling a silhouette into a probability; correct a stale docstring
+
+p_voice = 0.5*(silhouette + 1) turned a clustering-geometry index into a value that
+reads as a probability. CLAUDE.md names this defect class, and the L1
+post-processing register documents what it cost here: the signal produced
+0.4022-0.4996 doubt across 214 buckets with stdev 0.0227 and earned the highest
+fusion weight of fifteen signals precisely because it was near-constant, and
+removing its consumer moved published presence doubt from 0.0682 to 0.0385. The
+register closed item 12 by removing the consumer; this removes the computation.
+
+The module docstring claimed a 2.0 s / 1.0 s default while both the signature and
+its own 'Why 1.0 s / 0.5 s defaults' section said otherwise. The line is
+corrected, and the signature is not touched: 1.0/0.5 is measured for temporal
+resolution against the 0.5 s bucket grid. A pointer to the estimator's separately
+measured 2.0/1.0 keeps the two from being collapsed.
+
+Adds doc.md for the speaker-embeddings task: both entry points, the two window
+settings and their measurements, how to read the statistics against their analytic
+nulls, and a suggested non-binding vocabulary for the hint tags."
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** Every section of `design.md` maps to a task: hints layer → Task 1; descriptor
+geometry/nulls/LOO/spectrum → Task 2; within/cross-file → Task 3; file effect → Task 4; aggregator
+and robustness → Task 5; contamination rejection → Task 6; layering promotion and the guard →
+Task 7; estimator and provenance → Task 8; both defect fixes and the docs → Task 9. The spec's
+`separability` field is realised as `file_effect.auc_same_file_vs_diff_file` (Task 4), which is the
+same statistic — with clustering gone there is no within-cluster contrast, as the spec notes.
+
+**Placeholder scan.** No TBD/TODO. Every code step carries real code. Two steps deliberately
+instruct the implementer to *discover* a fact rather than assume one (Task 1 Step 3, the
+content-hash helper's real name; Task 9 Step 1, whether anything still consumes `p_voice`), and
+both say what to do with either answer, including when to stop and report.
+
+**Type consistency.** `EmbeddingDistribution` is constructed once in Task 2 and extended by
+default-valued fields in Tasks 3-5, so each task's tests keep passing. `SimilarityStats` is defined
+in Task 2 and reused in Tasks 3-4. `TargetSpeakerEmbedding.distribution` is `Any | None` in Task 1
+and narrowed to `EmbeddingDistribution` in Task 8, which is stated in both places. `window_starts`
+and `slice_audio` are the promoted public names throughout Tasks 7-8; the old private names appear
+only in Task 7's grep step.
+
+**One known risk, flagged rather than hidden.** Task 8's test monkeypatches
+`extract_per_window_embeddings` and `_resolve_embedding_model` as attributes of `api`. If the
+implementer imports them differently the patch silently misses and the test will try to load a real
+model. Task 8 Step 5 names both failure modes and says which fix to prefer.

--- a/specs/20260814-153013-audio-hints-speaker-embedding/plan.md
+++ b/specs/20260814-153013-audio-hints-speaker-embedding/plan.md
@@ -927,10 +927,10 @@ def _loo_cos_to_centroid(x: np.ndarray) -> np.ndarray:
     s = x.sum(axis=0)
     diff = s[None, :] - x
     denom = np.linalg.norm(diff, axis=1)
-    numer = np.einsum("ij,ij->i", x, diff)
+    numerator = np.einsum("ij,ij->i", x, diff)
     out = np.zeros_like(denom)
     nz = denom > 0
-    out[nz] = numer[nz] / denom[nz]
+    out[nz] = numerator[nz] / denom[nz]
     return out
 
 

--- a/src/senselab/audio/data_structures/__init__.py
+++ b/src/senselab/audio/data_structures/__init__.py
@@ -2,3 +2,9 @@
 
 from .audio import Audio, batch_audios, unbatch_audios  # noqa: F401
 from .audio_classification_result import AudioClassificationResult  # noqa: F401
+from .audio_hints import (  # noqa: F401
+    AudioHints,
+    ExpectedSpeech,
+    SpeakerEmbeddingProvenance,
+    TargetSpeakerEmbedding,
+)

--- a/src/senselab/audio/data_structures/audio.py
+++ b/src/senselab/audio/data_structures/audio.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 from pydantic import BaseModel, Field, PrivateAttr
 
+from senselab.audio.data_structures.audio_hints import AudioHints
 from senselab.utils.constants import SENSELAB_NAMESPACE
 
 try:
@@ -41,6 +42,9 @@ class Audio(BaseModel):
 
     Attributes:
         metadata: A dictionary containing any additional metadata.
+        hints: Declared expectations about this recording (see ``audio_hints``). ``None`` means
+            nobody declared anything, which is deliberately distinct from an empty ``AudioHints``.
+            Nothing in senselab consumes hints; they are carried.
     """
 
     # Private attributes used for lazy loading and internal state.
@@ -53,6 +57,7 @@ class Audio(BaseModel):
 
     # Public fields:
     metadata: Dict = Field(default={})
+    hints: Optional[AudioHints] = None
     model_config = {"arbitrary_types_allowed": True}
 
     def __init__(self, **data: Any) -> None:  # noqa: ANN401,D417

--- a/src/senselab/audio/data_structures/audio_hints.py
+++ b/src/senselab/audio/data_structures/audio_hints.py
@@ -18,6 +18,13 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+# Imported from the submodule path, not the `utils.tasks` package `__init__`: that package's
+# `__init__` pulls in sibling task modules (batching, pooling, ...) that have nothing to do with
+# a hint, and `data_structures` importing all of them just to reach one leaf class would be a
+# needless dependency surface. `embedding_distribution.py` itself imports only numpy, pydantic,
+# scipy and stdlib, so this edge stays a leaf.
+from senselab.utils.tasks.embedding_distribution import EmbeddingDistribution
+
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
@@ -101,14 +108,14 @@ class TargetSpeakerEmbedding(BaseModel):
             so a hint is interpretable on its own -- a reference that outlives its file is the
             dangling-pointer failure this avoids.
         provenance: Required. A vector with no provenance cannot be interpreted or reproduced.
-        distribution: Optional statistics describing the set the vector was estimated from. Typed
-            loosely here to keep ``data_structures`` from importing ``utils.tasks``; narrowed by
-            the estimator's own signature.
+        distribution: Optional statistics describing the set the vector was estimated from --
+            produced by ``estimate_speaker_embedding_from_audios``, absent for a hint declared by
+            other means (e.g. a corpus-supplied enrollment vector with no windowed audio behind it).
     """
 
     vector: list[float]
     provenance: SpeakerEmbeddingProvenance
-    distribution: Optional[Any] = None
+    distribution: Optional[EmbeddingDistribution] = None
 
 
 class AudioHints(BaseModel):

--- a/src/senselab/audio/data_structures/audio_hints.py
+++ b/src/senselab/audio/data_structures/audio_hints.py
@@ -1,0 +1,139 @@
+"""Declared hints about what an ``Audio`` may contain.
+
+A hint is an **assertion** -- by an operator, an acquisition protocol, or a corpus description --
+about what a recording was *meant* to contain. It is never a measurement, and nothing in this
+change consumes one: no task alters its behaviour because a hint is present. How a hint should
+inform a decision is itself a decision, and it gets its own derivation when someone builds that
+consumer.
+
+This is deliberately not the same thing as dataset metadata resolved by a lookup (PR #543's
+``AudioPlus``). A lookup's trust comes from the dataset; a hint's comes from whoever declared it.
+Keeping them apart means hints work with no provider, no corpus, and no network.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class ExpectedSpeech(BaseModel):
+    """The text a speaker was asked to produce, for a read task.
+
+    Attributes:
+        text: The verbatim prompt. Present so the hint is self-contained -- a consumer can match
+            a transcript against it without resolving anything.
+        prompt_id: Identifier in an external reference set, e.g. ``"harvard-01"``.
+        reference: Which reference set the id belongs to (name, version, or URI). Together with
+            ``prompt_id`` this traces the prompt back to its corpus without vendoring that corpus
+            into this repository.
+    """
+
+    text: Optional[str] = None
+    prompt_id: Optional[str] = None
+    reference: Optional[str] = None
+
+
+class SpeakerEmbeddingProvenance(BaseModel):
+    """Where a target-speaker embedding came from.
+
+    Attributes:
+        model_id: The embedding model, e.g. ``"speechbrain/spkrec-ecapa-voxceleb"``.
+        model_commit_sha: The **resolved** 40-hex commit the vector was produced with, or ``None``.
+            Never a ref: recording ``"main"`` here would be provenance that is confidently wrong,
+            which is worse than recording none.
+        unresolved_reason: Why ``model_commit_sha`` is ``None``. Required in that case, so an
+            absent commit is always explained rather than merely missing.
+        method: How the vector was aggregated, e.g. ``"spherical_mean"`` or
+            ``"spherical_mean+dominant_cluster"`` when contamination rejection ran.
+        source_files: What the estimate was computed from.
+        window_s: Window length used, in seconds.
+        hop_s: Hop between windows, in seconds.
+        n_windows_used: Windows that contributed to the returned vector.
+        n_windows_dropped: Windows excluded -- zero-norm, or removed by contamination rejection.
+            Kept beside ``n_windows_used`` so a curated estimate cannot look like a clean one.
+        created_at: ISO-8601 timestamp, stamped by the caller. Not defaulted to "now": a library
+            that stamps wall-clock time makes its own output unreproducible.
+    """
+
+    model_id: str
+    model_commit_sha: Optional[str] = None
+    unresolved_reason: Optional[str] = None
+    method: str = "spherical_mean"
+    source_files: list[str] = Field(default_factory=list)
+    window_s: Optional[float] = None
+    hop_s: Optional[float] = None
+    n_windows_used: int = 0
+    n_windows_dropped: int = 0
+    created_at: Optional[str] = None
+
+    @field_validator("model_commit_sha")
+    @classmethod
+    def _must_be_a_sha(cls, v: Optional[str]) -> Optional[str]:
+        """Reject anything that is not a full 40-hex commit.
+
+        Args:
+            v: The candidate value.
+
+        Returns:
+            The value unchanged when it is ``None`` or a 40-hex commit.
+
+        Raises:
+            ValueError: When the value is a ref name or a short hash. The field's whole purpose is
+                to be immutable; a ref in it silently reintroduces the ambiguity it removes.
+        """
+        if v is None:
+            return v
+        if not _SHA_RE.match(v):
+            raise ValueError(f"model_commit_sha must be a resolved 40-hex commit, got {v!r}")
+        return v
+
+
+class TargetSpeakerEmbedding(BaseModel):
+    """A speaker embedding declared as the target for a recording.
+
+    Attributes:
+        vector: The embedding, unit-norm. Held inline rather than as a path to a stored artifact
+            so a hint is interpretable on its own -- a reference that outlives its file is the
+            dangling-pointer failure this avoids.
+        provenance: Required. A vector with no provenance cannot be interpreted or reproduced.
+        distribution: Optional statistics describing the set the vector was estimated from. Typed
+            loosely here to keep ``data_structures`` from importing ``utils.tasks``; narrowed by
+            the estimator's own signature.
+    """
+
+    vector: list[float]
+    provenance: SpeakerEmbeddingProvenance
+    distribution: Optional[Any] = None
+
+
+class AudioHints(BaseModel):
+    """What a recording was declared to contain.
+
+    Attributes:
+        may_contain: Open tags -- ``"read-speech"``, ``"cough"``, ``"music"``. Named *may* contain
+            because a hint is an expectation, not an observation; nothing downstream should read
+            it as ground truth. Open strings rather than an enum: a closed vocabulary here would
+            be a taxonomy nobody fitted, and every corpus that did not fit it would force an edit.
+            See ``speaker_embeddings/doc.md`` for a suggested, non-binding vocabulary.
+        targeted_speaker_count: How many speakers the acquisition protocol aimed for -- intent,
+            not a count of who is audible. A range is deliberately not modelled; it goes in
+            ``metadata`` until a caller needs it, rather than shipping parallel min/max fields.
+        environment: Open tag, e.g. ``"quiet-room"``, ``"clinic"``, ``"telephone"``.
+        expected_speech: Ordered prompts for a read task. Ordered and separate rather than one
+            concatenated string, because "which sentence was skipped" is a different question
+            from "how close was the whole thing".
+        target_speaker: The declared target speaker's embedding, with provenance.
+        metadata: Escape hatch for corpus-specific extras that do not deserve a typed field.
+    """
+
+    may_contain: list[str] = Field(default_factory=list)
+    targeted_speaker_count: Optional[int] = None
+    environment: Optional[str] = None
+    expected_speech: list[ExpectedSpeech] = Field(default_factory=list)
+    target_speaker: Optional[TargetSpeakerEmbedding] = None
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/src/senselab/audio/data_structures/audio_hints.py
+++ b/src/senselab/audio/data_structures/audio_hints.py
@@ -65,6 +65,13 @@ class SpeakerEmbeddingProvenance(BaseModel):
             Kept beside ``n_windows_used`` so a curated estimate cannot look like a clean one.
         created_at: ISO-8601 timestamp, stamped by the caller. Not defaulted to "now": a library
             that stamps wall-clock time makes its own output unreproducible.
+        extraction_failures: ``{file_id -> reason}`` for any file in ``source_files`` whose
+            extraction raised or loaded nothing. Extraction swallows a per-file exception into an
+            empty window list, so without this a model failing on *some* files produced a silently
+            thinner estimate -- ``n_windows_dropped`` stayed 0 and every file still appeared in
+            ``source_files`` -- with no way to tell "this file had no target speaker" from "this
+            file's extraction crashed". Empty means every file that was attempted produced at
+            least one window.
     """
 
     model_id: str
@@ -77,6 +84,7 @@ class SpeakerEmbeddingProvenance(BaseModel):
     n_windows_used: int = 0
     n_windows_dropped: int = 0
     created_at: Optional[str] = None
+    extraction_failures: dict[str, str] = Field(default_factory=dict)
 
     @field_validator("model_commit_sha")
     @classmethod

--- a/src/senselab/audio/tasks/classification/speech_emotion_recognition/api.py
+++ b/src/senselab/audio/tasks/classification/speech_emotion_recognition/api.py
@@ -37,6 +37,7 @@ from senselab.utils.data_structures import (
     SenselabModel,
     SpeechBrainModel,
     _select_device_and_dtype,
+    device_run_opt,
     logger,
 )
 from senselab.utils.dependencies import hf_subprocess_env, resolve_model, speechbrain_loading_cwd, speechbrain_savedir
@@ -961,7 +962,7 @@ def _load_speechbrain_ser_model(model: SpeechBrainModel, device_type: DeviceType
         {"MODULES_NEEDED": modules_needed},
     )
 
-    run_opts = {"device": device_type.value}
+    run_opts = {"device": device_run_opt(device_type)}
     savedir = speechbrain_savedir(str(model.path_or_uri), model.revision)
     with speechbrain_loading_cwd(savedir):
         recognizer = recognizer_cls.from_hparams(  # type: ignore[attr-defined]

--- a/src/senselab/audio/tasks/speaker_embeddings/__init__.py
+++ b/src/senselab/audio/tasks/speaker_embeddings/__init__.py
@@ -1,5 +1,5 @@
 """.. include:: ./doc.md"""  # noqa: D415
 
-from .api import extract_speaker_embeddings_from_audios  # noqa: F401
+from .api import estimate_speaker_embedding_from_audios, extract_speaker_embeddings_from_audios  # noqa: F401
 
-__all__ = ["extract_speaker_embeddings_from_audios"]
+__all__ = ["estimate_speaker_embedding_from_audios", "extract_speaker_embeddings_from_audios"]

--- a/src/senselab/audio/tasks/speaker_embeddings/api.py
+++ b/src/senselab/audio/tasks/speaker_embeddings/api.py
@@ -2,12 +2,30 @@
 
 from typing import List, Optional
 
+import numpy as np
 import torch
 
 from senselab.audio.data_structures import Audio
+from senselab.audio.data_structures.audio_hints import SpeakerEmbeddingProvenance, TargetSpeakerEmbedding
 from senselab.audio.tasks.speaker_embeddings.speechbrain import SpeechBrainEmbeddings
 from senselab.utils.compatibility import requires_compatibility
-from senselab.utils.data_structures import DeviceType, SpeechBrainModel
+from senselab.utils.data_structures import DeviceType, SenselabModel, SpeechBrainModel
+from senselab.utils.tasks.embedding_distribution import (
+    describe_embedding_distribution,
+    select_dominant_vectors,
+)
+
+# ECAPA rather than a pair: PR #543 defaulted to ECAPA+ResNet because analyze_audio scores both
+# per-window, and this estimator is deliberately decoupled from that consumer, so a second model
+# would be unused cost. provenance.model_id records which one produced a vector.
+DEFAULT_SPEAKER_EMBEDDING_MODEL = "speechbrain/spkrec-ecapa-voxceleb"
+
+# Measured for a profile centroid, not picked: a 2.0 s window on a 1.0 s hop gave cross-file
+# centroid stability 0.890 and cross-subject separation 0.168, against 0.331 for a 0.5/0.25 grid
+# carrying four times the windows. Deliberately different from windowing.py's 1.0/0.5 detection
+# defaults, which are tuned for temporal resolution on a 0.5 s bucket grid.
+PROFILE_WINDOW_S = 2.0
+PROFILE_HOP_S = 1.0
 
 
 @requires_compatibility("audio.tasks.speaker_embeddings.extract_speaker_embeddings_from_audios")
@@ -83,3 +101,163 @@ def extract_speaker_embeddings_from_audios(
         raise NotImplementedError(
             "Only SpeechBrain models are supported for now. We aim to support more models in the future."
         )
+
+
+# Imported here rather than at module top: `windowing.py` itself imports
+# `extract_speaker_embeddings_from_audios` back out of this module (it needs the plain
+# per-audio extractor to build its per-window grid), so a top-of-file import would run before
+# that name is bound and the package's own `__init__` -- still mid-import -- would hand
+# `windowing.py` a partially initialized module. By this point in the file the name above is
+# already defined, so the cycle closes cleanly.
+from senselab.audio.tasks.speaker_embeddings.windowing import (  # noqa: E402
+    WindowEmbedding,
+    extract_per_window_embeddings,
+)
+
+
+def _resolve_embedding_model(model: Optional[SenselabModel]) -> tuple[str, Optional[str], Optional[str]]:
+    """Return ``(model_id, commit_sha, unresolved_reason)`` for provenance.
+
+    A ref in the commit field would be provenance that is confidently wrong, so an unresolvable
+    model yields ``None`` plus a stated reason instead.
+
+    Args:
+        model: The caller's model, or ``None`` for the default.
+
+    Returns:
+        ``(model_id, commit_sha, unresolved_reason)``; exactly one of the last two is ``None``.
+    """
+    model_id = str(model.path_or_uri) if model is not None else DEFAULT_SPEAKER_EMBEDDING_MODEL
+    sha = getattr(model, "commit_sha", None) if model is not None else None
+    if sha:
+        return model_id, str(sha), None
+    try:
+        from senselab.utils.model_revision import resolve_revision
+
+        return model_id, resolve_revision(model_id, "main"), None
+    except Exception as exc:  # noqa: BLE001 — an unresolved commit must be recorded, not raised
+        return model_id, None, f"{type(exc).__name__}: {exc}"
+
+
+def estimate_speaker_embedding_from_audios(
+    audios: List[Audio],
+    model: Optional[SenselabModel] = None,
+    device: Optional[DeviceType] = None,
+    window_s: float = PROFILE_WINDOW_S,
+    hop_s: float = PROFILE_HOP_S,
+    aggregator: str = "spherical_mean",
+    reject_contamination: bool = False,
+    created_at: Optional[str] = None,
+) -> TargetSpeakerEmbedding:
+    """Estimate one speaker embedding from files that *may* contain that speaker.
+
+    Windows each file, embeds every window, pools them, and describes the resulting distribution.
+    The returned statistics are what let a caller judge how well-supported the centroid is: this
+    function reaches no verdict about whether the file set was clean.
+
+    Args:
+        audios: The recordings to enroll from. A file that does not contain the target speaker is
+            not an error -- it shows up in the returned per-file statistics, which is how a caller
+            curates its input.
+        model: Embedding model. Defaults to ECAPA.
+        device: CPU or CUDA.
+        window_s: Window length. Defaults to the measured profile-centroid value, 2.0 s.
+        hop_s: Hop between windows. Defaults to 1.0 s.
+        aggregator: ``"spherical_mean"``, ``"trimmed_mean"`` or ``"medoid"``.
+        reject_contamination: When ``True``, group the pooled windows and keep only the dominant
+            group before describing. Off by default, because selecting a dominant group is a
+            decision. What it removed is recorded in ``provenance.method`` and
+            ``provenance.n_windows_dropped``.
+        created_at: ISO-8601 timestamp for provenance. Not defaulted to "now": a library that
+            stamps wall-clock time makes its own output unreproducible.
+
+    Returns:
+        A :class:`TargetSpeakerEmbedding` carrying the vector, its provenance, and the
+        distribution it was estimated from.
+
+    Raises:
+        ValueError: If ``audios`` is empty, or if no window survived extraction.
+    """
+    if not audios:
+        raise ValueError("estimate_speaker_embedding_from_audios needs at least one audio")
+
+    model_id, commit_sha, unresolved = _resolve_embedding_model(model)
+    # Deliberately *not* `SpeechBrainModel(path_or_uri=model_id, revision="main")` here: HFModel's
+    # validators (`validate_hf_model_id`, `_resolve_commit_sha`) call the Hub over the network on
+    # a cache miss, and on a cold cache `check_hf_repo_exists` -> `ensure_hf_model` runs a full
+    # `snapshot_download` -- exactly the 20 GB mistake this task was warned against, and it would
+    # fire regardless of any patch to `_resolve_embedding_model`, since it is a *separate*
+    # construction. The plain `SenselabModel` base class carries `path_or_uri` with no such
+    # validator, which is all `extract_per_window_embeddings` and its own tests need from it.
+    speaker_model: SenselabModel = model if model is not None else SenselabModel(path_or_uri=model_id)
+
+    vectors: list[np.ndarray] = []
+    file_ids: list[str] = []
+    starts: list[float] = []
+    source_files: list[str] = []
+    for idx, audio in enumerate(audios):
+        # `Audio.filepath` is a method, not a property (`getattr(audio, "filepath")` alone
+        # returns the bound-method object, which is truthy for every audio and stringifies
+        # off the object's *field* repr rather than its identity or path -- two audios with
+        # equal metadata then collide onto one file id). Calling it is required to get the
+        # actual path, or `None` for an in-memory audio with no backing file.
+        file_id = str(audio.filepath() or f"audio-{idx}")
+        source_files.append(file_id)
+        # `models` is typed `list[str]` on the real `extract_per_window_embeddings` (plain model
+        # ids), but the model object is passed through here instead: the extraction seam -- real
+        # or, in tests, monkeypatched -- reads `.path_or_uri` off it rather than re-deriving an id
+        # string, so provenance and the mocked extraction agree on one source of truth. See the
+        # comment above on why this can't instead be a network-validated `SpeechBrainModel`.
+        per_model: dict[str, list[WindowEmbedding]] = extract_per_window_embeddings(
+            audio=audio,
+            models=[speaker_model],  # type: ignore[list-item]
+            device=device,
+            window_s=window_s,
+            hop_s=hop_s,
+        )
+        for windows in per_model.values():
+            for w in windows:
+                vectors.append(np.asarray(w.vector, dtype=np.float64))
+                file_ids.append(file_id)
+                starts.append(float(w.start_s))
+
+    if not vectors:
+        raise ValueError("no embedding windows were produced; are the inputs shorter than window_s?")
+
+    pooled = np.vstack(vectors)
+    n_input = int(pooled.shape[0])
+    method = aggregator
+
+    if reject_contamination:
+        selection = select_dominant_vectors(pooled, file_ids)
+        keep = selection.kept_indices
+        pooled = pooled[keep]
+        file_ids = [file_ids[i] for i in keep]
+        starts = [starts[i] for i in keep]
+        method = f"{aggregator}+dominant_cluster"
+
+    centroid, distribution = describe_embedding_distribution(
+        pooled,
+        file_ids,
+        aggregator=aggregator,
+        window_s=window_s,
+        hop_s=hop_s,
+        window_starts_s=starts,
+    )
+
+    return TargetSpeakerEmbedding(
+        vector=centroid,
+        provenance=SpeakerEmbeddingProvenance(
+            model_id=model_id,
+            model_commit_sha=commit_sha,
+            unresolved_reason=unresolved,
+            method=method,
+            source_files=source_files,
+            window_s=window_s,
+            hop_s=hop_s,
+            n_windows_used=int(distribution.counts.n_scored),
+            n_windows_dropped=n_input - int(distribution.counts.n_scored),
+            created_at=created_at,
+        ),
+        distribution=distribution,
+    )

--- a/src/senselab/audio/tasks/speaker_embeddings/api.py
+++ b/src/senselab/audio/tasks/speaker_embeddings/api.py
@@ -148,6 +148,7 @@ def estimate_speaker_embedding_from_audios(
     aggregator: str = "spherical_mean",
     reject_contamination: bool = False,
     created_at: Optional[str] = None,
+    file_ids: Optional[List[str]] = None,
 ) -> TargetSpeakerEmbedding:
     """Estimate one speaker embedding from files that *may* contain that speaker.
 
@@ -170,16 +171,27 @@ def estimate_speaker_embedding_from_audios(
             ``provenance.n_windows_dropped``.
         created_at: ISO-8601 timestamp for provenance. Not defaulted to "now": a library that
             stamps wall-clock time makes its own output unreproducible.
+        file_ids: Optional caller-supplied id per audio, same length and order as ``audios``.
+            Preferred over the positional fallback below: ``Audio.filepath()`` is empty for any
+            in-memory or preprocessed audio -- ``resample_audios``, which this module's own
+            docstring recommends running first, drops ``filepath`` entirely -- so the positional
+            form (``"audio-0"``, ``"audio-1"``, ...) is unmappable back to a real recording. Those
+            same ids key ``vectors_per_file``, ``within_file``, ``cross_file`` and
+            ``leave_one_file_out_cos`` in the returned distribution, so an uninformative id makes
+            the whole per-file block uninterpretable, not just ``source_files``.
 
     Returns:
         A :class:`TargetSpeakerEmbedding` carrying the vector, its provenance, and the
         distribution it was estimated from.
 
     Raises:
-        ValueError: If ``audios`` is empty, or if no window survived extraction.
+        ValueError: If ``audios`` is empty, if ``file_ids`` is supplied with a different length
+            than ``audios``, or if no window survived extraction.
     """
     if not audios:
         raise ValueError("estimate_speaker_embedding_from_audios needs at least one audio")
+    if file_ids is not None and len(file_ids) != len(audios):
+        raise ValueError(f"file_ids has {len(file_ids)} entries for {len(audios)} audios")
 
     model_id, commit_sha, unresolved = _resolve_embedding_model(model)
     # `extract_per_window_embeddings`'s contract is `models: list[str]` -- plain ids, not model
@@ -194,31 +206,52 @@ def estimate_speaker_embedding_from_audios(
     # raised `KeyError`/`TypeError` before returning a single vector.)
 
     vectors: list[np.ndarray] = []
-    file_ids: list[str] = []
+    row_file_ids: list[str] = []
     starts: list[float] = []
     source_files: list[str] = []
+    extraction_failures: dict[str, str] = {}
     for idx, audio in enumerate(audios):
-        # `Audio.filepath` is a method, not a property (`getattr(audio, "filepath")` alone
-        # returns the bound-method object, which is truthy for every audio and stringifies
-        # off the object's *field* repr rather than its identity or path -- two audios with
-        # equal metadata then collide onto one file id). Calling it is required to get the
-        # actual path, or `None` for an in-memory audio with no backing file.
-        file_id = str(audio.filepath() or f"audio-{idx}")
+        if file_ids is not None:
+            file_id = str(file_ids[idx])
+        else:
+            # `Audio.filepath` is a method, not a property (`getattr(audio, "filepath")` alone
+            # returns the bound-method object, which is truthy for every audio and stringifies
+            # off the object's *field* repr rather than its identity or path -- two audios with
+            # equal metadata then collide onto one file id). Calling it is required to get the
+            # actual path, or `None` for an in-memory audio with no backing file. This positional
+            # form is the fallback of last resort -- pass `file_ids` to keep the per-file block
+            # mappable back to a real recording.
+            file_id = str(audio.filepath() or f"audio-{idx}")
         source_files.append(file_id)
+        # A fresh dict per file: `extract_per_window_embeddings` keys its `failures` output by
+        # `model_id`, which is the same single value on every call in this loop, so reusing one
+        # dict across files would let a later file's success silently erase an earlier file's
+        # failure under that shared key.
+        this_file_failures: dict[str, str] = {}
         per_model: dict[str, list[WindowEmbedding]] = extract_per_window_embeddings(
             audio=audio,
             models=[model_id],
             device=device,
             window_s=window_s,
             hop_s=hop_s,
+            revision=commit_sha,
+            failures=this_file_failures,
         )
+        if model_id in this_file_failures:
+            extraction_failures[file_id] = this_file_failures[model_id]
         for windows in per_model.values():
             for w in windows:
                 vectors.append(np.asarray(w.vector, dtype=np.float64))
-                file_ids.append(file_id)
+                row_file_ids.append(file_id)
                 starts.append(float(w.start_s))
 
     if not vectors:
+        if extraction_failures:
+            # Every file that failed extraction has a recorded reason -- surface it instead of
+            # the generic "shorter than window_s?" guess, which misdiagnoses a load failure (a
+            # missing model, an unresolvable revision, ...) as a duration problem.
+            detail = "; ".join(f"{fid}: {reason}" for fid, reason in extraction_failures.items())
+            raise ValueError(f"no embedding windows were produced -- every file failed extraction ({detail})")
         raise ValueError("no embedding windows were produced; are the inputs shorter than window_s?")
 
     pooled = np.vstack(vectors)
@@ -226,16 +259,16 @@ def estimate_speaker_embedding_from_audios(
     method = aggregator
 
     if reject_contamination:
-        selection = select_dominant_vectors(pooled, file_ids)
+        selection = select_dominant_vectors(pooled, row_file_ids)
         keep = selection.kept_indices
         pooled = pooled[keep]
-        file_ids = [file_ids[i] for i in keep]
+        row_file_ids = [row_file_ids[i] for i in keep]
         starts = [starts[i] for i in keep]
         method = f"{aggregator}+dominant_cluster"
 
     centroid, distribution = describe_embedding_distribution(
         pooled,
-        file_ids,
+        row_file_ids,
         aggregator=aggregator,
         window_s=window_s,
         hop_s=hop_s,
@@ -255,6 +288,7 @@ def estimate_speaker_embedding_from_audios(
             n_windows_used=int(distribution.counts.n_scored),
             n_windows_dropped=n_input - int(distribution.counts.n_scored),
             created_at=created_at,
+            extraction_failures=extraction_failures,
         ),
         distribution=distribution,
     )

--- a/src/senselab/audio/tasks/speaker_embeddings/api.py
+++ b/src/senselab/audio/tasks/speaker_embeddings/api.py
@@ -182,14 +182,16 @@ def estimate_speaker_embedding_from_audios(
         raise ValueError("estimate_speaker_embedding_from_audios needs at least one audio")
 
     model_id, commit_sha, unresolved = _resolve_embedding_model(model)
-    # Deliberately *not* `SpeechBrainModel(path_or_uri=model_id, revision="main")` here: HFModel's
-    # validators (`validate_hf_model_id`, `_resolve_commit_sha`) call the Hub over the network on
-    # a cache miss, and on a cold cache `check_hf_repo_exists` -> `ensure_hf_model` runs a full
-    # `snapshot_download` -- exactly the 20 GB mistake this task was warned against, and it would
-    # fire regardless of any patch to `_resolve_embedding_model`, since it is a *separate*
-    # construction. The plain `SenselabModel` base class carries `path_or_uri` with no such
-    # validator, which is all `extract_per_window_embeddings` and its own tests need from it.
-    speaker_model: SenselabModel = model if model is not None else SenselabModel(path_or_uri=model_id)
+    # `extract_per_window_embeddings`'s contract is `models: list[str]` -- plain ids, not model
+    # objects. It constructs its own `SpeechBrainModel` per id internally, so passing the id
+    # string here is what keeps this function from ever constructing a network-validated model at
+    # all: no `SpeechBrainModel`/`HFModel` object is built anywhere in this function, on any path.
+    # (An earlier version of this code passed a `SenselabModel` object instead, matching neither
+    # the callee's declared type nor its runtime expectations -- mypy flagged the mismatch via a
+    # `# type: ignore` that should have been read as "this call is wrong" rather than suppressed;
+    # the object's `path_or_uri` was never reachable inside `extract_per_window_embeddings`'s own
+    # `SpeechBrainModel(path_or_uri=model_id, ...)` construction, so every real, unmocked call
+    # raised `KeyError`/`TypeError` before returning a single vector.)
 
     vectors: list[np.ndarray] = []
     file_ids: list[str] = []
@@ -203,14 +205,9 @@ def estimate_speaker_embedding_from_audios(
         # actual path, or `None` for an in-memory audio with no backing file.
         file_id = str(audio.filepath() or f"audio-{idx}")
         source_files.append(file_id)
-        # `models` is typed `list[str]` on the real `extract_per_window_embeddings` (plain model
-        # ids), but the model object is passed through here instead: the extraction seam -- real
-        # or, in tests, monkeypatched -- reads `.path_or_uri` off it rather than re-deriving an id
-        # string, so provenance and the mocked extraction agree on one source of truth. See the
-        # comment above on why this can't instead be a network-validated `SpeechBrainModel`.
         per_model: dict[str, list[WindowEmbedding]] = extract_per_window_embeddings(
             audio=audio,
-            models=[speaker_model],  # type: ignore[list-item]
+            models=[model_id],
             device=device,
             window_s=window_s,
             hop_s=hop_s,

--- a/src/senselab/audio/tasks/speaker_embeddings/doc.md
+++ b/src/senselab/audio/tasks/speaker_embeddings/doc.md
@@ -1,4 +1,4 @@
-# Speech to text evaluation
+# Speaker embedding extraction
 
 
 <button class="tutorial-button" onclick="window.location.href='https://github.com/sensein/senselab/blob/main/tutorials/audio/extract_speaker_embeddings.ipynb'">Tutorial</button>
@@ -41,11 +41,14 @@ Always refer to the most recent literature for up-to-date benchmarks.
 Windowing appears in two places in this task family, tuned for two different jobs, and the two settings must not be
 collapsed into one "the" default:
 
-- **Detection / temporal resolution** -- `windowing.extract_per_window_embeddings`'s own defaults,
-  `window_s=1.0, hop_s=0.5`. ECAPA / ResNet embeddings get noisier below 1 s but stay functional; the 0.5 s hop was
-  chosen to land one embedding per 0.5 s bucket on `audio_analysis`'s bucket grid, which is what removed the
-  same-window dedup that used to drop half of consecutive same-cluster comparisons. See
-  `workflows/audio_analysis/embeddings.py`'s "Why 1.0 s / 0.5 s defaults" section for the full measurement.
+- **Detection / temporal resolution** -- `windowing.extract_per_window_embeddings`'s own fallback defaults,
+  `window_s=1.0, hop_s=0.5`, exercised only when a caller passes nothing. Neither production caller does:
+  `audio_analysis`'s `data/run_config/default.yaml` runs the workflow at `window_s=0.5, hop_s=0.25`, and that file's
+  own derivation measured 1.0 s as *worse* for this job -- ARI 0.70 at 0.5 s against 0.48 at 1.0 s on a 4-speaker
+  validation clip, because a 1.0 s window straddles turn boundaries. See
+  `workflows/audio_analysis/embeddings.py`'s "Why 1.0 s / 0.5 s defaults" section for the function-level rationale
+  behind the fallback pair, and `default.yaml`'s own derivation comment for the measurement that supersedes it in
+  every real run.
 - **Profile enrollment / centroid stability** -- `estimate_speaker_embedding_from_audios`'s defaults,
   `window_s=2.0, hop_s=1.0` (`PROFILE_WINDOW_S`, `PROFILE_HOP_S` in `api.py`). Measured directly for this job: a
   2.0 s window on a 1.0 s hop gave cross-file centroid stability 0.890 and cross-subject separation 0.168, against

--- a/src/senselab/audio/tasks/speaker_embeddings/doc.md
+++ b/src/senselab/audio/tasks/speaker_embeddings/doc.md
@@ -22,6 +22,99 @@ xvector (speechbrain/spkrec-xvect-voxceleb).
 **Note**: Performance can vary significantly depending on the specific dataset, task, and evaluation protocol used.
 Always refer to the most recent literature for up-to-date benchmarks.
 
+## Two entry points
+
+- **`extract_speaker_embeddings_from_audios`** returns one embedding per input `Audio`, whole-file. Reach for this
+  when the caller already knows each file is a single, clean utterance from one speaker and only wants the vector --
+  e.g. scoring a verification pair, or feeding a downstream classifier that expects exactly one vector per file.
+  It makes no windowing decision and reports no statistics: it is the plain per-audio extractor everything else in
+  this module is built from.
+- **`estimate_speaker_embedding_from_audios`** takes a *set* of files that may contain the target speaker, windows
+  and embeds each one, pools the windows, and returns a `TargetSpeakerEmbedding` carrying both the centroid and the
+  `EmbeddingDistribution` it was estimated from. Reach for this for profile enrollment: several recordings of one
+  person, of unknown per-file purity, where the caller wants both an estimate and the evidence for how well-supported
+  it is. It decides nothing about whether the input set was clean -- see "Contamination rejection" below for the one
+  place a decision is made, and only on request.
+
+## Two window settings, two separate measurements
+
+Windowing appears in two places in this task family, tuned for two different jobs, and the two settings must not be
+collapsed into one "the" default:
+
+- **Detection / temporal resolution** -- `windowing.extract_per_window_embeddings`'s own defaults,
+  `window_s=1.0, hop_s=0.5`. ECAPA / ResNet embeddings get noisier below 1 s but stay functional; the 0.5 s hop was
+  chosen to land one embedding per 0.5 s bucket on `audio_analysis`'s bucket grid, which is what removed the
+  same-window dedup that used to drop half of consecutive same-cluster comparisons. See
+  `workflows/audio_analysis/embeddings.py`'s "Why 1.0 s / 0.5 s defaults" section for the full measurement.
+- **Profile enrollment / centroid stability** -- `estimate_speaker_embedding_from_audios`'s defaults,
+  `window_s=2.0, hop_s=1.0` (`PROFILE_WINDOW_S`, `PROFILE_HOP_S` in `api.py`). Measured directly for this job: a
+  2.0 s window on a 1.0 s hop gave cross-file centroid stability 0.890 and cross-subject separation 0.168, against
+  0.331 for a finer 0.5/0.25 grid carrying four times the windows. Finer windows do not make a better centroid here
+  -- they make a noisier one, because each window is a shorter, less certain sample of the same speaker.
+
+Both defaults can be overridden by the caller; neither is "the" senselab default, because they were fitted for
+different trade-offs (temporal resolution against centroid stability), not for the same objective at different
+resolutions.
+
+## Reading the statistics block against its analytic nulls
+
+`EmbeddingDistribution` (`senselab.utils.tasks.embedding_distribution`) **describes and never decides**: there is no
+verdict field, no boolean, no thresholded label. Every statistic is either bounded on an interpretable scale, or
+paired with a closed-form null it should be read against rather than against a fitted or remembered number:
+
+- `nulls.cos_sd_null = 1/sqrt(d)` (0.0722 at ECAPA's d=192) -- the sd of pairwise cosines between *independent random
+  directions* at this dimension.
+- `nulls.rbar_null = 1/sqrt(n)` -- the mean resultant length `n` independent directions would produce.
+- `nulls.participation_ratio_null = d*n/(d+n)` -- the Marchenko-Pastur value for white noise at this shape.
+- `nulls.auc_null = 0.5` -- the Mann-Whitney AUC of same-file vs. different-file cosines under exchangeability.
+
+**The counter-intuitive one, worth stating explicitly**: a *small* sd of cosines is not evidence of a coherent
+speaker. At d=192, independent random directions already give sd ~= 0.072 (`nulls.cos_sd_null`); an observed sd of
+0.05 is *below* that random-vector null, which is a property of the dimensionality, not of the speaker. This is why
+`sd` is never reported as a headline dispersion figure on its own in this codebase -- only next to
+`nulls.cos_sd_null`, so a reader compares the two rather than reading `sd` as if lower always meant tighter.
+
+The rest of the block follows the same discipline: `spectrum.participation_ratio` reads against
+`nulls.participation_ratio_null`; `file_effect.auc_same_file_vs_diff_file` reads against `nulls.auc_null`; and
+`file_effect.permutation_quantile` is a block-permutation reference built from the data itself rather than a second
+closed-form null, because windows overlap and shuffling individual vectors would destroy dependence the observed
+statistic retains. See the module docstring in `embedding_distribution.py` for the full derivation, including why
+silhouette, k-NN purity, intrinsic-dimensionality estimators, and von Mises-Fisher concentration are all deliberately
+absent from this block (each for a specific, mechanical reason, not a judgement call).
+
+## Contamination rejection
+
+`select_dominant_vectors` groups the pooled windows (agglomerative clustering on geodesic angular distance) and
+returns the dominant group -- **this is the one function in the distribution-statistics module that decides
+something**, which is why it is a separate, opt-in call rather than folded into `describe_embedding_distribution`.
+`estimate_speaker_embedding_from_audios(..., reject_contamination=True)` calls it and keeps only the dominant group
+before describing the result; it is off by default, because choosing a dominant group is a decision the function
+does not make on the caller's behalf unasked.
+
+What it removed is recorded, not silently discarded: `provenance.method` gains a `+dominant_cluster` suffix,
+`provenance.n_windows_dropped` counts what was cut, and the full `DominantSelection` (cluster summaries, the merge
+heights, which cut rule fired) is available from `select_dominant_vectors` directly if the caller wants to inspect
+the decision rather than just its outcome.
+
+Once contamination rejection has run, **the statistics describe the curated set, not the raw input**. A caller
+reading `EmbeddingDistribution` off a contamination-rejected pool is reading "how coherent is what we kept", not
+"how coherent was everything we were given" -- the two questions look identical in the returned fields and are not
+the same question.
+
+## Suggested vocabulary for hint tags
+
+`AudioHints.may_contain` and `AudioHints.environment` (`senselab.audio.data_structures.audio_hints`) are open
+strings, not an enum, because a closed vocabulary here would be a taxonomy nobody fitted: every corpus that didn't
+fit it would force an edit to a type definition rather than to a tag. The following is a **suggestion, not a
+contract** -- nothing downstream validates against it, and a caller is free to use any string:
+
+- `may_contain`: `read-speech`, `spontaneous-speech`, `sustained-vowel`, `cough`, `breath`, `singing`, `music`,
+  `multiple-speakers`, `silence`
+- `environment`: `quiet-room`, `clinic`, `home`, `telephone`, `outdoors`, `unknown`
+
+Using this vocabulary where it fits is useful for cross-corpus consistency, but it should be extended or ignored
+freely rather than treated as exhaustive.
+
 ## Learn more:
 - [SpeechBrain](https://speechbrain.github.io/)
 - [ECAPA-TDNN](https://arxiv.org/abs/2005.07143)

--- a/src/senselab/audio/tasks/speaker_embeddings/speechbrain.py
+++ b/src/senselab/audio/tasks/speaker_embeddings/speechbrain.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 
 from senselab.audio.data_structures import Audio
-from senselab.utils.data_structures import DeviceType, SpeechBrainModel, _select_device_and_dtype
+from senselab.utils.data_structures import DeviceType, SpeechBrainModel, _select_device_and_dtype, device_run_opt
 from senselab.utils.dependencies import (
     resolve_model,
     retry_on_transient_error,
@@ -71,7 +71,7 @@ class SpeechBrainEmbeddings:
                     EncoderClassifier.from_hparams,
                     source=str(snapshot_path),
                     savedir=str(savedir),
-                    run_opts={"device": device.value},
+                    run_opts={"device": device_run_opt(device)},
                 )
         return cls._models[key]
 

--- a/src/senselab/audio/tasks/speaker_embeddings/windowing.py
+++ b/src/senselab/audio/tasks/speaker_embeddings/windowing.py
@@ -1,0 +1,183 @@
+"""Uniform windowing and per-window speaker-embedding extraction.
+
+Lives in the task layer because two callers need it: the ``audio_analysis`` workflow's
+speaker-identity path, and ``estimate_speaker_embedding_from_audios``. It was previously private to
+that workflow; a task importing it there would invert the dependency direction, since workflows
+compose tasks and not the reverse. Promoted rather than duplicated -- two copies of a windowing
+grid drift the moment either is edited.
+
+**The defaults here are the detection defaults, and they are deliberate.** ``window_s=1.0`` with
+``hop_s=0.5`` trades embedding precision for temporal resolution: SpeechBrain speaker models are
+trained on multi-second utterances so an embedding below 1 s is noisier, but a 1.0 s window on a
+0.5 s hop yields one embedding per 0.5 s bucket, which is what eliminated the same-window dedup
+that previously dropped half of all consecutive same-cluster comparisons. Profile *enrollment*
+wants the opposite trade and passes ``window_s=2.0, hop_s=1.0`` explicitly -- measured at
+cross-file centroid stability 0.890 and cross-subject separation 0.168, against 0.331 for a
+0.5/0.25 grid carrying four times the windows. Two purposes, two measured settings; do not
+collapse them.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import torch
+
+from senselab.audio.data_structures import Audio
+from senselab.audio.tasks.speaker_embeddings import extract_speaker_embeddings_from_audios
+from senselab.utils.data_structures import DeviceType, SpeechBrainModel
+
+
+@dataclass(frozen=True)
+class WindowEmbedding:
+    """One embedding vector for a fixed time window."""
+
+    start_s: float
+    end_s: float
+    vector: np.ndarray
+
+
+def slice_audio(audio: Audio, start_s: float, end_s: float) -> Audio:
+    """Return a new ``Audio`` covering ``[start_s, end_s]`` (clamped to audio bounds).
+
+    Assumes the input is shaped ``(channels, samples)``. Multichannel audio is
+    sliced unchanged — the embedding backend's own preprocessor handles it.
+    """
+    sr = audio.sampling_rate
+    n_samples = audio.waveform.shape[-1]
+    start_sample = max(0, int(start_s * sr))
+    end_sample = min(n_samples, max(start_sample + 1, int(end_s * sr)))
+    waveform = audio.waveform[:, start_sample:end_sample]
+    return Audio(waveform=waveform, sampling_rate=sr)
+
+
+def window_starts(duration_s: float, window_s: float, hop_s: float) -> list[float]:
+    """Return window start times spanning ``[0, duration_s]``.
+
+    The last window is anchored to ``duration_s - window_s`` (or 0) so it always
+    covers exactly ``window_s`` seconds — the embedding model needs the full
+    minimum-length input.
+    """
+    if duration_s <= 0 or window_s <= 0 or hop_s <= 0:
+        return []
+    if duration_s <= window_s:
+        return [0.0]
+    starts: list[float] = []
+    t = 0.0
+    while t + window_s <= duration_s + 1e-9:
+        starts.append(t)
+        t += hop_s
+    # Pin the last window to the audio tail so we don't drop the final speaker turn.
+    last = max(0.0, duration_s - window_s)
+    if not starts or starts[-1] < last - 1e-6:
+        starts.append(last)
+    return starts
+
+
+def extract_per_window_embeddings(
+    *,
+    audio: Audio,
+    models: list[str],
+    window_s: float = 1.0,
+    hop_s: float = 0.5,
+    device: DeviceType | None = None,
+    failures: dict[str, str] | None = None,
+) -> dict[str, list[WindowEmbedding]]:
+    """Run each embedding model on every fixed window of ``audio``.
+
+    Args:
+        audio: The pass's full ``Audio`` object.
+        models: HuggingFace model ids for the embedding backends (ECAPA, ResNet, ...).
+        window_s: Window length in seconds. Defaults to 1.0.
+        hop_s: Window hop in seconds. Defaults to 0.5.
+        device: Optional device override.
+        failures: Optional dict the function will populate with
+            ``{model_id → reason}`` for any model that produced an empty result.
+            The caller can fold these into ``incomparable_reasons`` so silent
+            empty-vote behavior is auditable.
+
+    Returns:
+        ``{model_id → [WindowEmbedding, ...]}``. Each list shares the same window
+        grid across models, so ``out[m_a][i]`` and ``out[m_b][i]`` cover the same
+        time span. A model that fails to load returns ``[]`` (and writes a reason
+        into ``failures`` when provided).
+    """
+    if not models:
+        return {}
+    if audio.waveform.ndim < 2:
+        raise ValueError(
+            f"extract_per_window_embeddings expects a (channels, samples) waveform; "
+            f"got shape {tuple(audio.waveform.shape)}."
+        )
+    duration_s = audio.waveform.shape[-1] / audio.sampling_rate
+    starts = window_starts(duration_s, window_s, hop_s)
+    if not starts:
+        msg = (
+            f"audio duration ({duration_s:.3f} s) is shorter than the embedding "
+            f"window ({window_s} s); no window grid producible"
+        )
+        print(f"warn: {msg}", file=sys.stderr)
+        if failures is not None:
+            for m in models:
+                failures[m] = msg
+        return {m: [] for m in models}
+
+    audio_slices: list[Audio] = []
+    spans: list[tuple[float, float]] = []
+    for s in starts:
+        e = min(duration_s, s + window_s)
+        audio_slices.append(slice_audio(audio, s, e))
+        spans.append((s, e))
+
+    out: dict[str, list[WindowEmbedding]] = {}
+    for model_id in models:
+        try:
+            sb_model: SpeechBrainModel = SpeechBrainModel(path_or_uri=model_id, revision="main")
+            tensors = extract_speaker_embeddings_from_audios(audios=audio_slices, model=sb_model, device=device)
+            entries: list[WindowEmbedding] = []
+            for (start_s, end_s), t in zip(spans, tensors, strict=False):
+                vec = _flatten_to_1d(t)
+                entries.append(WindowEmbedding(start_s=start_s, end_s=end_s, vector=vec))
+            out[model_id] = entries
+        except Exception as exc:  # noqa: BLE001
+            # Surface per-model failure to the caller via stderr so the user can
+            # tell "model crashed" from "audio too short" — both produce an empty
+            # list, but only one is a real configuration problem.
+            msg = f"model failed during extraction: {exc!r}"
+            print(
+                f"warn: speaker-embedding model {model_id!r} {msg}",
+                file=sys.stderr,
+            )
+            if failures is not None:
+                failures[model_id] = msg
+            out[model_id] = []
+    return out
+
+
+def _flatten_to_1d(t: Any) -> np.ndarray:  # noqa: ANN401
+    """Coerce an embedding tensor / array to a 1-D ``float32`` numpy vector.
+
+    SpeechBrain returns ``(1, D)``, ``(B, D)``, or ``(K, D)`` depending on the
+    backend; ``.squeeze()`` would silently leave a 2-D ``(K, D)`` if K>1, which
+    the cosine helper then sees as a length-mismatch and drops to ``None``. Here
+    we always reshape to a single 1-D vector — when the backend returns multiple
+    candidate vectors we average them (the closest the workflow can do without
+    backend-specific knowledge).
+    """
+    if t is None:
+        return np.zeros(0, dtype=np.float32)
+    if isinstance(t, torch.Tensor):
+        arr = t.detach().cpu().numpy()
+    else:
+        arr = np.asarray(t)
+    if arr.size == 0:
+        return np.zeros(0, dtype=np.float32)
+    while arr.ndim > 1 and arr.shape[0] == 1:
+        arr = arr[0]
+    if arr.ndim > 1:
+        # Multiple candidate vectors → average to a single representative.
+        arr = arr.mean(axis=tuple(range(arr.ndim - 1)))
+    return arr.astype(np.float32, copy=False)

--- a/src/senselab/audio/tasks/speaker_embeddings/windowing.py
+++ b/src/senselab/audio/tasks/speaker_embeddings/windowing.py
@@ -6,15 +6,18 @@ that workflow; a task importing it there would invert the dependency direction, 
 compose tasks and not the reverse. Promoted rather than duplicated -- two copies of a windowing
 grid drift the moment either is edited.
 
-**The defaults here are the detection defaults, and they are deliberate.** ``window_s=1.0`` with
-``hop_s=0.5`` trades embedding precision for temporal resolution: SpeechBrain speaker models are
-trained on multi-second utterances so an embedding below 1 s is noisier, but a 1.0 s window on a
-0.5 s hop yields one embedding per 0.5 s bucket, which is what eliminated the same-window dedup
-that previously dropped half of all consecutive same-cluster comparisons. Profile *enrollment*
-wants the opposite trade and passes ``window_s=2.0, hop_s=1.0`` explicitly -- measured at
-cross-file centroid stability 0.890 and cross-subject separation 0.168, against 0.331 for a
-0.5/0.25 grid carrying four times the windows. Two purposes, two measured settings; do not
-collapse them.
+**``window_s=1.0``, ``hop_s=0.5`` here are this function's own fallback, exercised only when a
+caller passes nothing -- neither production caller does.** ``audio_analysis.compute.harvest_pass``
+and ``adaptive.backends.embed_windows`` both pass explicit values sourced from
+``workflows/audio_analysis/data/run_config/default.yaml``'s ``embeddings:`` block, currently
+``window_s=0.5, hop_s=0.25``. That file's own derivation measured 1.0 s as *worse* for this job --
+ARI 0.70 at 0.5 s against 0.48 at 1.0 s on a 4-speaker validation clip, because a 1.0 s window
+straddles turn boundaries. The 1.0/0.5 pair below predates that measurement and is kept only as a
+conservative fallback for a caller that supplies no config. Profile *enrollment* wants a third,
+different trade and passes ``window_s=2.0, hop_s=1.0`` explicitly -- measured at cross-file
+centroid stability 0.890 and cross-subject separation 0.168, against 0.331 for a 0.5/0.25 grid
+carrying four times the windows. Three numbers, three separately measured jobs; do not collapse
+them.
 """
 
 from __future__ import annotations
@@ -90,6 +93,7 @@ def extract_per_window_embeddings(
     hop_s: float = 0.5,
     device: DeviceType | None = None,
     failures: dict[str, str] | None = None,
+    revision: str | None = None,
 ) -> dict[str, list[WindowEmbedding]]:
     """Run each embedding model on every fixed window of ``audio``.
 
@@ -103,6 +107,15 @@ def extract_per_window_embeddings(
             ``{model_id → reason}`` for any model that produced an empty result.
             The caller can fold these into ``incomparable_reasons`` so silent
             empty-vote behavior is auditable.
+        revision: The commit SHA (or ref) to load every model in ``models`` at. ``None`` (the
+            default) resolves each model's own ``"main"`` to a SHA independently, which is what
+            the two existing production callers get since neither passes this. Always resolved to
+            a full 40-hex SHA before ``SpeechBrainModel`` construction -- through
+            ``resolve_revision``, which short-circuits for free when this is already a SHA -- so
+            the model that loads is never addressed by a mutable ref. A caller that has already
+            resolved its own commit (e.g. ``estimate_speaker_embedding_from_audios``) passes it
+            here specifically so the SHA it records in provenance is the SHA that produced the
+            vector, not a second, possibly different, resolution of ``"main"``.
 
     Returns:
         ``{model_id → [WindowEmbedding, ...]}``. Each list shares the same window
@@ -140,7 +153,15 @@ def extract_per_window_embeddings(
     out: dict[str, list[WindowEmbedding]] = {}
     for model_id in models:
         try:
-            sb_model: SpeechBrainModel = SpeechBrainModel(path_or_uri=model_id, revision="main")
+            # Imported inside the loop, not at module scope: a test patches
+            # `model_revision.resolve_revision` to avoid a live Hub call, and that patch is only
+            # visible to a call-time lookup of the name -- a module-level `from ... import` would
+            # bind the pre-patch function object here and never see the substitution. Same
+            # constraint as `api._resolve_embedding_model`.
+            from senselab.utils.model_revision import resolve_revision
+
+            resolved_revision = resolve_revision(model_id, revision or "main")
+            sb_model: SpeechBrainModel = SpeechBrainModel(path_or_uri=model_id, revision=resolved_revision)
             tensors = extract_speaker_embeddings_from_audios(audios=audio_slices, model=sb_model, device=device)
             entries: list[WindowEmbedding] = []
             for (start_s, end_s), t in zip(spans, tensors, strict=False):

--- a/src/senselab/audio/tasks/speaker_embeddings/windowing.py
+++ b/src/senselab/audio/tasks/speaker_embeddings/windowing.py
@@ -27,7 +27,12 @@ import numpy as np
 import torch
 
 from senselab.audio.data_structures import Audio
-from senselab.audio.tasks.speaker_embeddings import extract_speaker_embeddings_from_audios
+
+# Imported from the submodule, not the `speaker_embeddings` package `__init__`: Task 8's estimator
+# (`api.py`) imports this module, so importing the package here instead would re-enter `__init__`
+# while it is still mid-import and hand back a partially initialized module -- exactly the
+# `ImportError: ... partially initialized module` failure this leaf-edge form avoids.
+from senselab.audio.tasks.speaker_embeddings.api import extract_speaker_embeddings_from_audios
 from senselab.utils.data_structures import DeviceType, SpeechBrainModel
 
 

--- a/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
+++ b/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
@@ -7,7 +7,7 @@ import torch
 
 from senselab.audio.data_structures import Audio
 from senselab.audio.tasks.preprocessing import concatenate_audios, evenly_segment_audios
-from senselab.utils.data_structures import DeviceType, SpeechBrainModel, _select_device_and_dtype
+from senselab.utils.data_structures import DeviceType, SpeechBrainModel, _select_device_and_dtype, device_run_opt
 from senselab.utils.data_structures.logging import logger
 from senselab.utils.dependencies import (
     resolve_model,
@@ -73,7 +73,7 @@ class SpeechBrainEnhancer:
                         enhance_model.from_hparams,
                         source=str(snapshot_path),
                         savedir=str(savedir),
-                        run_opts={"device": device.value},
+                        run_opts={"device": device_run_opt(device)},
                     )
                 except Exception as e:
                     logger.info("Trying SepformerSeparation model after SpectralMaskEnhancement failed: %s", e)
@@ -81,7 +81,7 @@ class SpeechBrainEnhancer:
                         separator.from_hparams,
                         source=str(snapshot_path),
                         savedir=str(savedir),
-                        run_opts={"device": device.value},
+                        run_opts={"device": device_run_opt(device)},
                     )
 
         return cls._models[key], device, dtype

--- a/src/senselab/audio/tasks/ssl_embeddings/self_supervised_features.py
+++ b/src/senselab/audio/tasks/ssl_embeddings/self_supervised_features.py
@@ -8,7 +8,13 @@ import torch.nn.functional as F
 from transformers import AutoFeatureExtractor, AutoModel
 
 from senselab.audio.data_structures import Audio
-from senselab.utils.data_structures import DeviceType, HFModel, SpeechBrainModel, _select_device_and_dtype
+from senselab.utils.data_structures import (
+    DeviceType,
+    HFModel,
+    SpeechBrainModel,
+    _select_device_and_dtype,
+    device_run_opt,
+)
 from senselab.utils.dependencies import (
     resolve_model,
     retry_on_transient_error,
@@ -198,7 +204,7 @@ class SpeechBrainSSLEmbeddings:
                     EncoderClassifier.from_hparams,
                     source=str(snapshot_path),
                     savedir=str(savedir),
-                    run_opts={"device": device.value},
+                    run_opts={"device": device_run_opt(device)},
                 )
         return cls._models[key]
 

--- a/src/senselab/audio/workflows/audio_analysis/embeddings.py
+++ b/src/senselab/audio/workflows/audio_analysis/embeddings.py
@@ -1,9 +1,11 @@
 """Per-window speaker-embedding extraction.
 
-Slices the pass audio into uniform fixed-duration windows (default 2.0 s with 1.0 s
+Slices the pass audio into uniform fixed-duration windows (default 1.0 s with 0.5 s
 hop) and runs each requested embedding model on every window. Output is a list of
 ``(start_s, end_s, vector_np)`` per model, written to disk by the caller and consumed
-by the speaker workflow.
+by the speaker workflow. Profile enrollment wants the opposite trade and passes
+``window_s=2.0, hop_s=1.0`` explicitly — see ``tasks/speaker_embeddings``. Two
+purposes, two measured settings.
 
 Why windows, not diarization segments
 -------------------------------------
@@ -50,7 +52,6 @@ __all__ = [
     "window_embedding_at",
     "window_index_at",
     "cluster_pass_speakers",
-    "silhouette_voice_score",
     "calibrate_cosine_uncertainty",
 ]
 
@@ -118,8 +119,8 @@ def cluster_pass_speakers(
         is_speech_per_window: Boolean mask per ``entries`` index indicating
             whether the window contains speech (per YAMNet / AST / loudness).
             When provided, only ``True`` windows participate in clustering;
-            ``False`` windows get ``cluster_id="NOISE"`` and ``p_voice = 0.0``.
-            This stops silent / background windows from being counted as a
+            ``False`` windows get ``cluster_id="NOISE"``. This stops silent
+            / background windows from being counted as a
             "speaker" — the bug that previously inflated ``n_speakers`` on
             recordings with long silent stretches. ``None`` clusters every
             non-zero-norm window (legacy behavior).
@@ -138,7 +139,7 @@ def cluster_pass_speakers(
        clustering algorithm on L2-normalized embedding vectors.
     3. **Pick k\* = argmax silhouette_score** across the sweep.
     4. **If best silhouette ≥ coherent_silhouette_threshold** → multi-cluster regime:
-       ``n_speakers = k\*``; per-window ``p_voice`` is the rescaled silhouette.
+       ``n_speakers = k\*``.
     5. **Else** → single-cluster regime (1 if the speech windows cluster
        tightly around the mean, 0 if even that fails).
 
@@ -147,14 +148,13 @@ def cluster_pass_speakers(
     pass-wide cluster ids (``C0``…) that harmonise labels across diar models, and from the
     fused speaker ids (``S0``…) in ``final/speakers.json``; three namespaces that all read
     as "S0" made the label-correspondence table unreadable on a real run. Non-speech
-    or zero-norm windows are tagged ``"NOISE"``. ``p_voice`` is keyed by the
-    window index in ``entries``.
+    or zero-norm windows are tagged ``"NOISE"``.
 
     Returns ``None`` when too few windows to cluster, or sklearn unavailable.
     """
     try:
         from sklearn.cluster import KMeans, SpectralClustering
-        from sklearn.metrics import silhouette_samples, silhouette_score
+        from sklearn.metrics import silhouette_score
     except ImportError as exc:
         msg = f"sklearn unavailable for clustering: {exc!r}"
         print(f"warn: cluster_pass_speakers skipped: {msg}", file=sys.stderr)
@@ -179,11 +179,9 @@ def cluster_pass_speakers(
         valid_indices.append(i)
 
     cluster_labels: dict[int, str] = {}
-    p_voice: dict[int, float] = {}
     for i in range(len(entries)):
         if i not in valid_indices:
             cluster_labels[i] = "NOISE"
-            p_voice[i] = 0.0
 
     if not valid_indices:
         msg = "no valid speech embedding windows (all filtered as zero-norm or non-speech)"
@@ -194,7 +192,6 @@ def cluster_pass_speakers(
             "n_speakers": 0,
             "best_silhouette": None,
             "labels": cluster_labels,
-            "p_voice": p_voice,
             "valid_indices": [],
         }
 
@@ -205,14 +202,12 @@ def cluster_pass_speakers(
     if len(vectors) < min_windows_for_clustering:
         for idx in valid_indices:
             cluster_labels[idx] = "spk0"
-            p_voice[idx] = 1.0
         band = _within_cluster_band(np.stack(vectors, axis=0)) if vectors else None
         same_floor, diff_floor = band if band is not None else (None, None)
         return {
             "n_speakers": 1,
             "best_silhouette": None,
             "labels": cluster_labels,
-            "p_voice": p_voice,
             "valid_indices": list(valid_indices),
             "empirical_same_speaker_floor": same_floor,
             "empirical_diff_speaker_floor": diff_floor,
@@ -333,16 +328,8 @@ def cluster_pass_speakers(
         # Renumber to spk0..spk(n-1) so downstream label sets are dense.
         relabel = {old: new for new, old in enumerate(unique_after_merge)}
         best_labels = np.array([relabel[int(x)] for x in best_labels], dtype=int)
-        try:
-            per_sample = silhouette_samples(X, best_labels, metric="cosine") if n_speakers_final >= 2 else None
-        except ValueError:
-            per_sample = None
         for vi, idx in enumerate(valid_indices):
             cluster_labels[idx] = f"spk{int(best_labels[vi])}"
-            if per_sample is None:
-                p_voice[idx] = 1.0 if n_speakers_final == 1 else 0.5
-            else:
-                p_voice[idx] = max(0.0, min(1.0, 0.5 * (float(per_sample[vi]) + 1.0)))
         # Empirical per-pass calibration band for the speaker-axis cosine
         # validation: ``same_floor`` = 75th percentile of within-cluster
         # pairwise cos_dist (most same-speaker pairs are below this),
@@ -358,7 +345,6 @@ def cluster_pass_speakers(
             "n_speakers": n_speakers_final,
             "best_silhouette": float(best_overall),
             "labels": cluster_labels,
-            "p_voice": p_voice,
             "valid_indices": list(valid_indices),
             "empirical_same_speaker_floor": same_floor,
             "empirical_diff_speaker_floor": diff_floor,
@@ -373,12 +359,10 @@ def cluster_pass_speakers(
         # All-zero pass — no detectable voice.
         for idx in valid_indices:
             cluster_labels[idx] = "NOISE"
-            p_voice[idx] = 0.0
         return {
             "n_speakers": 0,
             "best_silhouette": float(best_overall) if best_overall > -1.0 else None,
             "labels": cluster_labels,
-            "p_voice": p_voice,
             "valid_indices": list(valid_indices),
         }
     centroid_unit = centroid / centroid_norm
@@ -386,32 +370,40 @@ def cluster_pass_speakers(
     mean_sim = float(np.mean(sims))
     if mean_sim >= coherent_silhouette_threshold:
         # Single coherent speaker.
-        for vi, idx in enumerate(valid_indices):
+        for idx in valid_indices:
             cluster_labels[idx] = "spk0"
-            # cos sim → [0,1] via (s+1)/2.
-            p_voice[idx] = max(0.0, min(1.0, 0.5 * (float(sims[vi]) + 1.0)))
         band = _within_cluster_band(X)
         same_floor, diff_floor = band if band is not None else (None, None)
         return {
             "n_speakers": 1,
             "best_silhouette": float(best_overall) if best_overall > -1.0 else None,
             "labels": cluster_labels,
-            "p_voice": p_voice,
             "valid_indices": list(valid_indices),
             "empirical_same_speaker_floor": same_floor,
             "empirical_diff_speaker_floor": diff_floor,
         }
     # No coherent cluster — likely noise / silence dominated.
-    for vi, idx in enumerate(valid_indices):
+    for idx in valid_indices:
         cluster_labels[idx] = "NOISE"
-        p_voice[idx] = max(0.0, min(1.0, 0.5 * (float(sims[vi]) + 1.0)))
     return {
         "n_speakers": 0,
         "best_silhouette": float(best_overall) if best_overall > -1.0 else None,
         "labels": cluster_labels,
-        "p_voice": p_voice,
         "valid_indices": list(valid_indices),
     }
+
+
+# A per-window map computed as ``0.5 * (silhouette + 1)`` used to live here, rescaling a
+# clustering-geometry index into a value that reads as a probability. A silhouette
+# coefficient is a property of a chosen partition on a chosen metric, not a probability:
+# silhouette computed with cosine and with Euclidean return different numbers for identical
+# geometry on unit vectors, so any probability read off it is a probability about a
+# parameterisation choice. The L1 post-processing register (item 12) removed the consumer —
+# the presence voter that read it as confidence with no ramp and no anchors, contributing a
+# near-constant ~0.44 doubt across every bucket while earning the highest fusion weight of
+# fifteen signals precisely because it was near-constant (see ``speech_presence_link.py``'s
+# comment on ``_silhouette_votes_by_bucket``). Nothing else reads the per-window value, so
+# this removes the computation rather than leaving a renamed field with no reader.
 
 
 def _merge_close_clusters(
@@ -614,26 +606,6 @@ def _within_cluster_band(
         # out rather than returning an inverted band that would score every comparison.
         diff_floor = min(0.95, same_floor + 0.20)
     return same_floor, diff_floor
-
-
-def silhouette_voice_score(
-    entries: list[WindowEmbedding],
-    *,
-    n_clusters_max: int = 6,
-    min_windows_for_clustering: int = 4,
-) -> dict[int, float] | None:
-    """Backwards-compatible thin wrapper returning just the per-window p_voice map.
-
-    Prefer ``cluster_pass_speakers`` for new code — it also exposes the
-    estimated speaker count and per-window cluster labels (used to synthesise
-    an embedding-derived diarization source).
-    """
-    res = cluster_pass_speakers(
-        entries,
-        n_clusters_max=n_clusters_max,
-        min_windows_for_clustering=min_windows_for_clustering,
-    )
-    return None if res is None else res["p_voice"]
 
 
 def calibrate_cosine_uncertainty(

--- a/src/senselab/audio/workflows/audio_analysis/embeddings.py
+++ b/src/senselab/audio/workflows/audio_analysis/embeddings.py
@@ -31,167 +31,28 @@ and ``hop_s``.
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
-import torch
 
-from senselab.audio.data_structures import Audio
-from senselab.audio.tasks.speaker_embeddings import extract_speaker_embeddings_from_audios
-from senselab.utils.data_structures import DeviceType, SpeechBrainModel
+from senselab.audio.tasks.speaker_embeddings.windowing import (
+    WindowEmbedding,
+    extract_per_window_embeddings,
+    slice_audio,
+    window_starts,
+)
 
-
-@dataclass(frozen=True)
-class WindowEmbedding:
-    """One embedding vector for a fixed time window."""
-
-    start_s: float
-    end_s: float
-    vector: np.ndarray
-
-
-def _slice_audio(audio: Audio, start_s: float, end_s: float) -> Audio:
-    """Return a new ``Audio`` covering ``[start_s, end_s]`` (clamped to audio bounds).
-
-    Assumes the input is shaped ``(channels, samples)``. Multichannel audio is
-    sliced unchanged — the embedding backend's own preprocessor handles it.
-    """
-    sr = audio.sampling_rate
-    n_samples = audio.waveform.shape[-1]
-    start_sample = max(0, int(start_s * sr))
-    end_sample = min(n_samples, max(start_sample + 1, int(end_s * sr)))
-    waveform = audio.waveform[:, start_sample:end_sample]
-    return Audio(waveform=waveform, sampling_rate=sr)
-
-
-def _window_starts(duration_s: float, window_s: float, hop_s: float) -> list[float]:
-    """Return window start times spanning ``[0, duration_s]``.
-
-    The last window is anchored to ``duration_s - window_s`` (or 0) so it always
-    covers exactly ``window_s`` seconds — the embedding model needs the full
-    minimum-length input.
-    """
-    if duration_s <= 0 or window_s <= 0 or hop_s <= 0:
-        return []
-    if duration_s <= window_s:
-        return [0.0]
-    starts: list[float] = []
-    t = 0.0
-    while t + window_s <= duration_s + 1e-9:
-        starts.append(t)
-        t += hop_s
-    # Pin the last window to the audio tail so we don't drop the final speaker turn.
-    last = max(0.0, duration_s - window_s)
-    if not starts or starts[-1] < last - 1e-6:
-        starts.append(last)
-    return starts
-
-
-def extract_per_window_embeddings(
-    *,
-    audio: Audio,
-    models: list[str],
-    window_s: float = 1.0,
-    hop_s: float = 0.5,
-    device: DeviceType | None = None,
-    failures: dict[str, str] | None = None,
-) -> dict[str, list[WindowEmbedding]]:
-    """Run each embedding model on every fixed window of ``audio``.
-
-    Args:
-        audio: The pass's full ``Audio`` object.
-        models: HuggingFace model ids for the embedding backends (ECAPA, ResNet, ...).
-        window_s: Window length in seconds. Defaults to 1.0.
-        hop_s: Window hop in seconds. Defaults to 0.5.
-        device: Optional device override.
-        failures: Optional dict the function will populate with
-            ``{model_id → reason}`` for any model that produced an empty result.
-            The caller can fold these into ``incomparable_reasons`` so silent
-            empty-vote behavior is auditable.
-
-    Returns:
-        ``{model_id → [WindowEmbedding, ...]}``. Each list shares the same window
-        grid across models, so ``out[m_a][i]`` and ``out[m_b][i]`` cover the same
-        time span. A model that fails to load returns ``[]`` (and writes a reason
-        into ``failures`` when provided).
-    """
-    if not models:
-        return {}
-    if audio.waveform.ndim < 2:
-        raise ValueError(
-            f"extract_per_window_embeddings expects a (channels, samples) waveform; "
-            f"got shape {tuple(audio.waveform.shape)}."
-        )
-    duration_s = audio.waveform.shape[-1] / audio.sampling_rate
-    starts = _window_starts(duration_s, window_s, hop_s)
-    if not starts:
-        msg = (
-            f"audio duration ({duration_s:.3f} s) is shorter than the embedding "
-            f"window ({window_s} s); no window grid producible"
-        )
-        print(f"warn: {msg}", file=sys.stderr)
-        if failures is not None:
-            for m in models:
-                failures[m] = msg
-        return {m: [] for m in models}
-
-    audio_slices: list[Audio] = []
-    spans: list[tuple[float, float]] = []
-    for s in starts:
-        e = min(duration_s, s + window_s)
-        audio_slices.append(_slice_audio(audio, s, e))
-        spans.append((s, e))
-
-    out: dict[str, list[WindowEmbedding]] = {}
-    for model_id in models:
-        try:
-            sb_model: SpeechBrainModel = SpeechBrainModel(path_or_uri=model_id, revision="main")
-            tensors = extract_speaker_embeddings_from_audios(audios=audio_slices, model=sb_model, device=device)
-            entries: list[WindowEmbedding] = []
-            for (start_s, end_s), t in zip(spans, tensors, strict=False):
-                vec = _flatten_to_1d(t)
-                entries.append(WindowEmbedding(start_s=start_s, end_s=end_s, vector=vec))
-            out[model_id] = entries
-        except Exception as exc:  # noqa: BLE001
-            # Surface per-model failure to the caller via stderr so the user can
-            # tell "model crashed" from "audio too short" — both produce an empty
-            # list, but only one is a real configuration problem.
-            msg = f"model failed during extraction: {exc!r}"
-            print(
-                f"warn: speaker-embedding model {model_id!r} {msg}",
-                file=sys.stderr,
-            )
-            if failures is not None:
-                failures[model_id] = msg
-            out[model_id] = []
-    return out
-
-
-def _flatten_to_1d(t: Any) -> np.ndarray:  # noqa: ANN401
-    """Coerce an embedding tensor / array to a 1-D ``float32`` numpy vector.
-
-    SpeechBrain returns ``(1, D)``, ``(B, D)``, or ``(K, D)`` depending on the
-    backend; ``.squeeze()`` would silently leave a 2-D ``(K, D)`` if K>1, which
-    the cosine helper then sees as a length-mismatch and drops to ``None``. Here
-    we always reshape to a single 1-D vector — when the backend returns multiple
-    candidate vectors we average them (the closest the workflow can do without
-    backend-specific knowledge).
-    """
-    if t is None:
-        return np.zeros(0, dtype=np.float32)
-    if isinstance(t, torch.Tensor):
-        arr = t.detach().cpu().numpy()
-    else:
-        arr = np.asarray(t)
-    if arr.size == 0:
-        return np.zeros(0, dtype=np.float32)
-    while arr.ndim > 1 and arr.shape[0] == 1:
-        arr = arr[0]
-    if arr.ndim > 1:
-        # Multiple candidate vectors → average to a single representative.
-        arr = arr.mean(axis=tuple(range(arr.ndim - 1)))
-    return arr.astype(np.float32, copy=False)
+__all__ = [
+    "WindowEmbedding",
+    "extract_per_window_embeddings",
+    "slice_audio",
+    "window_starts",
+    "window_embedding_at",
+    "window_index_at",
+    "cluster_pass_speakers",
+    "silhouette_voice_score",
+    "calibrate_cosine_uncertainty",
+]
 
 
 def window_embedding_at(

--- a/src/senselab/audio/workflows/audio_analysis/quality.py
+++ b/src/senselab/audio/workflows/audio_analysis/quality.py
@@ -51,7 +51,7 @@ from senselab.audio.tasks.quality_control.metrics import (
     spectral_gating_snr_metric,
 )
 from senselab.audio.tasks.scene_quality.brouhaha import BROUHAHA_MODEL_ID, BROUHAHA_REVISION, BrouhahaFrames
-from senselab.audio.workflows.audio_analysis.embeddings import _slice_audio, _window_starts
+from senselab.audio.tasks.speaker_embeddings.windowing import slice_audio, window_starts
 from senselab.audio.workflows.audio_analysis.grid import BucketGrid
 from senselab.audio.workflows.audio_analysis.resolution import resample_series
 from senselab.audio.workflows.audio_analysis.shapes import Series
@@ -266,11 +266,11 @@ def harvest_quality_measurements(
     if duration_s <= 0:
         return []
 
-    starts = _window_starts(duration_s, QUALITY_ANALYSIS_WIN_S, QUALITY_ANALYSIS_HOP_S)
+    starts = window_starts(duration_s, QUALITY_ANALYSIS_WIN_S, QUALITY_ANALYSIS_HOP_S)
     analysis: list[dict[str, Any]] = []
     for t in starts:
         end = min(duration_s, t + QUALITY_ANALYSIS_WIN_S)
-        window = _analysis_window(_slice_audio(audio, t, end), brouhaha, t, end)
+        window = _analysis_window(slice_audio(audio, t, end), brouhaha, t, end)
         window["_center"] = 0.5 * (t + end)
         analysis.append(window)
 
@@ -353,14 +353,14 @@ def quality_series(*, audio: Audio, brouhaha: Optional[BrouhahaFrames]) -> dict[
     duration_s = float(audio.waveform.shape[-1]) / float(audio.sampling_rate)
     if duration_s <= 0:
         return {}
-    starts = _window_starts(duration_s, QUALITY_ANALYSIS_WIN_S, QUALITY_ANALYSIS_HOP_S)
+    starts = window_starts(duration_s, QUALITY_ANALYSIS_WIN_S, QUALITY_ANALYSIS_HOP_S)
     if not starts:
         return {}
 
     windows = []
     for t in starts:
         end = min(duration_s, t + QUALITY_ANALYSIS_WIN_S)
-        windows.append(_analysis_window(_slice_audio(audio, t, end), brouhaha, t, end))
+        windows.append(_analysis_window(slice_audio(audio, t, end), brouhaha, t, end))
 
     out: dict[str, Series] = {}
     for name in QUALITY_SIGNALS:

--- a/src/senselab/utils/data_structures/__init__.py
+++ b/src/senselab/utils/data_structures/__init__.py
@@ -1,7 +1,7 @@
 """This module provides the APIs of the senselab utils data structures."""
 
 from .dataset import Participant, SenselabDataset, Session  # noqa: F401
-from .device import DeviceType, _select_device_and_dtype  # noqa: F401
+from .device import DeviceType, _select_device_and_dtype, device_run_opt  # noqa: F401
 from .file import File, from_strings_to_files, get_common_directory  # noqa: F401
 from .language import Language  # noqa: F401
 from .logging import logger  # noqa: F401

--- a/src/senselab/utils/data_structures/device.py
+++ b/src/senselab/utils/data_structures/device.py
@@ -146,3 +146,35 @@ def _select_device_and_dtype(
             return DeviceType.CPU, DTYPE_MAP[DeviceType.CPU]
         else:
             raise ValueError("Something went wrong and no devices were available or compatible.")
+
+
+def device_run_opt(device: DeviceType) -> str:
+    """Return a concrete device string suitable for a library's ``run_opts["device"]``.
+
+    ``DeviceType.CUDA.value`` is the bare string ``"cuda"``, which several libraries cannot
+    parse. SpeechBrain in particular does ``device.split(":")`` and, when that unpack fails,
+    logs "Could not parse CUDA device string" and calls ``torch.cuda.set_device(0)`` itself
+    (``speechbrain/inference/interfaces.py``). That silently discards the caller's choice:
+    on a node with several visible GPUs it moves the model to card 0 no matter which one was
+    selected.
+
+    The index therefore comes from ``torch.cuda.current_device()`` rather than a hardcoded
+    ``0``. That is what makes this correct on a cluster: under Slurm, ``CUDA_VISIBLE_DEVICES``
+    masks the allocation so the granted GPU is index 0 *inside the process* and this returns
+    ``"cuda:0"`` — the allocated card, not merely the first one on the host — while a caller
+    who selected a device explicitly gets the card they chose.
+
+    Args:
+        device: The selected device.
+
+    Returns:
+        ``"cuda:<index>"`` for CUDA when a GPU is actually visible, otherwise the device's
+        bare value. ``cpu`` and ``mps`` take no index -- ``"cpu:0"`` is not a valid device
+        string -- and a CUDA request with no visible GPU stays bare so the downstream
+        library raises its own clearer error rather than this helper failing first.
+    """
+    if device is not DeviceType.CUDA:
+        return str(device.value)
+    if not torch.cuda.is_available():
+        return str(device.value)
+    return f"cuda:{torch.cuda.current_device()}"

--- a/src/senselab/utils/tasks/data/embedding_gap_significance.json
+++ b/src/senselab/utils/tasks/data/embedding_gap_significance.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "margin": 5.0,
+  "scope": "The significance margin select_dominant_vectors requires the largest merge-height gap to beat the runner-up gap by before trusting it as a real cluster split, rather than the largest fluctuation a single coherent group produces by chance. Guards only the derived branch (cut_theta=None); a caller-supplied cut_theta, and a caller-supplied gap_significance_margin, bypass this file entirely and are recorded with source='caller'.",
+  "derivation": "A first implementation used argmax(diff(merge_heights)) with no significance test and failed the brief's own fixed-seed single-coherent fixture (n=50, d=32, spread=0.02): the top gap sat near the leaves from sampling noise, not at the root. Fixed by requiring the top gap to exceed margin * runner-up-gap. The first-cut margin (2.0) was chosen from that one fixture's ratio (1.87x) against two other fixed-seed fixtures' ratios (86x, 187x) -- a single-seed eyeball, not a distribution, and code review caught it: an independent 300-draw sweep at the same fixture measured a 4.03x max and a 15.7% rate of ratio > 2.0, i.e. a 1-in-6 false-split rate on genuinely homogeneous input. This file replaces that eyeball with a proper sweep and a stated target. Swept the null (single coherent vMF cone, no intruder) over n in {30,50,100,200,300}, d in {32,64,192,256} (192-256 bracket real speaker-embedding dimensionality), spread in {0.01,0.02,0.05,0.1}, 20 independent-seed draws per (n,d,spread) cell -- 80 cells, 1600 draws total, seeds 100000..101599 via numpy.random.default_rng, each draw an independent axis plus a fresh cone. For each draw: AHC average-linkage on geodesic angular distance (identical to the runtime path), then top-gap / runner-up-gap over the merge-height diffs. Observed quantiles of that ratio: p50=1.399, p90=2.590, p95=3.060, p99=4.840, p99.5=5.462, p99.9=6.363, max=9.330 (n=1600). False-split rate (fraction of the 1600 draws whose ratio exceeds the margin) by candidate margin: 2.0 -> 20.31%, 3.0 -> 5.56%, 4.0 -> 2.12%, 4.5 -> 1.38%, 5.0 -> 0.88%, 6.0 -> 0.31%, 8.0 -> 0.06%, 10.0 -> 0.00%. Target stated up front: false-split rate <= 1%. margin=5.0 is the smallest tested value clearing that target (0.88% achieved, with 4.5 at 1.38% failing it), so it is chosen as the value with the least unnecessary insensitivity to genuine splits while meeting the stated rate. Real-split ratios measured on this module's own fixed-seed fixtures for comparison, none of which this margin should ever gate: two_speakers (60 target/20 intruder, near-orthogonal) ~86x; file_balanced (200 long-file vs 30 target across 3 files) ~187x; the 0.35 rad-separated cut-scaling regression fixture ~23x. All three clear margin=5.0 by at least 4.5x, so the chosen value costs no known real-split test in this module.",
+  "sweep": {
+    "n_values": [30, 50, 100, 200, 300],
+    "d_values": [32, 64, 192, 256],
+    "spread_values": [0.01, 0.02, 0.05, 0.1],
+    "draws_per_cell": 20,
+    "n_cells": 80,
+    "n_draws_total": 1600,
+    "seed_scheme": "numpy.random.default_rng(100000 + i) for i in range(1600), row-major over (n, d, spread, draw)",
+    "statistic": "top-gap / runner-up-gap over np.diff(merge_heights), average-linkage AHC on geodesic angular distance",
+    "quantiles": {
+      "p50": 1.399,
+      "p90": 2.590,
+      "p95": 3.060,
+      "p99": 4.840,
+      "p995": 5.462,
+      "p999": 6.363,
+      "max": 9.330
+    },
+    "false_split_rate_by_margin": {
+      "2.0": 0.20313,
+      "3.0": 0.05563,
+      "4.0": 0.02125,
+      "4.5": 0.01375,
+      "5.0": 0.00875,
+      "6.0": 0.00313,
+      "8.0": 0.00063,
+      "10.0": 0.0
+    },
+    "target_false_split_rate": 0.01,
+    "chosen_margin": 5.0,
+    "achieved_false_split_rate": 0.00875
+  }
+}

--- a/src/senselab/utils/tasks/data/embedding_gap_significance.json
+++ b/src/senselab/utils/tasks/data/embedding_gap_significance.json
@@ -1,38 +1,54 @@
 {
-  "version": 1,
-  "margin": 5.0,
-  "scope": "The significance margin select_dominant_vectors requires the largest merge-height gap to beat the runner-up gap by before trusting it as a real cluster split, rather than the largest fluctuation a single coherent group produces by chance. Guards only the derived branch (cut_theta=None); a caller-supplied cut_theta, and a caller-supplied gap_significance_margin, bypass this file entirely and are recorded with source='caller'.",
-  "derivation": "A first implementation used argmax(diff(merge_heights)) with no significance test and failed the brief's own fixed-seed single-coherent fixture (n=50, d=32, spread=0.02): the top gap sat near the leaves from sampling noise, not at the root. Fixed by requiring the top gap to exceed margin * runner-up-gap. The first-cut margin (2.0) was chosen from that one fixture's ratio (1.87x) against two other fixed-seed fixtures' ratios (86x, 187x) -- a single-seed eyeball, not a distribution, and code review caught it: an independent 300-draw sweep at the same fixture measured a 4.03x max and a 15.7% rate of ratio > 2.0, i.e. a 1-in-6 false-split rate on genuinely homogeneous input. This file replaces that eyeball with a proper sweep and a stated target. Swept the null (single coherent vMF cone, no intruder) over n in {30,50,100,200,300}, d in {32,64,192,256} (192-256 bracket real speaker-embedding dimensionality), spread in {0.01,0.02,0.05,0.1}, 20 independent-seed draws per (n,d,spread) cell -- 80 cells, 1600 draws total, seeds 100000..101599 via numpy.random.default_rng, each draw an independent axis plus a fresh cone. For each draw: AHC average-linkage on geodesic angular distance (identical to the runtime path), then top-gap / runner-up-gap over the merge-height diffs. Observed quantiles of that ratio: p50=1.399, p90=2.590, p95=3.060, p99=4.840, p99.5=5.462, p99.9=6.363, max=9.330 (n=1600). False-split rate (fraction of the 1600 draws whose ratio exceeds the margin) by candidate margin: 2.0 -> 20.31%, 3.0 -> 5.56%, 4.0 -> 2.12%, 4.5 -> 1.38%, 5.0 -> 0.88%, 6.0 -> 0.31%, 8.0 -> 0.06%, 10.0 -> 0.00%. Target stated up front: false-split rate <= 1%. margin=5.0 is the smallest tested value clearing that target (0.88% achieved, with 4.5 at 1.38% failing it), so it is chosen as the value with the least unnecessary insensitivity to genuine splits while meeting the stated rate. Real-split ratios measured on this module's own fixed-seed fixtures for comparison, none of which this margin should ever gate: two_speakers (60 target/20 intruder, near-orthogonal) ~86x; file_balanced (200 long-file vs 30 target across 3 files) ~187x; the 0.35 rad-separated cut-scaling regression fixture ~23x. All three clear margin=5.0 by at least 4.5x, so the chosen value costs no known real-split test in this module.",
-  "sweep": {
-    "n_values": [30, 50, 100, 200, 300],
-    "d_values": [32, 64, 192, 256],
-    "spread_values": [0.01, 0.02, 0.05, 0.1],
-    "draws_per_cell": 20,
-    "n_cells": 80,
-    "n_draws_total": 1600,
-    "seed_scheme": "numpy.random.default_rng(100000 + i) for i in range(1600), row-major over (n, d, spread, draw)",
-    "statistic": "top-gap / runner-up-gap over np.diff(merge_heights), average-linkage AHC on geodesic angular distance",
-    "quantiles": {
-      "p50": 1.399,
-      "p90": 2.590,
-      "p95": 3.060,
-      "p99": 4.840,
-      "p995": 5.462,
-      "p999": 6.363,
-      "max": 9.330
-    },
-    "false_split_rate_by_margin": {
-      "2.0": 0.20313,
-      "3.0": 0.05563,
-      "4.0": 0.02125,
-      "4.5": 0.01375,
-      "5.0": 0.00875,
-      "6.0": 0.00313,
-      "8.0": 0.00063,
-      "10.0": 0.0
-    },
-    "target_false_split_rate": 0.01,
-    "chosen_margin": 5.0,
-    "achieved_false_split_rate": 0.00875
-  }
+    "version": 1,
+    "margin": 5.0,
+    "scope": "The significance margin select_dominant_vectors requires the largest merge-height gap to beat the runner-up gap by before trusting it as a real cluster split, rather than the largest fluctuation a single coherent group produces by chance. Guards only the derived branch (cut_theta=None); a caller-supplied cut_theta, and a caller-supplied gap_significance_margin, bypass this file entirely and are recorded with source='caller'.",
+    "derivation": "A first implementation used argmax(diff(merge_heights)) with no significance test and failed the brief's own fixed-seed single-coherent fixture (n=50, d=32, spread=0.02): the top gap sat near the leaves from sampling noise, not at the root. Fixed by requiring the top gap to exceed margin * runner-up-gap. The first-cut margin (2.0) was chosen from that one fixture's ratio (1.87x) against two other fixed-seed fixtures' ratios (86x, 187x) -- a single-seed eyeball, not a distribution, and code review caught it: an independent 300-draw sweep at the same fixture measured a 4.03x max and a 15.7% rate of ratio > 2.0, i.e. a 1-in-6 false-split rate on genuinely homogeneous input. This file replaces that eyeball with a proper sweep and a stated target. Swept the null (single coherent vMF cone, no intruder) over n in {30,50,100,200,300}, d in {32,64,192,256} (192-256 bracket real speaker-embedding dimensionality), spread in {0.01,0.02,0.05,0.1}, 20 independent-seed draws per (n,d,spread) cell -- 80 cells, 1600 draws total, seeds 100000..101599 via numpy.random.default_rng, each draw an independent axis plus a fresh cone. For each draw: AHC average-linkage on geodesic angular distance (identical to the runtime path), then top-gap / runner-up-gap over the merge-height diffs. Observed quantiles of that ratio: p50=1.399, p90=2.590, p95=3.060, p99=4.840, p99.5=5.462, p99.9=6.363, max=9.330 (n=1600). False-split rate (fraction of the 1600 draws whose ratio exceeds the margin) by candidate margin: 2.0 -> 20.31%, 3.0 -> 5.56%, 4.0 -> 2.12%, 4.5 -> 1.38%, 5.0 -> 0.88%, 6.0 -> 0.31%, 8.0 -> 0.06%, 10.0 -> 0.00%. Target stated up front: false-split rate <= 1%. margin=5.0 is the smallest tested value clearing that target (0.88% achieved, with 4.5 at 1.38% failing it), so it is chosen as the value with the least unnecessary insensitivity to genuine splits while meeting the stated rate. Real-split ratios measured on this module's own fixed-seed fixtures for comparison, none of which this margin should ever gate: two_speakers (60 target/20 intruder, near-orthogonal) ~86x; file_balanced (200 long-file vs 30 target across 3 files) ~187x; the 0.35 rad-separated cut-scaling regression fixture ~23x. All three clear margin=5.0 by at least 4.5x, so the chosen value costs no known real-split test in this module.",
+    "sweep": {
+        "n_values": [
+            30,
+            50,
+            100,
+            200,
+            300
+        ],
+        "d_values": [
+            32,
+            64,
+            192,
+            256
+        ],
+        "spread_values": [
+            0.01,
+            0.02,
+            0.05,
+            0.1
+        ],
+        "draws_per_cell": 20,
+        "n_cells": 80,
+        "n_draws_total": 1600,
+        "seed_scheme": "numpy.random.default_rng(100000 + i) for i in range(1600), row-major over (n, d, spread, draw)",
+        "statistic": "top-gap / runner-up-gap over np.diff(merge_heights), average-linkage AHC on geodesic angular distance",
+        "quantiles": {
+            "p50": 1.399,
+            "p90": 2.59,
+            "p95": 3.06,
+            "p99": 4.84,
+            "p995": 5.462,
+            "p999": 6.363,
+            "max": 9.33
+        },
+        "false_split_rate_by_margin": {
+            "2.0": 0.20313,
+            "3.0": 0.05563,
+            "4.0": 0.02125,
+            "4.5": 0.01375,
+            "5.0": 0.00875,
+            "6.0": 0.00313,
+            "8.0": 0.00063,
+            "10.0": 0.0
+        },
+        "target_false_split_rate": 0.01,
+        "chosen_margin": 5.0,
+        "achieved_false_split_rate": 0.00875
+    }
 }

--- a/src/senselab/utils/tasks/embedding_distribution.py
+++ b/src/senselab/utils/tasks/embedding_distribution.py
@@ -153,6 +153,38 @@ class SpectrumStats(BaseModel):
     eigenvalue_shares_top5: list[float]
 
 
+class WithinFileStats(BaseModel):
+    """Coherence inside one file.
+
+    Attributes:
+        n_vectors: Rows from this file that survived normalisation.
+        rbar: Mean resultant length of this file's rows. ``1.0`` for a single row, by definition.
+        cos_to_own_centroid_q05: 5th percentile of cosine to *this file's* centroid.
+        cos_to_own_centroid_q50: Median cosine to this file's centroid.
+    """
+
+    n_vectors: int
+    rbar: float
+    cos_to_own_centroid_q05: float
+    cos_to_own_centroid_q50: float
+
+
+class CrossFileStats(BaseModel):
+    """How the files sit relative to each other and to the pooled centroid.
+
+    Attributes:
+        cos_file_centroid_to_pooled: Per file, the cosine of its own centroid to the pooled
+            centroid. A contaminated file shows up here directly, which is what lets a caller
+            curate its input without any clustering.
+        file_centroid_pairwise_cos: Quantiles of the pairwise cosines between file centroids.
+            ``None`` with fewer than two files, because no pair exists and a reported number would
+            be invented.
+    """
+
+    cos_file_centroid_to_pooled: dict[str, float] = Field(default_factory=dict)
+    file_centroid_pairwise_cos: Optional[SimilarityStats] = None
+
+
 class EmbeddingDistribution(BaseModel):
     """Statistics describing one set of embedding vectors. Contains no verdict."""
 
@@ -162,6 +194,12 @@ class EmbeddingDistribution(BaseModel):
     cos_to_centroid_loo: SimilarityStats
     rbar: float
     spectrum: SpectrumStats
+    # Kept as two separate blocks rather than one pooled dispersion figure: prior measurement on
+    # this pipeline puts essentially the whole error budget cross-file (within-file cosine
+    # stability 0.984 against cross-file 0.891), so averaging the two would destroy the most
+    # informative split known about this data. See `_per_file_stats`.
+    within_file: dict[str, WithinFileStats] = Field(default_factory=dict)
+    cross_file: CrossFileStats = Field(default_factory=CrossFileStats)
 
 
 def _as_array(
@@ -302,6 +340,58 @@ def _spectrum(x: np.ndarray) -> SpectrumStats:
     return SpectrumStats(participation_ratio=pr, pc1_share_centred=float(shares[0]), eigenvalue_shares_top5=top5)
 
 
+def _per_file_stats(
+    x: np.ndarray, file_ids: Optional[list[str]], pooled_centroid: np.ndarray
+) -> tuple[dict[str, WithinFileStats], CrossFileStats]:
+    """Within-file coherence and cross-file agreement.
+
+    Kept strictly apart because the measured error budget on this pipeline is almost entirely
+    cross-file (within-file cosine stability 0.984 against cross-file 0.891). Pooling them would
+    average away the most informative split there is.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+        file_ids: One id per row, or ``None``.
+        pooled_centroid: The centroid over all rows.
+
+    Returns:
+        ``(within_file, cross_file)``. Both are empty when ``file_ids`` is ``None``.
+    """
+    if file_ids is None:
+        return {}, CrossFileStats()
+
+    order: list[str] = []
+    for f in file_ids:
+        if f not in order:
+            order.append(f)
+
+    within: dict[str, WithinFileStats] = {}
+    centroids: dict[str, np.ndarray] = {}
+    ids = np.asarray(file_ids)
+    for f in order:
+        rows = x[ids == f]
+        c = _spherical_mean(rows)
+        centroids[f] = c
+        cos_own = rows @ c
+        within[f] = WithinFileStats(
+            n_vectors=int(rows.shape[0]),
+            rbar=float(np.linalg.norm(rows.sum(axis=0)) / rows.shape[0]),
+            cos_to_own_centroid_q05=float(np.quantile(cos_own, 0.05)),
+            cos_to_own_centroid_q50=float(np.quantile(cos_own, 0.50)),
+        )
+
+    to_pooled = {f: float(centroids[f] @ pooled_centroid) for f in order}
+
+    pairwise: Optional[SimilarityStats] = None
+    if len(order) >= 2:
+        stacked = np.stack([centroids[f] for f in order])
+        gram = stacked @ stacked.T
+        iu = np.triu_indices(len(order), k=1)
+        pairwise = _similarity_stats(gram[iu])
+
+    return within, CrossFileStats(cos_file_centroid_to_pooled=to_pooled, file_centroid_pairwise_cos=pairwise)
+
+
 def describe_embedding_distribution(
     vectors: Union[Sequence[Sequence[float]], np.ndarray, Any],  # noqa: ANN401 — torch.Tensor duck-typed
     file_ids: Optional[Sequence[str]] = None,
@@ -363,6 +453,8 @@ def describe_embedding_distribution(
 
     centroid = _spherical_mean(x)  # Tasks 4-5 replace this with the aggregator dispatch.
 
+    within_file, cross_file = _per_file_stats(x, kept_files, centroid)
+
     per_file: dict[str, int] = {}
     if kept_files is not None:
         for f in kept_files:
@@ -401,4 +493,6 @@ def describe_embedding_distribution(
         cos_to_centroid_loo=_similarity_stats(_loo_cos_to_centroid(x)),
         rbar=float(np.linalg.norm(x.sum(axis=0)) / n),
         spectrum=_spectrum(x),
+        within_file=within_file,
+        cross_file=cross_file,
     )

--- a/src/senselab/utils/tasks/embedding_distribution.py
+++ b/src/senselab/utils/tasks/embedding_distribution.py
@@ -1,0 +1,404 @@
+"""Describe one set of embedding vectors: a centroid, and statistics about the distribution.
+
+This module **describes and never decides**. There is no verdict field, no boolean, no
+probability, and no thresholded label anywhere in its output. A consumer applies its own
+threshold, so every statistic here is either bounded on an interpretable scale or paired with an
+analytic null it can be read against.
+
+Every reference scale is closed-form, which is what keeps the module free of literals nobody
+fitted:
+
+- sd of pairwise cosines between independent directions: ``1/sqrt(d)`` (0.0722 at d=192)
+- mean resultant length of ``n`` independent directions: ``E[Rbar^2] = 1/n``, so ``1/sqrt(n)``
+- participation ratio under Marchenko-Pastur: ``d*n/(d+n)``
+- Mann-Whitney AUC under exchangeability: exactly ``0.5``
+
+**The counter-intuitive one.** A *small* sd of cosines is not evidence of a coherent speaker. At
+d=192 independent random directions give sd ~= 0.072, so an observed 0.05 is *below* the
+random-vector null. sd is therefore never reported as a headline dispersion figure -- only beside
+``nulls.cos_sd_null``.
+
+Geometry: vectors are L2-normalised on entry, unconditionally. SpeechBrain speaker embeddings are
+not unit norm, and the norm covaries with window energy and how much speech fills the window -- a
+cough, or 0.4 s of speech in a 2.0 s window, gets a systematically different norm. Any
+unnormalised statistic would mix that loudness/occupancy nuisance into what a reader takes for
+speaker dispersion. ECAPA is trained with an angular-margin objective and scored by cosine, so
+the norm is not part of the discriminative geometry to begin with.
+
+After normalisation cosine and Euclidean are the *same* geometry --
+``||x-y||^2 = 2(1-cos t)``, a strictly monotone reparametrisation -- so the common "Euclidean is
+unusable at high d" objection does not apply to any rank- or neighbour-based quantity. Where a
+true metric is needed (medoid, linkage) the geodesic ``arccos(clip(cos,-1,1))`` is used, because
+``cos`` is not a metric and neither is ``1-cos``.
+
+**Deliberately absent**, each for a mechanical reason rather than taste:
+
+- *Silhouette.* ``silhouette(metric="cosine")`` and ``silhouette(metric="euclidean")`` return
+  different numbers for identical geometry on unit vectors (Jensen: the square root compresses
+  large distances more than small ones), so any threshold on silhouette is a threshold on a
+  parameterisation choice. It is also a property of a chosen partition, not of the data.
+- *k-NN purity.* Hubness is severe at this dimension -- k-occurrence skew ~3.3 at d=192, with a
+  measurable fraction of points appearing in no neighbour list -- so neighbour counts carry a bias
+  unrelated to speaker identity. Worse, at 50% window overlap a window's nearest neighbour is
+  almost always the temporally adjacent window, so any same-file purity statistic would read ~1.0
+  for every input: it would measure the hop size.
+- *Intrinsic-dimensionality estimators.* Two-NN's ``r1`` becomes the distance to a near-duplicate
+  window, driving the estimate down by the hop size. Same artefact.
+- *von Mises-Fisher concentration.* ``kappa = Rbar(d - Rbar^2)/(1 - Rbar^2)`` is a deterministic
+  function of ``Rbar`` and ``d``, both reported, so it stores nothing new; it is unbounded as
+  ``Rbar -> 1``, so it is not interpretable on its own scale; and vMF assumes isotropic
+  concentration, which embedding spaces violate. Recover it in one line if you want it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence, Union
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+AGGREGATOR_SPHERICAL_MEAN = "spherical_mean"
+AGGREGATOR_TRIMMED_MEAN = "trimmed_mean"
+AGGREGATOR_MEDOID = "medoid"
+_AGGREGATORS = (AGGREGATOR_SPHERICAL_MEAN, AGGREGATOR_TRIMMED_MEAN, AGGREGATOR_MEDOID)
+
+# The fraction trimmed by the trimmed-mean aggregator and by the robustness diagnostic. Not a
+# decision threshold: nothing is accepted or rejected on it, and both the trimmed result and its
+# cosine to the untrimmed mean are reported, so a reader sees what trimming did rather than
+# inheriting its verdict.
+_TRIM_FRACTION = 0.10
+
+
+class SimilarityStats(BaseModel):
+    """Quantiles of a set of cosine values, plus mean and sd.
+
+    Quantiles rather than mean-and-sd alone because contamination makes this distribution a
+    *mixture*: mean +/- sd of a bimodal mixture describes neither lobe, and the sd is inflated by
+    exactly the thing worth exposing -- so sd alone cannot separate "one loose speaker" from "two
+    tight speakers". ``q05`` and ``min`` are where an intruder shows up.
+    """
+
+    min: float
+    q05: float
+    q25: float
+    q50: float
+    q75: float
+    q95: float
+    max: float
+    mean: float
+    sd: float
+
+
+class GeometryInfo(BaseModel):
+    """What was done to the vectors, so a stored block can be interpreted later."""
+
+    metric: str
+    l2_normalised: bool
+    dim: int
+    distance: str
+    centroid_rule: str
+
+
+class CountsInfo(BaseModel):
+    """Sizes, and the effective sample size after accounting for window overlap.
+
+    Attributes:
+        n_effective: ``total_windowed_duration / window_s``, which is about ``n/2`` at a 2.0 s
+            window on a 1.0 s hop. ``None`` when window information was not supplied -- it cannot
+            be derived from vectors alone, and a guess would be worse than an absence. Any null
+            whose width scales as ``n^-1/2`` is about sqrt(2) overconfident without this discount.
+    """
+
+    n_vectors_total: int
+    n_scored: int
+    n_zero_norm_dropped: int
+    n_files: int
+    vectors_per_file: dict[str, int] = Field(default_factory=dict)
+    window_s: Optional[float] = None
+    hop_s: Optional[float] = None
+    n_effective: Optional[float] = None
+
+
+class NullsInfo(BaseModel):
+    """Closed-form reference scales, so no statistic needs a fitted threshold.
+
+    ``dim`` and ``n_scored`` are in ``CountsInfo`` and ``GeometryInfo`` specifically so a consumer
+    can recompute every one of these and check ours.
+    """
+
+    cos_sd_null: float
+    rbar_null: float
+    participation_ratio_null: float
+    auc_null: float
+
+
+class SpectrumStats(BaseModel):
+    """How many directions the set actually occupies.
+
+    Attributes:
+        participation_ratio: ``(sum lambda)^2 / sum lambda^2`` of the centred covariance, in
+            ``[1, min(n,d)]``. Read against ``nulls.participation_ratio_null``: well below it means
+            a genuinely low-dimensional set, near it means indistinguishable from white noise at
+            this sample size.
+        pc1_share_centred: ``lambda_1 / sum lambda`` on **centred** data. Uncentred, PC1 is the
+            mean direction and explains almost everything for any coherent set, which would make
+            this a field that always reads the same. Centred, a high share is the signature of
+            bimodality.
+        eigenvalue_shares_top5: The five largest ``lambda_i / sum lambda``, zero-padded when
+            ``min(n,d) < 5``.
+    """
+
+    participation_ratio: float
+    pc1_share_centred: float
+    eigenvalue_shares_top5: list[float]
+
+
+class EmbeddingDistribution(BaseModel):
+    """Statistics describing one set of embedding vectors. Contains no verdict."""
+
+    geometry: GeometryInfo
+    counts: CountsInfo
+    nulls: NullsInfo
+    cos_to_centroid_loo: SimilarityStats
+    rbar: float
+    spectrum: SpectrumStats
+
+
+def _as_array(
+    vectors: Union[Sequence[Sequence[float]], np.ndarray, Any],  # noqa: ANN401 — torch.Tensor duck-typed
+) -> np.ndarray:
+    """Coerce input to a 2-D float64 array without importing torch at module scope.
+
+    Args:
+        vectors: A nested sequence, a numpy array, or anything exposing ``detach``/``cpu``/``numpy``
+            (a torch tensor).
+
+    Returns:
+        A 2-D ``float64`` array, one row per vector.
+
+    Raises:
+        ValueError: If the result is not 2-D.
+    """
+    if hasattr(vectors, "detach"):
+        vectors = vectors.detach().cpu().numpy()
+    arr = np.asarray(vectors, dtype=np.float64)
+    if arr.ndim != 2:
+        raise ValueError(f"vectors must be 2-D (n, d); got shape {arr.shape}")
+    return arr
+
+
+def _l2_normalise(x: np.ndarray) -> tuple[np.ndarray, int]:
+    """Return unit-norm rows and the count of zero-norm rows removed.
+
+    Args:
+        x: ``(n, d)`` array.
+
+    Returns:
+        ``(normalised, n_dropped)``. A zero-norm row has no direction, so it cannot contribute to
+        any angular statistic; it is dropped rather than producing ``nan``, and counted so
+        ``n_scored`` stays explainable.
+    """
+    norms = np.linalg.norm(x, axis=1)
+    keep = norms > 0
+    n_dropped = int((~keep).sum())
+    return x[keep] / norms[keep][:, None], n_dropped
+
+
+def _spherical_mean(x: np.ndarray) -> np.ndarray:
+    """Unit-norm mean direction of unit-norm rows.
+
+    This is the von Mises-Fisher MLE direction, and its error shrinks as ``O(n^-1/2)``. An
+    arithmetic mean of *unnormalised* vectors would weight each row by its norm -- i.e. by
+    loudness and speech occupancy -- so a loud cough would outvote a quiet target utterance.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+
+    Returns:
+        A unit-norm ``(d,)`` direction.
+
+    Raises:
+        ValueError: If the rows sum to the zero vector, which has no direction.
+    """
+    s = x.sum(axis=0)
+    norm = float(np.linalg.norm(s))
+    if norm == 0.0:
+        raise ValueError("vectors sum to zero; no mean direction exists")
+    return s / norm
+
+
+def _similarity_stats(values: np.ndarray) -> SimilarityStats:
+    """Summarise a 1-D array of cosine values.
+
+    Args:
+        values: Any 1-D array of cosines.
+
+    Returns:
+        Quantiles plus mean and sd. ``sd`` is included for completeness but is meaningless without
+        ``nulls.cos_sd_null`` beside it; see the module docstring.
+    """
+    v = np.asarray(values, dtype=np.float64).ravel()
+    q = np.quantile(v, [0.05, 0.25, 0.50, 0.75, 0.95])
+    return SimilarityStats(
+        min=float(v.min()),
+        q05=float(q[0]),
+        q25=float(q[1]),
+        q50=float(q[2]),
+        q75=float(q[3]),
+        q95=float(q[4]),
+        max=float(v.max()),
+        mean=float(v.mean()),
+        sd=float(v.std(ddof=1)) if v.size > 1 else 0.0,
+    )
+
+
+def _loo_cos_to_centroid(x: np.ndarray) -> np.ndarray:
+    """Cosine of each row to the centroid computed *without* that row.
+
+    Scoring a vector against a centroid it helped define is optimistically biased -- each row pulls
+    the centroid toward itself. Closed form, one pass, no loop: with ``S = sum x_j`` over unit
+    rows, the leave-one-out mean direction is proportional to ``S - x_i``, so
+    ``cos_loo(i) = x_i . (S - x_i) / ||S - x_i||``.
+
+    Args:
+        x: ``(n, d)`` unit-norm array with ``n >= 2``.
+
+    Returns:
+        ``(n,)`` array of leave-one-out cosines.
+    """
+    s = x.sum(axis=0)
+    diff = s[None, :] - x
+    denom = np.linalg.norm(diff, axis=1)
+    numer = np.einsum("ij,ij->i", x, diff)
+    out = np.zeros_like(denom)
+    nz = denom > 0
+    out[nz] = numer[nz] / denom[nz]
+    return out
+
+
+def _spectrum(x: np.ndarray) -> SpectrumStats:
+    """Participation ratio, centred PC1 share, and the top-5 eigenvalue shares.
+
+    Uses singular values of the centred matrix rather than forming the ``d x d`` covariance: both
+    quantities are ratios, so the ``1/(n-1)`` factor cancels and the SVD is cheaper and better
+    conditioned.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+
+    Returns:
+        The spectrum summary.
+    """
+    centred = x - x.mean(axis=0, keepdims=True)
+    sv = np.linalg.svd(centred, compute_uv=False)
+    lam = sv**2
+    total = float(lam.sum())
+    if total == 0.0:
+        # Every row identical: no variation at all. One occupied direction, by definition.
+        return SpectrumStats(participation_ratio=1.0, pc1_share_centred=0.0, eigenvalue_shares_top5=[0.0] * 5)
+    pr = float(total**2 / float((lam**2).sum()))
+    shares = (lam / total).tolist()
+    top5 = [float(v) for v in shares[:5]] + [0.0] * max(0, 5 - len(shares))
+    return SpectrumStats(participation_ratio=pr, pc1_share_centred=float(shares[0]), eigenvalue_shares_top5=top5)
+
+
+def describe_embedding_distribution(
+    vectors: Union[Sequence[Sequence[float]], np.ndarray, Any],  # noqa: ANN401 — torch.Tensor duck-typed
+    file_ids: Optional[Sequence[str]] = None,
+    *,
+    aggregator: str = AGGREGATOR_SPHERICAL_MEAN,
+    window_s: Optional[float] = None,
+    hop_s: Optional[float] = None,
+    window_starts_s: Optional[Sequence[float]] = None,
+    n_permutations: int = 1000,
+    seed: int = 0,
+) -> tuple[list[float], EmbeddingDistribution]:
+    """Describe one set of embedding vectors: a centroid and statistics about the distribution.
+
+    Decides nothing. See the module docstring for the geometry, the analytic nulls, and what is
+    deliberately absent.
+
+    Args:
+        vectors: ``(n, d)`` embeddings. Normalised on entry regardless of input scale.
+        file_ids: One id per row, when the vectors come from several files. Enables the per-file
+            statistics; ``None`` treats the set as one group.
+        aggregator: ``"spherical_mean"`` (default), ``"trimmed_mean"``, or ``"medoid"``. A tool
+            parameter, not a decision: the returned block always reports the cosine between the
+            mean and both alternatives, so a reader sees whether the choice mattered.
+        window_s: Window length in seconds, used for ``n_effective`` and the permutation block
+            length. ``None`` leaves both unreported rather than guessed.
+        hop_s: Hop between windows in seconds.
+        window_starts_s: Start time of each window, same order as ``vectors``. Required for the
+            same-file guard band; without it that guard is skipped and reported as ``None``.
+        n_permutations: Permutations for the file-effect reference.
+        seed: Seed for the permutation. Fixed by default so the reported quantile is reproducible.
+
+    Returns:
+        ``(centroid, distribution)``. The centroid is a unit-norm ``list[float]``.
+
+    Raises:
+        ValueError: If fewer than 2 vectors survive normalisation, if ``vectors`` is not 2-D, if
+            ``aggregator`` is unknown, or if ``file_ids``/``window_starts_s`` lengths disagree with
+            ``vectors``.
+    """
+    if aggregator not in _AGGREGATORS:
+        raise ValueError(f"aggregator must be one of {_AGGREGATORS}; got {aggregator!r}")
+
+    raw = _as_array(vectors)
+    n_total = int(raw.shape[0])
+    if file_ids is not None and len(file_ids) != n_total:
+        raise ValueError(f"file_ids has {len(file_ids)} entries for {n_total} vectors")
+    if window_starts_s is not None and len(window_starts_s) != n_total:
+        raise ValueError(f"window_starts_s has {len(window_starts_s)} entries for {n_total} vectors")
+
+    norms = np.linalg.norm(raw, axis=1)
+    keep_mask = norms > 0
+    x, n_dropped = _l2_normalise(raw)
+    n = int(x.shape[0])
+    if n < 2:
+        raise ValueError(f"need at least 2 non-zero vectors to describe a distribution; got {n}")
+    d = int(x.shape[1])
+
+    kept_files = [str(f) for f, k in zip(file_ids, keep_mask) if k] if file_ids is not None else None
+
+    centroid = _spherical_mean(x)  # Tasks 4-5 replace this with the aggregator dispatch.
+
+    per_file: dict[str, int] = {}
+    if kept_files is not None:
+        for f in kept_files:
+            per_file[f] = per_file.get(f, 0) + 1
+
+    n_effective: Optional[float] = None
+    if window_s is not None and hop_s is not None and window_s > 0:
+        # total covered duration / window_s: overlapping windows do not carry independent
+        # information, and pretending they do makes every n^-1/2 null overconfident.
+        n_effective = float((hop_s * (n - 1) + window_s) / window_s)
+
+    return centroid.tolist(), EmbeddingDistribution(
+        geometry=GeometryInfo(
+            metric="cosine",
+            l2_normalised=True,
+            dim=d,
+            distance="angular",
+            centroid_rule=aggregator,
+        ),
+        counts=CountsInfo(
+            n_vectors_total=n_total,
+            n_scored=n,
+            n_zero_norm_dropped=n_dropped,
+            n_files=len(per_file) if per_file else (1 if kept_files is None else 0),
+            vectors_per_file=per_file,
+            window_s=window_s,
+            hop_s=hop_s,
+            n_effective=n_effective,
+        ),
+        nulls=NullsInfo(
+            cos_sd_null=float(1.0 / np.sqrt(d)),
+            rbar_null=float(1.0 / np.sqrt(n)),
+            participation_ratio_null=float(d * n / (d + n)),
+            auc_null=0.5,
+        ),
+        cos_to_centroid_loo=_similarity_stats(_loo_cos_to_centroid(x)),
+        rbar=float(np.linalg.norm(x.sum(axis=0)) / n),
+        spectrum=_spectrum(x),
+    )

--- a/src/senselab/utils/tasks/embedding_distribution.py
+++ b/src/senselab/utils/tasks/embedding_distribution.py
@@ -1,9 +1,9 @@
 """Describe one set of embedding vectors: a centroid, and statistics about the distribution.
 
-This module **describes and never decides**. There is no verdict field, no boolean, no
-probability, and no thresholded label anywhere in its output. A consumer applies its own
-threshold, so every statistic here is either bounded on an interpretable scale or paired with an
-analytic null it can be read against.
+This module **describes and never decides**. There is no verdict field, no probability, and no
+thresholded label anywhere in its output. A consumer applies its own threshold, so every statistic
+here is either bounded on an interpretable scale or paired with an analytic null it can be read
+against.
 
 Every reference scale is closed-form, which is what keeps the module free of literals nobody
 fitted:
@@ -267,13 +267,14 @@ _GAP_SIGNIFICANCE_PROFILE_PATH = Path(__file__).parent / "data" / "embedding_gap
 _GAP_SIGNIFICANCE_PROFILE_VERSION = 1
 DEFAULT_GAP_SIGNIFICANCE_MARGIN = 5.0
 """Mirrors the bundled profile's ``margin`` (achieved false-split rate 0.88% at n=1600 draws); see
-`data/embedding_gap_significance.json`. Used only if that file is absent from the install, which
-should not happen for a properly packaged senselab -- an absent bundled profile is itself worth
-noticing rather than silently patching over."""
+`data/embedding_gap_significance.json`. Documentation only -- it is never substituted silently when
+that file is missing (`_load_gap_significance_margin` raises instead; see there for why), so its
+only live use is as `SelectionRule.gap_significance_margin`'s pydantic schema default, which no real
+call path exercises since that field is always populated explicitly."""
 
 
 def _load_gap_significance_margin(path: Optional[Path] = None) -> float:
-    """Load the gap-significance margin, ``None`` (the default) reading the bundled profile.
+    """Load the gap-significance margin from the bundled profile.
 
     Args:
         path: Profile path, or ``None`` for the bundled default.
@@ -284,12 +285,21 @@ def _load_gap_significance_margin(path: Optional[Path] = None) -> float:
         fluctuation.
 
     Raises:
-        ValueError: If the profile's version does not match, or ``margin`` is missing or not
-            positive -- a malformed profile must fail loudly rather than silently gate nothing.
+        ValueError: If the profile file is missing, its version does not match, or ``margin`` is
+            missing or not positive. A missing profile used to fall back to
+            ``DEFAULT_GAP_SIGNIFICANCE_MARGIN`` while the caller still recorded
+            ``gap_significance_margin_source="profile"`` -- an unfitted constant mislabeled as a
+            measured one. Raising is what closes that gap: a broken install now fails loudly here
+            instead of shipping confidently-wrong provenance.
     """
     target = path if path is not None else _GAP_SIGNIFICANCE_PROFILE_PATH
     if not Path(target).exists():
-        return DEFAULT_GAP_SIGNIFICANCE_MARGIN
+        raise ValueError(
+            f"gap-significance profile {target} is missing from this install. Refusing to "
+            f"substitute the undocumented constant {DEFAULT_GAP_SIGNIFICANCE_MARGIN} for it and "
+            "report the result as profile-derived; reinstall senselab or pass an explicit "
+            "gap_significance_margin."
+        )
     profile = json.loads(Path(target).read_text())
     if int(profile.get("version", -1)) != _GAP_SIGNIFICANCE_PROFILE_VERSION:
         raise ValueError(
@@ -901,13 +911,17 @@ def _file_effect(
     rng = np.random.default_rng(seed)
     n = x.shape[0]
     n_blocks = int(np.ceil(n / block_len))
-    exceeded = 0
+    # Named for what it counts, not what it sounds like it should: each iteration tests
+    # `shuffled_eta_sq <= observed`, i.e. a permutation draw that does *not* exceed the observed
+    # statistic, so the resulting quantile is "share of the null at or below observed" -- a
+    # variable called `exceeded` here previously counted the opposite of its own name.
+    n_le_observed = 0
     for _ in range(n_permutations):
         block_order = rng.permutation(n_blocks)
         shuffled = np.concatenate([ids[b * block_len : (b + 1) * block_len] for b in block_order])[:n]
         if _eta_squared_between_files(x, shuffled) <= observed:
-            exceeded += 1
-    quantile = float(exceeded / n_permutations) if n_permutations > 0 else None
+            n_le_observed += 1
+    quantile = float(n_le_observed / n_permutations) if n_permutations > 0 else None
 
     return FileEffect(
         auc_same_file_vs_diff_file=auc,
@@ -1001,9 +1015,18 @@ def describe_embedding_distribution(
 
     n_effective: Optional[float] = None
     if window_s is not None and hop_s is not None and window_s > 0:
-        # total covered duration / window_s: overlapping windows do not carry independent
-        # information, and pretending they do makes every n^-1/2 null overconfident.
-        n_effective = float((hop_s * (n - 1) + window_s) / window_s)
+        # total covered duration / window_s (this class's own contract, see `CountsInfo`):
+        # overlapping windows do not carry independent information, and pretending they do makes
+        # every n^-1/2 null overconfident. Per file, not over the pooled set as one timeline --
+        # a multi-file pool has no single timeline to begin with, and treating `n` rows as one
+        # contiguous recording undercounts duration by roughly half whenever there are several
+        # files (measured: 100 single-window files reported 50.5 against the correct 100.0).
+        # `per_file` already holds one count per file (or one entry for the whole set when no
+        # file ids were supplied), so this reduces to the single-timeline formula in that case.
+        if per_file:
+            n_effective = float(sum((hop_s * (nf - 1) + window_s) / window_s for nf in per_file.values()))
+        else:
+            n_effective = float((hop_s * (n - 1) + window_s) / window_s)
 
     return centroid.tolist(), EmbeddingDistribution(
         geometry=GeometryInfo(

--- a/src/senselab/utils/tasks/embedding_distribution.py
+++ b/src/senselab/utils/tasks/embedding_distribution.py
@@ -255,6 +255,221 @@ class EmbeddingDistribution(BaseModel):
     centroid_robustness: CentroidRobustness = Field(default_factory=CentroidRobustness)
 
 
+LINKAGE_AVERAGE = "average"
+
+
+class ClusterSummary(BaseModel):
+    """One group found by the selector.
+
+    Attributes:
+        cluster_id: Stable id within this selection.
+        n_vectors: Rows in this group.
+        window_share: Share of all scored rows. Reported alongside ``file_balanced_share`` because
+            the two disagree exactly when duration imbalance is driving the answer.
+        file_balanced_share: Share with each file weighted ``1/n_f``, so a long recording cannot
+            outvote several short ones.
+        n_files_contributing: How many distinct files put rows in this group.
+        per_file_share: Per file, the share of that file's rows landing in this group.
+    """
+
+    cluster_id: int
+    n_vectors: int
+    window_share: float
+    file_balanced_share: float
+    n_files_contributing: int
+    per_file_share: dict[str, float] = Field(default_factory=dict)
+
+
+class SelectionRule(BaseModel):
+    """What the selector actually did, so the decision is auditable and reversible.
+
+    Attributes:
+        linkage: Linkage used for the agglomerative clustering.
+        cut_theta: The angular cut applied, in radians.
+        cut_source: ``"caller"`` when supplied, ``"largest_merge_gap"`` when derived. A reader has
+            to be able to tell which, because a derived cut is a rule and a supplied one is a
+            caller's judgement.
+        merge_heights: The full ascending merge-height sequence. This is the threshold-free form of
+            the "how many clusters" question; a consumer can re-cut it anywhere.
+        min_file_share: Optional minimum per-file share for a file to count toward a group's
+            file-balanced share. ``None`` means unused.
+    """
+
+    linkage: str
+    cut_theta: float
+    cut_source: str
+    merge_heights: list[float] = Field(default_factory=list)
+    min_file_share: Optional[float] = None
+
+
+class DominantSelection(BaseModel):
+    """Which vectors survived contamination rejection, and everything about how that was decided."""
+
+    kept_indices: list[int]
+    dropped_indices: list[int]
+    clusters: list[ClusterSummary]
+    dominant_cluster_id: int
+    runner_up_cluster_id: Optional[int] = None
+    cos_dominant_to_runner_up: Optional[float] = None
+    dropped_per_file: dict[str, int] = Field(default_factory=dict)
+    rule_used: SelectionRule
+
+
+def select_dominant_vectors(
+    vectors: Union[Sequence[Sequence[float]], np.ndarray, Any],  # noqa: ANN401 — torch.Tensor duck-typed
+    file_ids: Optional[Sequence[str]] = None,
+    *,
+    linkage: str = LINKAGE_AVERAGE,
+    cut_theta: Optional[float] = None,
+    min_file_share: Optional[float] = None,
+) -> DominantSelection:
+    """Group vectors and return the dominant group, for optional contamination rejection.
+
+    **This is the one function in the module that decides something**, which is why it is separate
+    from :func:`describe_embedding_distribution` and why callers opt in. Everything it did is
+    recorded in the returned object.
+
+    Agglomerative hierarchical clustering on geodesic angular distance, average linkage. Chosen
+    over spectral clustering for three reasons: it is deterministic, where
+    ``SpectralClustering(assign_labels="kmeans")`` is stochastic and pinning a seed hides that
+    variance rather than removing it; k-means-family clustering carries an equal-size bias and will
+    split one speaker's prosodic halves before isolating a small intruder; and AHC turns "choose
+    k" into a merge-height profile that can be reported instead of decided.
+
+    Args:
+        vectors: ``(n, d)`` embeddings. L2-normalised on entry.
+        file_ids: One id per row. Enables file-balanced selection and per-file drop accounting.
+        linkage: Passed to ``scipy.cluster.hierarchy.linkage``. ``"average"`` by default.
+        cut_theta: Angular cut in radians. ``None`` derives it from the largest gap in the merge
+            heights, accepted only when it structurally dominates the runner-up gap -- a *rule*,
+            not a fitted constant; see the derivation below. Supply a value to override; either way
+            the value used and its source are recorded.
+        min_file_share: Optional floor on a file's share within a group before that file counts
+            toward the group's file-balanced share. ``None`` counts every contributing file.
+
+    Returns:
+        A :class:`DominantSelection`.
+
+    Raises:
+        ValueError: If fewer than 2 vectors survive normalisation, or ``file_ids`` length disagrees.
+    """
+    from scipy.cluster.hierarchy import fcluster
+    from scipy.cluster.hierarchy import linkage as scipy_linkage
+    from scipy.spatial.distance import squareform
+
+    raw = _as_array(vectors)
+    n_total = int(raw.shape[0])
+    if file_ids is not None and len(file_ids) != n_total:
+        raise ValueError(f"file_ids has {len(file_ids)} entries for {n_total} vectors")
+
+    norms = np.linalg.norm(raw, axis=1)
+    keep_mask = norms > 0
+    original_index = np.flatnonzero(keep_mask)
+    x, _ = _l2_normalise(raw)
+    n = int(x.shape[0])
+    if n < 2:
+        raise ValueError(f"need at least 2 non-zero vectors to select a dominant group; got {n}")
+
+    ids = [str(f) for f, k in zip(file_ids, keep_mask) if k] if file_ids is not None else ["_all"] * n
+
+    theta = np.arccos(np.clip(x @ x.T, -1.0, 1.0))
+    np.fill_diagonal(theta, 0.0)
+    theta = (theta + theta.T) / 2.0  # enforce exact symmetry for squareform
+    z = scipy_linkage(squareform(theta, checks=False), method=linkage)
+    merge_heights = [float(h) for h in z[:, 2]]
+
+    if cut_theta is None:
+        # The largest gap between consecutive merge heights is where the data itself separates --
+        # but the raw argmax is not enough on its own. Measured on 50 vectors drawn from one vMF
+        # cone (no intruder at all): the single biggest gap sits down near the leaves (ratio to the
+        # runner-up gap ~1.87x) purely from sampling noise in how tightly the first few points
+        # happen to land, while a real two-population split (60 target / 20 intruder) puts the
+        # biggest gap at the root with the runner-up gap dwarfed 86x-190x over. That gap between
+        # "noise's biggest fluctuation" and "an actual population boundary" is two orders of
+        # magnitude, not a close call -- so the biggest gap is only trusted as a cut when it beats
+        # the runner-up gap by a wide, structural margin (taken as 2x: any single coherent cluster's
+        # noisiest gap was, in the measurement above, within a factor of 2 of its own runner-up).
+        # Below that margin nothing stands out from the rest, and the cut is set at the maximum
+        # merge height, which folds every row into one cluster rather than fabricating a split.
+        heights = np.asarray(merge_heights)
+        gaps = np.diff(heights)
+        if gaps.size >= 2:
+            order = np.argsort(gaps)
+            top1_idx, top2_idx = int(order[-1]), int(order[-2])
+            if gaps[top1_idx] > 2.0 * gaps[top2_idx]:
+                resolved_cut = float((heights[top1_idx] + heights[top1_idx + 1]) / 2.0)
+            else:
+                resolved_cut = float(heights.max())
+        elif heights.size:
+            # Fewer than two gaps to compare -- too little evidence to call a gap significant, so
+            # the conservative reading (one cluster) is the same fallback as the no-signal branch.
+            resolved_cut = float(heights.max())
+        else:
+            resolved_cut = 0.0
+        cut_source = "largest_merge_gap"
+    else:
+        resolved_cut = float(cut_theta)
+        cut_source = "caller"
+
+    labels = fcluster(z, t=resolved_cut, criterion="distance")
+
+    file_counts: dict[str, int] = {}
+    for f in ids:
+        file_counts[f] = file_counts.get(f, 0) + 1
+
+    summaries: list[ClusterSummary] = []
+    for cid in sorted(set(int(v) for v in labels)):
+        member = labels == cid
+        member_files = [f for f, m in zip(ids, member) if m]
+        per_file: dict[str, float] = {}
+        for f in set(member_files):
+            per_file[f] = member_files.count(f) / file_counts[f]
+        counted = {f: s for f, s in per_file.items() if min_file_share is None or s >= min_file_share}
+        summaries.append(
+            ClusterSummary(
+                cluster_id=cid,
+                n_vectors=int(member.sum()),
+                window_share=float(member.sum() / n),
+                file_balanced_share=float(sum(counted.values()) / len(file_counts)),
+                n_files_contributing=len(per_file),
+                per_file_share=per_file,
+            )
+        )
+
+    ranked = sorted(summaries, key=lambda c: (c.file_balanced_share, c.window_share), reverse=True)
+    dominant = ranked[0]
+    runner_up = ranked[1] if len(ranked) > 1 else None
+
+    dominant_centroid = _spherical_mean(x[labels == dominant.cluster_id])
+    cos_to_runner: Optional[float] = None
+    if runner_up is not None:
+        cos_to_runner = float(dominant_centroid @ _spherical_mean(x[labels == runner_up.cluster_id]))
+
+    kept = [int(original_index[i]) for i in range(n) if labels[i] == dominant.cluster_id]
+    dropped = [int(original_index[i]) for i in range(n) if labels[i] != dominant.cluster_id]
+    dropped_per_file: dict[str, int] = {}
+    for i in range(n):
+        if labels[i] != dominant.cluster_id:
+            dropped_per_file[ids[i]] = dropped_per_file.get(ids[i], 0) + 1
+
+    return DominantSelection(
+        kept_indices=kept,
+        dropped_indices=dropped,
+        clusters=summaries,
+        dominant_cluster_id=dominant.cluster_id,
+        runner_up_cluster_id=runner_up.cluster_id if runner_up else None,
+        cos_dominant_to_runner_up=cos_to_runner,
+        dropped_per_file=dropped_per_file,
+        rule_used=SelectionRule(
+            linkage=linkage,
+            cut_theta=resolved_cut,
+            cut_source=cut_source,
+            merge_heights=merge_heights,
+            min_file_share=min_file_share,
+        ),
+    )
+
+
 def _as_array(
     vectors: Union[Sequence[Sequence[float]], np.ndarray, Any],  # noqa: ANN401 — torch.Tensor duck-typed
 ) -> np.ndarray:

--- a/src/senselab/utils/tasks/embedding_distribution.py
+++ b/src/senselab/utils/tasks/embedding_distribution.py
@@ -185,6 +185,36 @@ class CrossFileStats(BaseModel):
     file_centroid_pairwise_cos: Optional[SimilarityStats] = None
 
 
+class FileEffect(BaseModel):
+    """Whether file identity explains similarity, and how surprising that is.
+
+    Attributes:
+        auc_same_file_vs_diff_file: Mann-Whitney AUC of same-file pair cosines against
+            different-file pair cosines. Exact null 0.5 under exchangeability, which is what lets
+            it be read with no fitted scale. Rank-based, so unlike silhouette it does not change
+            when the same geometry is expressed as cosine rather than Euclidean distance. ``None``
+            without file ids or with fewer than two files.
+        permutation_quantile: Where the observed between-file share of angular variance falls in
+            the block-permutation reference, in ``[0, 1]``.
+        permutation_block_len: Block length used, ``ceil(window_s/hop_s)`` when both are known and
+            1 otherwise. Windows overlap, so shuffling single vectors would destroy dependence the
+            observed statistic retains and the quantile would come out anti-conservative.
+        n_permutations: How many shuffles produced the reference.
+        guard_band_s: Same-file pairs closer together in time than this were excluded. ``None``
+            when ``window_starts_s`` was not supplied, so a reader can tell "not applied" from
+            "applied with value X" -- at 50% overlap a window's neighbour is a near-duplicate, and
+            leaving those in makes the AUC measure the hop size.
+        seed: Permutation seed, recorded so the quantile is reproducible.
+    """
+
+    auc_same_file_vs_diff_file: Optional[float] = None
+    permutation_quantile: Optional[float] = None
+    permutation_block_len: int = 1
+    n_permutations: int = 0
+    guard_band_s: Optional[float] = None
+    seed: int = 0
+
+
 class EmbeddingDistribution(BaseModel):
     """Statistics describing one set of embedding vectors. Contains no verdict."""
 
@@ -200,6 +230,7 @@ class EmbeddingDistribution(BaseModel):
     # informative split known about this data. See `_per_file_stats`.
     within_file: dict[str, WithinFileStats] = Field(default_factory=dict)
     cross_file: CrossFileStats = Field(default_factory=CrossFileStats)
+    file_effect: FileEffect = Field(default_factory=FileEffect)
 
 
 def _as_array(
@@ -392,6 +423,128 @@ def _per_file_stats(
     return within, CrossFileStats(cos_file_centroid_to_pooled=to_pooled, file_centroid_pairwise_cos=pairwise)
 
 
+def _mann_whitney_auc(within: np.ndarray, between: np.ndarray) -> float:
+    """Probability that a randomly chosen within-group value exceeds a between-group one.
+
+    ``AUC = P(w > b) + 0.5*P(w == b)``, computed from ranks so it costs one sort rather than a
+    quadratic comparison. Rank-based is the point: the value is invariant to any monotone
+    reparametrisation of the similarity, which is exactly the property silhouette lacks.
+
+    Args:
+        within: 1-D array of within-group values.
+        between: 1-D array of between-group values.
+
+    Returns:
+        The AUC in ``[0, 1]``. Returns ``0.5`` when either side is empty -- no evidence either way.
+    """
+    if within.size == 0 or between.size == 0:
+        return 0.5
+    from scipy.stats import rankdata
+
+    combined = np.concatenate([within, between])
+    ranks = rankdata(combined)
+    r_within = float(ranks[: within.size].sum())
+    u = r_within - within.size * (within.size + 1) / 2.0
+    return float(u / (within.size * between.size))
+
+
+def _eta_squared_between_files(x: np.ndarray, ids: np.ndarray) -> float:
+    """Between-file share of angular variance.
+
+    ``1 - sum_f n_f (1 - Rbar_f^2) / [n (1 - Rbar^2)]``: the residual within-file dispersion
+    removed from the total. Bounded in ``[0, 1]`` for well-formed input.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+        ids: ``(n,)`` array of file ids.
+
+    Returns:
+        The between-file share; ``0.0`` when the pooled set has no dispersion to explain.
+    """
+    n = x.shape[0]
+    rbar = float(np.linalg.norm(x.sum(axis=0)) / n)
+    total = n * (1.0 - rbar**2)
+    if total <= 0:
+        return 0.0
+    resid = 0.0
+    for f in np.unique(ids):
+        rows = x[ids == f]
+        nf = rows.shape[0]
+        rf = float(np.linalg.norm(rows.sum(axis=0)) / nf)
+        resid += nf * (1.0 - rf**2)
+    return float(1.0 - resid / total)
+
+
+def _file_effect(
+    x: np.ndarray,
+    file_ids: Optional[list[str]],
+    window_starts_s: Optional[list[float]],
+    window_s: Optional[float],
+    hop_s: Optional[float],
+    n_permutations: int,
+    seed: int,
+) -> FileEffect:
+    """Separability AUC plus a block-permutation reference for the between-file variance share.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+        file_ids: One id per row, or ``None``.
+        window_starts_s: Window start times aligned to ``x``, or ``None``.
+        window_s: Window length, used for the guard band and the block length.
+        hop_s: Hop, used for the block length.
+        n_permutations: Shuffles for the reference.
+        seed: Permutation seed.
+
+    Returns:
+        The populated :class:`FileEffect`, or a default one when there is no file structure.
+    """
+    block_len = 1
+    if window_s is not None and hop_s is not None and hop_s > 0:
+        block_len = max(1, int(np.ceil(window_s / hop_s)))
+
+    if file_ids is None or len(set(file_ids)) < 2:
+        return FileEffect(permutation_block_len=block_len, n_permutations=0, seed=seed)
+
+    ids = np.asarray(file_ids)
+    gram = x @ x.T
+    iu = np.triu_indices(x.shape[0], k=1)
+    same = ids[iu[0]] == ids[iu[1]]
+    cos_pairs = gram[iu]
+
+    guard_band_s: Optional[float] = None
+    keep = np.ones(cos_pairs.shape, dtype=bool)
+    if window_starts_s is not None and window_s is not None:
+        # Adjacent windows share audio, so a same-file pair drawn from them is a near-duplicate.
+        # Excluded from both sides, or the AUC would report the hop size.
+        guard_band_s = float(window_s)
+        starts = np.asarray(window_starts_s, dtype=np.float64)
+        too_close = np.abs(starts[iu[0]] - starts[iu[1]]) < guard_band_s
+        keep = ~(same & too_close)
+
+    auc = _mann_whitney_auc(cos_pairs[keep & same], cos_pairs[keep & ~same])
+
+    observed = _eta_squared_between_files(x, ids)
+    rng = np.random.default_rng(seed)
+    n = x.shape[0]
+    n_blocks = int(np.ceil(n / block_len))
+    exceeded = 0
+    for _ in range(n_permutations):
+        block_order = rng.permutation(n_blocks)
+        shuffled = np.concatenate([ids[b * block_len : (b + 1) * block_len] for b in block_order])[:n]
+        if _eta_squared_between_files(x, shuffled) <= observed:
+            exceeded += 1
+    quantile = float(exceeded / n_permutations) if n_permutations > 0 else None
+
+    return FileEffect(
+        auc_same_file_vs_diff_file=auc,
+        permutation_quantile=quantile,
+        permutation_block_len=block_len,
+        n_permutations=n_permutations,
+        guard_band_s=guard_band_s,
+        seed=seed,
+    )
+
+
 def describe_embedding_distribution(
     vectors: Union[Sequence[Sequence[float]], np.ndarray, Any],  # noqa: ANN401 — torch.Tensor duck-typed
     file_ids: Optional[Sequence[str]] = None,
@@ -455,6 +608,9 @@ def describe_embedding_distribution(
 
     within_file, cross_file = _per_file_stats(x, kept_files, centroid)
 
+    starts_list = [float(s) for s, k in zip(window_starts_s, keep_mask) if k] if window_starts_s is not None else None
+    file_effect = _file_effect(x, kept_files, starts_list, window_s, hop_s, n_permutations, seed)
+
     per_file: dict[str, int] = {}
     if kept_files is not None:
         for f in kept_files:
@@ -495,4 +651,5 @@ def describe_embedding_distribution(
         spectrum=_spectrum(x),
         within_file=within_file,
         cross_file=cross_file,
+        file_effect=file_effect,
     )

--- a/src/senselab/utils/tasks/embedding_distribution.py
+++ b/src/senselab/utils/tasks/embedding_distribution.py
@@ -52,6 +52,8 @@ true metric is needed (medoid, linkage) the geodesic ``arccos(clip(cos,-1,1))`` 
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any, Optional, Sequence, Union
 
 import numpy as np
@@ -257,6 +259,48 @@ class EmbeddingDistribution(BaseModel):
 
 LINKAGE_AVERAGE = "average"
 
+# Where the fitted gap-significance margin lives -- see `data/embedding_gap_significance.json`
+# for the full derivation (what was swept, the null distribution's quantiles, the achieved
+# false-split rate). Thresholds belong in `data/` with a written derivation, never as code
+# literals; this constant is only ever a fallback for the rare case the packaged file is missing.
+_GAP_SIGNIFICANCE_PROFILE_PATH = Path(__file__).parent / "data" / "embedding_gap_significance.json"
+_GAP_SIGNIFICANCE_PROFILE_VERSION = 1
+DEFAULT_GAP_SIGNIFICANCE_MARGIN = 5.0
+"""Mirrors the bundled profile's ``margin`` (achieved false-split rate 0.88% at n=1600 draws); see
+`data/embedding_gap_significance.json`. Used only if that file is absent from the install, which
+should not happen for a properly packaged senselab -- an absent bundled profile is itself worth
+noticing rather than silently patching over."""
+
+
+def _load_gap_significance_margin(path: Optional[Path] = None) -> float:
+    """Load the gap-significance margin, ``None`` (the default) reading the bundled profile.
+
+    Args:
+        path: Profile path, or ``None`` for the bundled default.
+
+    Returns:
+        The margin: how many times larger the top merge-height gap must be than the runner-up gap
+        before it is trusted as a real cluster split rather than a single coherent group's largest
+        fluctuation.
+
+    Raises:
+        ValueError: If the profile's version does not match, or ``margin`` is missing or not
+            positive -- a malformed profile must fail loudly rather than silently gate nothing.
+    """
+    target = path if path is not None else _GAP_SIGNIFICANCE_PROFILE_PATH
+    if not Path(target).exists():
+        return DEFAULT_GAP_SIGNIFICANCE_MARGIN
+    profile = json.loads(Path(target).read_text())
+    if int(profile.get("version", -1)) != _GAP_SIGNIFICANCE_PROFILE_VERSION:
+        raise ValueError(
+            f"gap-significance profile {target} has version {profile.get('version')!r}; "
+            f"expected {_GAP_SIGNIFICANCE_PROFILE_VERSION!r}"
+        )
+    margin = float(profile.get("margin", 0.0))
+    if margin <= 0:
+        raise ValueError(f"gap-significance profile {target}: margin must be > 0; got {margin}")
+    return margin
+
 
 class ClusterSummary(BaseModel):
     """One group found by the selector.
@@ -291,6 +335,13 @@ class SelectionRule(BaseModel):
             caller's judgement.
         merge_heights: The full ascending merge-height sequence. This is the threshold-free form of
             the "how many clusters" question; a consumer can re-cut it anywhere.
+        gap_significance_margin: How many times larger the top merge-height gap had to be than the
+            runner-up gap before it was trusted as a real split. Fitted from data
+            (`data/embedding_gap_significance.json`), not a code literal -- reported the same way
+            as ``cut_theta`` for the same reason: the number alone is not auditable without knowing
+            where it came from.
+        gap_significance_margin_source: ``"caller"`` when supplied, ``"profile"`` when loaded from
+            the bundled derivation. Mirrors ``cut_source``.
         min_file_share: Optional minimum per-file share for a file to count toward a group's
             file-balanced share. ``None`` means unused.
     """
@@ -299,6 +350,8 @@ class SelectionRule(BaseModel):
     cut_theta: float
     cut_source: str
     merge_heights: list[float] = Field(default_factory=list)
+    gap_significance_margin: float = DEFAULT_GAP_SIGNIFICANCE_MARGIN
+    gap_significance_margin_source: str = "profile"
     min_file_share: Optional[float] = None
 
 
@@ -321,6 +374,7 @@ def select_dominant_vectors(
     *,
     linkage: str = LINKAGE_AVERAGE,
     cut_theta: Optional[float] = None,
+    gap_significance_margin: Optional[float] = None,
     min_file_share: Optional[float] = None,
 ) -> DominantSelection:
     """Group vectors and return the dominant group, for optional contamination rejection.
@@ -341,9 +395,15 @@ def select_dominant_vectors(
         file_ids: One id per row. Enables file-balanced selection and per-file drop accounting.
         linkage: Passed to ``scipy.cluster.hierarchy.linkage``. ``"average"`` by default.
         cut_theta: Angular cut in radians. ``None`` derives it from the largest gap in the merge
-            heights, accepted only when it structurally dominates the runner-up gap -- a *rule*,
-            not a fitted constant; see the derivation below. Supply a value to override; either way
-            the value used and its source are recorded.
+            heights, accepted only when it beats the runner-up gap by ``gap_significance_margin``
+            -- a *rule*, not a fitted constant; see the derivation below. Supply a value to
+            override; either way the value used and its source are recorded.
+        gap_significance_margin: How many times larger the top merge-height gap must be than the
+            runner-up gap before it is trusted as a real split. ``None`` (the default) loads the
+            fitted value from `data/embedding_gap_significance.json`, derived from a 1600-draw
+            sweep of the null (single coherent group) merge-gap-ratio distribution to hold the
+            false-split rate at or below 1%; see that file for the full derivation. Supply a value
+            to override; either way the value used and its source are recorded.
         min_file_share: Optional floor on a file's share within a group before that file counts
             toward the group's file-balanced share. ``None`` counts every contributing file.
 
@@ -378,25 +438,30 @@ def select_dominant_vectors(
     z = scipy_linkage(squareform(theta, checks=False), method=linkage)
     merge_heights = [float(h) for h in z[:, 2]]
 
+    if gap_significance_margin is None:
+        margin_value = _load_gap_significance_margin()
+        margin_source = "profile"
+    else:
+        margin_value = float(gap_significance_margin)
+        margin_source = "caller"
+
     if cut_theta is None:
         # The largest gap between consecutive merge heights is where the data itself separates --
-        # but the raw argmax is not enough on its own. Measured on 50 vectors drawn from one vMF
-        # cone (no intruder at all): the single biggest gap sits down near the leaves (ratio to the
-        # runner-up gap ~1.87x) purely from sampling noise in how tightly the first few points
-        # happen to land, while a real two-population split (60 target / 20 intruder) puts the
-        # biggest gap at the root with the runner-up gap dwarfed 86x-190x over. That gap between
-        # "noise's biggest fluctuation" and "an actual population boundary" is two orders of
-        # magnitude, not a close call -- so the biggest gap is only trusted as a cut when it beats
-        # the runner-up gap by a wide, structural margin (taken as 2x: any single coherent cluster's
-        # noisiest gap was, in the measurement above, within a factor of 2 of its own runner-up).
-        # Below that margin nothing stands out from the rest, and the cut is set at the maximum
-        # merge height, which folds every row into one cluster rather than fabricating a split.
+        # but the raw argmax is not enough on its own. A single coherent group (no intruder at all)
+        # still has *some* largest gap, and it is usually down near the leaves from sampling noise
+        # in how tightly the first few points happen to land, not at the root where a real
+        # population split would show up. `margin_value` is the fitted answer to "how much bigger
+        # than the runner-up gap must the top gap be before it is trusted": see
+        # `data/embedding_gap_significance.json` for the 1600-draw sweep of the null distribution
+        # and the false-split rate the bundled margin achieves. Below that margin nothing stands
+        # out from the rest, and the cut is set at the maximum merge height, which folds every row
+        # into one cluster rather than fabricating a split.
         heights = np.asarray(merge_heights)
         gaps = np.diff(heights)
         if gaps.size >= 2:
             order = np.argsort(gaps)
             top1_idx, top2_idx = int(order[-1]), int(order[-2])
-            if gaps[top1_idx] > 2.0 * gaps[top2_idx]:
+            if gaps[top1_idx] > margin_value * gaps[top2_idx]:
                 resolved_cut = float((heights[top1_idx] + heights[top1_idx + 1]) / 2.0)
             else:
                 resolved_cut = float(heights.max())
@@ -465,6 +530,8 @@ def select_dominant_vectors(
             cut_theta=resolved_cut,
             cut_source=cut_source,
             merge_heights=merge_heights,
+            gap_significance_margin=margin_value,
+            gap_significance_margin_source=margin_source,
             min_file_share=min_file_share,
         ),
     )

--- a/src/senselab/utils/tasks/embedding_distribution.py
+++ b/src/senselab/utils/tasks/embedding_distribution.py
@@ -215,6 +215,27 @@ class FileEffect(BaseModel):
     seed: int = 0
 
 
+class CentroidRobustness(BaseModel):
+    """Whether the centroid depends on how it was aggregated, or on one file.
+
+    Attributes:
+        cos_mean_vs_trimmed10: Cosine between the spherical mean and the 10%-trimmed spherical
+            mean. Near 1.0 means aggregation choice did not matter; a visible gap means the
+            estimate is contamination-sensitive. With no clustering rejecting contamination, this
+            is how a caller learns that.
+        cos_mean_vs_medoid: Cosine between the spherical mean and the medoid. The medoid has a
+            ~50% breakdown point but *is* one real vector, so its error does not shrink with ``n``;
+            it is reported as a diagnostic rather than used as the default centroid.
+        leave_one_file_out_cos: Per file, the cosine between the full centroid and the centroid
+            recomputed with that file removed. A jackknife along the cross-file axis, where the
+            measured error budget sits. Empty without file ids.
+    """
+
+    cos_mean_vs_trimmed10: float = 1.0
+    cos_mean_vs_medoid: float = 1.0
+    leave_one_file_out_cos: dict[str, float] = Field(default_factory=dict)
+
+
 class EmbeddingDistribution(BaseModel):
     """Statistics describing one set of embedding vectors. Contains no verdict."""
 
@@ -231,6 +252,7 @@ class EmbeddingDistribution(BaseModel):
     within_file: dict[str, WithinFileStats] = Field(default_factory=dict)
     cross_file: CrossFileStats = Field(default_factory=CrossFileStats)
     file_effect: FileEffect = Field(default_factory=FileEffect)
+    centroid_robustness: CentroidRobustness = Field(default_factory=CentroidRobustness)
 
 
 def _as_array(
@@ -343,6 +365,76 @@ def _loo_cos_to_centroid(x: np.ndarray) -> np.ndarray:
     nz = denom > 0
     out[nz] = numer[nz] / denom[nz]
     return out
+
+
+def _trimmed_spherical_mean(x: np.ndarray, fraction: float = _TRIM_FRACTION) -> np.ndarray:
+    """Spherical mean after dropping the ``fraction`` of rows least aligned with the full mean.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+        fraction: Share of rows to drop, from the low end of leave-one-out cosine.
+
+    Returns:
+        A unit-norm direction. Falls back to the untrimmed mean when trimming would leave fewer
+        than two rows.
+    """
+    n = x.shape[0]
+    k = int(np.floor(fraction * n))
+    if k < 1 or n - k < 2:
+        return _spherical_mean(x)
+    keep = np.argsort(_loo_cos_to_centroid(x))[k:]
+    return _spherical_mean(x[keep])
+
+
+def _medoid(x: np.ndarray) -> np.ndarray:
+    """The input row minimising total geodesic distance to the others.
+
+    Uses angular distance ``arccos(clip(cos))`` rather than ``1-cos``, because only the former is
+    a metric on the sphere and "medoid" is defined against a metric.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+
+    Returns:
+        A copy of the selected row.
+    """
+    theta = np.arccos(np.clip(x @ x.T, -1.0, 1.0))
+    return x[int(np.argmin(theta.sum(axis=1)))].copy()
+
+
+def _centroid_robustness(x: np.ndarray, file_ids: Optional[list[str]], mean_centroid: np.ndarray) -> CentroidRobustness:
+    """Aggregation sensitivity plus leave-one-file-out stability.
+
+    Args:
+        x: ``(n, d)`` unit-norm array.
+        file_ids: One id per row, or ``None``.
+        mean_centroid: The spherical mean over all rows. Kept as the one reference for every
+            comparison here regardless of which aggregator the caller selected for the returned
+            centroid, so e.g. ``cos_mean_vs_medoid`` never ends up comparing the medoid to itself.
+
+    Returns:
+        The populated robustness block.
+    """
+    trimmed = _trimmed_spherical_mean(x)
+    medoid = _medoid(x)
+
+    lofo: dict[str, float] = {}
+    if file_ids is not None:
+        ids = np.asarray(file_ids)
+        order: list[str] = []
+        for f in file_ids:
+            if f not in order:
+                order.append(f)
+        for f in order:
+            rows = x[ids != f]
+            # A single remaining row still has a direction; zero remaining rows does not.
+            lofo[f] = float(mean_centroid @ _spherical_mean(rows)) if rows.shape[0] >= 1 else 1.0
+
+    return CentroidRobustness(
+        cos_mean_vs_trimmed10=float(mean_centroid @ trimmed),
+        cos_mean_vs_medoid=float(mean_centroid @ medoid),
+        leave_one_file_out_cos=lofo,
+    )
 
 
 def _spectrum(x: np.ndarray) -> SpectrumStats:
@@ -604,9 +696,18 @@ def describe_embedding_distribution(
 
     kept_files = [str(f) for f, k in zip(file_ids, keep_mask) if k] if file_ids is not None else None
 
-    centroid = _spherical_mean(x)  # Tasks 4-5 replace this with the aggregator dispatch.
+    # The robustness comparisons and per-file statistics stay pinned to the spherical mean
+    # regardless of `aggregator`, so a caller who picked "medoid" still gets a diagnostic
+    # comparing the medoid *against* the mean rather than against itself.
+    mean_centroid = _spherical_mean(x)
+    if aggregator == AGGREGATOR_SPHERICAL_MEAN:
+        centroid = mean_centroid
+    elif aggregator == AGGREGATOR_TRIMMED_MEAN:
+        centroid = _trimmed_spherical_mean(x)
+    else:
+        centroid = _medoid(x)
 
-    within_file, cross_file = _per_file_stats(x, kept_files, centroid)
+    within_file, cross_file = _per_file_stats(x, kept_files, mean_centroid)
 
     starts_list = [float(s) for s, k in zip(window_starts_s, keep_mask) if k] if window_starts_s is not None else None
     file_effect = _file_effect(x, kept_files, starts_list, window_s, hop_s, n_permutations, seed)
@@ -652,4 +753,5 @@ def describe_embedding_distribution(
         within_file=within_file,
         cross_file=cross_file,
         file_effect=file_effect,
+        centroid_robustness=_centroid_robustness(x, kept_files, mean_centroid),
     )

--- a/src/senselab/utils/tasks/embedding_distribution.py
+++ b/src/senselab/utils/tasks/embedding_distribution.py
@@ -652,10 +652,10 @@ def _loo_cos_to_centroid(x: np.ndarray) -> np.ndarray:
     s = x.sum(axis=0)
     diff = s[None, :] - x
     denom = np.linalg.norm(diff, axis=1)
-    numer = np.einsum("ij,ij->i", x, diff)
+    numerator = np.einsum("ij,ij->i", x, diff)
     out = np.zeros_like(denom)
     nz = denom > 0
-    out[nz] = numer[nz] / denom[nz]
+    out[nz] = numerator[nz] / denom[nz]
     return out
 
 

--- a/src/tests/audio/data_structures/audio_hints_test.py
+++ b/src/tests/audio/data_structures/audio_hints_test.py
@@ -1,0 +1,121 @@
+"""Declared hints on an Audio.
+
+A hint is an assertion by whoever knows the acquisition protocol -- never a measurement, and
+never consumed by any task in this change. These tests pin the two properties that make
+"declared and carried" true: absent stays distinguishable from empty, and a hint cannot change
+what a computation returns.
+"""
+
+import torch
+
+from senselab.audio.data_structures import Audio
+from senselab.audio.data_structures.audio_hints import (
+    AudioHints,
+    ExpectedSpeech,
+    SpeakerEmbeddingProvenance,
+    TargetSpeakerEmbedding,
+)
+
+
+def test_an_audio_carries_no_hints_by_default() -> None:
+    """Absent must stay distinguishable from empty.
+
+    An empty AudioHints would make "nobody declared anything" read the same as "declared
+    nothing" -- the same collapse as reading a None confidence as 0.0, which pii_detection
+    documents at length.
+    """
+    audio = Audio(waveform=torch.zeros(1, 16000), sampling_rate=16000)
+    assert audio.hints is None
+
+
+def test_hints_hold_every_declared_field() -> None:
+    """Every hint in the request round-trips through the model."""
+    hints = AudioHints(
+        may_contain=["read-speech", "cough"],
+        targeted_speaker_count=1,
+        environment="quiet-room",
+        expected_speech=[
+            ExpectedSpeech(text="The quick brown fox.", prompt_id="harvard-01", reference="ieee-1969"),
+            ExpectedSpeech(text="Rice is often served in round bowls.", prompt_id="harvard-02"),
+        ],
+    )
+    audio = Audio(waveform=torch.zeros(1, 16000), sampling_rate=16000, hints=hints)
+    assert audio.hints is not None
+    assert audio.hints.may_contain == ["read-speech", "cough"]
+    assert audio.hints.targeted_speaker_count == 1
+    assert audio.hints.environment == "quiet-room"
+    assert len(audio.hints.expected_speech) == 2
+    assert audio.hints.expected_speech[0].prompt_id == "harvard-01"
+
+
+def test_expected_speech_preserves_order() -> None:
+    """A file often holds several sentences read in sequence.
+
+    Concatenating them would destroy the boundaries a matcher needs to say *which* sentence was
+    skipped or reordered -- a different question from how close the whole thing was.
+    """
+    hints = AudioHints(
+        expected_speech=[ExpectedSpeech(text="first"), ExpectedSpeech(text="second"), ExpectedSpeech(text="third")]
+    )
+    assert [e.text for e in hints.expected_speech] == ["first", "second", "third"]
+
+
+def test_provenance_records_a_resolved_sha_or_says_why_not() -> None:
+    """A ref in the commit-sha field would be provenance that is confidently wrong.
+
+    #550 established that recording a ref while claiming a commit is worse than recording
+    nothing, so an unresolved model must set unresolved_reason instead.
+    """
+    resolved = SpeakerEmbeddingProvenance(model_id="speechbrain/spkrec-ecapa-voxceleb", model_commit_sha="a" * 40)
+    assert resolved.model_commit_sha == "a" * 40
+    assert resolved.unresolved_reason is None
+
+    unresolved = SpeakerEmbeddingProvenance(
+        model_id="speechbrain/spkrec-ecapa-voxceleb",
+        model_commit_sha=None,
+        unresolved_reason="offline: hub unreachable and no cached ref",
+    )
+    assert unresolved.model_commit_sha is None
+    assert unresolved.unresolved_reason
+
+
+def test_a_non_sha_commit_value_is_rejected() -> None:
+    """The field means "resolved commit". Anything ref-shaped in it defeats the point."""
+    import pytest
+
+    with pytest.raises(ValueError, match="40"):
+        SpeakerEmbeddingProvenance(model_id="org/model", model_commit_sha="main")
+
+
+def test_a_target_speaker_embedding_carries_its_provenance() -> None:
+    """A vector with no provenance cannot be interpreted later, so provenance is required."""
+    emb = TargetSpeakerEmbedding(
+        vector=[0.1, 0.2, 0.3],
+        provenance=SpeakerEmbeddingProvenance(model_id="org/model", model_commit_sha="b" * 40),
+    )
+    assert emb.provenance.model_id == "org/model"
+    assert emb.distribution is None
+
+
+def test_hints_do_not_change_the_cache_key() -> None:
+    """A hint nothing consumes must not change what a computation returns.
+
+    Not a backwards-compatibility concern -- alpha owes none -- but a correctness one: if a hint
+    moved a cache key, "carried only" would be false.
+
+    ``audio_signature`` is the real waveform-hashing helper (the brief's draft guessed
+    ``audio_content_hash``, which does not exist). It is typed against the structural
+    ``_HasWaveform`` protocol -- ``waveform`` and ``sampling_rate`` only -- so it cannot read
+    ``hints`` even if a caller wanted it to; this test pins that behaviour rather than trusting
+    the type alone.
+    """
+    from senselab.utils.tasks.cached_inference import audio_signature
+
+    waveform = torch.rand(1, 16000)
+    bare = Audio(waveform=waveform, sampling_rate=16000)
+    hinted = Audio(
+        waveform=waveform.clone(),
+        sampling_rate=16000,
+        hints=AudioHints(may_contain=["read-speech"], targeted_speaker_count=2),
+    )
+    assert audio_signature(bare) == audio_signature(hinted)

--- a/src/tests/audio/tasks/speaker_embeddings_estimate_test.py
+++ b/src/tests/audio/tasks/speaker_embeddings_estimate_test.py
@@ -46,7 +46,12 @@ def _patch_extraction(monkeypatch: pytest.MonkeyPatch, per_audio_vectors: list[n
     def fake(audio, models, device=None, window_s=2.0, hop_s=1.0, **kwargs):  # noqa: ANN001, ANN003, ANN202
         vectors = per_audio_vectors[calls["i"]]
         calls["i"] += 1
-        model_id = str(models[0].path_or_uri) if models else "stub/model"
+        # `models` is a list of plain id strings -- `extract_per_window_embeddings`'s real
+        # contract -- not model objects; a fake that expected `.path_or_uri` here would pass
+        # even when the estimator called the real function with the wrong type, which is
+        # exactly the boundary bug `test_the_real_extraction_boundary_is_crossed_correctly`
+        # below exists to catch instead.
+        model_id = str(models[0]) if models else "stub/model"
         return {
             model_id: [
                 est_api.WindowEmbedding(start_s=float(i) * hop_s, end_s=float(i) * hop_s + window_s, vector=v)
@@ -156,3 +161,52 @@ def test_source_files_are_recorded_when_available(monkeypatch: pytest.MonkeyPatc
     audio.metadata["source"] = "unused"
     result = estimate_speaker_embedding_from_audios([audio])
     assert isinstance(result.provenance.source_files, list)
+
+
+def test_the_real_extraction_boundary_is_crossed_correctly(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """Regression test for a boundary bug the other tests structurally cannot see.
+
+    Every other test in this file monkeypatches `extract_per_window_embeddings` itself, which is
+    precisely the seam a call-site type mismatch lives on -- a fake standing in for the whole
+    function can accept whatever the estimator happens to pass it, real contract or not. A prior
+    version of the estimator passed a `SenselabModel` object where `extract_per_window_embeddings`
+    declares (and its real body assumes) a plain model-id string; every one of the other tests
+    still passed, because their fake never exercised that body.
+
+    This test instead lets the real `extract_per_window_embeddings` run -- real `window_starts`,
+    real `slice_audio`, real per-window loop, real `SpeechBrainModel(path_or_uri=model_id, ...)`
+    construction -- and only replaces the one call inside it that would otherwise load a model:
+    `extract_speaker_embeddings_from_audios`. `SpeechBrainModel` construction still runs for real,
+    so a wrong-typed id would still fail pydantic's `path_or_uri: Union[str, Path]` validation
+    exactly as it did in production; only the two network-touching leaf calls inside that
+    construction (`check_hf_repo_exists`, `resolve_revision`) are stubbed, so no HTTP request and
+    no model download happen anywhere in this test.
+    """
+    from senselab.audio.tasks.speaker_embeddings import windowing as windowing_module
+    from senselab.utils import model_revision as model_revision_module
+    from senselab.utils.data_structures import model as model_module
+
+    monkeypatch.setattr(model_module, "check_hf_repo_exists", lambda **kwargs: True)  # noqa: ANN003
+    monkeypatch.setattr(model_revision_module, "resolve_revision", lambda *a, **k: "d" * 40)  # noqa: ANN002, ANN003
+
+    target, _ = axes
+    synthetic_vector = torch.from_numpy(_cone(target, 1, 0.0, 7)[0]).float()
+
+    def fake_extract_embeddings(audios, model=None, device=None):  # noqa: ANN001, ANN202
+        # Stands in for the one call in `extract_per_window_embeddings` that would otherwise load
+        # ECAPA and run real inference; everything upstream of it (windowing, model construction)
+        # is real.
+        return [synthetic_vector for _ in audios]
+
+    monkeypatch.setattr(windowing_module, "extract_speaker_embeddings_from_audios", fake_extract_embeddings)
+
+    result = estimate_speaker_embedding_from_audios([_audio()])
+
+    assert isinstance(result.vector, list)
+    assert np.linalg.norm(np.asarray(result.vector)) == pytest.approx(1.0)
+    # provenance.model_id must still be the plain id string, and _resolve_embedding_model's own
+    # resolution (shared with HFModel's, both routed through the same patched `resolve_revision`)
+    # must still produce a real 40-hex commit rather than a ref.
+    assert result.provenance.model_id == "speechbrain/spkrec-ecapa-voxceleb"
+    assert result.provenance.model_commit_sha == "d" * 40
+    assert result.provenance.unresolved_reason is None

--- a/src/tests/audio/tasks/speaker_embeddings_estimate_test.py
+++ b/src/tests/audio/tasks/speaker_embeddings_estimate_test.py
@@ -163,6 +163,132 @@ def test_source_files_are_recorded_when_available(monkeypatch: pytest.MonkeyPatc
     assert isinstance(result.provenance.source_files, list)
 
 
+def test_the_resolved_commit_sha_is_what_gets_threaded_to_extraction(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """Provenance must record the same commit that extraction was actually asked to load with.
+
+    Regression: `estimate_speaker_embedding_from_audios` resolved `commit_sha` for provenance but
+    never passed it onward, so `extract_per_window_embeddings` (before its own fix) loaded
+    `revision="main"` regardless -- a caller pinning an old commit got that SHA recorded while
+    current-main weights loaded. This freezes that `commit_sha` is threaded through as the
+    `revision=` kwarg, so the two cannot drift apart silently again.
+    """
+    from senselab.audio.tasks.speaker_embeddings import api as est_api
+
+    target, _ = axes
+    captured_revisions: list[object] = []
+
+    def fake(audio, models, device=None, window_s=2.0, hop_s=1.0, revision=None, **kwargs):  # noqa: ANN001, ANN003, ANN202
+        captured_revisions.append(revision)
+        model_id = str(models[0]) if models else "stub/model"
+        vectors = _cone(target, 10, 0.03, 1)
+        return {
+            model_id: [
+                est_api.WindowEmbedding(start_s=float(i) * hop_s, end_s=float(i) * hop_s + window_s, vector=v)
+                for i, v in enumerate(vectors)
+            ]
+        }
+
+    monkeypatch.setattr(est_api, "extract_per_window_embeddings", fake)
+    monkeypatch.setattr(
+        est_api, "_resolve_embedding_model", lambda model: ("speechbrain/spkrec-ecapa-voxceleb", "e" * 40, None)
+    )
+
+    result = estimate_speaker_embedding_from_audios([_audio()])
+
+    assert captured_revisions == ["e" * 40]
+    assert result.provenance.model_commit_sha == "e" * 40
+
+
+def test_a_partial_extraction_failure_is_recorded_not_swallowed(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """One file's model failure must be visible in provenance, not just a silently thinner estimate.
+
+    Regression: this function was the only caller of `extract_per_window_embeddings` that omitted
+    `failures=`, so a model crashing on one file out of several vanished into an empty window list
+    with no trace -- `n_windows_dropped` stayed 0 and the failed file still appeared unmarked in
+    `source_files`.
+    """
+    from senselab.audio.tasks.speaker_embeddings import api as est_api
+
+    target, _ = axes
+    call_index = {"i": 0}
+
+    def fake(audio, models, device=None, window_s=2.0, hop_s=1.0, failures=None, **kwargs):  # noqa: ANN001, ANN003, ANN202
+        model_id = str(models[0])
+        i = call_index["i"]
+        call_index["i"] += 1
+        if i == 0:
+            if failures is not None:
+                failures[model_id] = "model failed during extraction: RuntimeError('boom')"
+            return {model_id: []}
+        vectors = _cone(target, 10, 0.03, 2)
+        return {
+            model_id: [
+                est_api.WindowEmbedding(start_s=float(j) * hop_s, end_s=float(j) * hop_s + window_s, vector=v)
+                for j, v in enumerate(vectors)
+            ]
+        }
+
+    monkeypatch.setattr(est_api, "extract_per_window_embeddings", fake)
+    monkeypatch.setattr(
+        est_api, "_resolve_embedding_model", lambda model: ("speechbrain/spkrec-ecapa-voxceleb", "f" * 40, None)
+    )
+
+    result = estimate_speaker_embedding_from_audios([_audio(), _audio()], file_ids=["failed-file", "ok-file"])
+
+    assert result.provenance.extraction_failures == {
+        "failed-file": "model failed during extraction: RuntimeError('boom')"
+    }
+    assert "ok-file" not in result.provenance.extraction_failures
+    assert result.provenance.n_windows_used == 10
+
+
+def test_every_file_failing_raises_the_real_cause_not_a_duration_guess(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A model that cannot load must not be misdiagnosed as "are the inputs shorter than window_s?".
+
+    Regression: with no `failures=` collector, a total extraction failure and a genuinely
+    too-short input produced the exact same generic message, hiding which one actually happened.
+    """
+    from senselab.audio.tasks.speaker_embeddings import api as est_api
+
+    def fake(audio, models, device=None, window_s=2.0, hop_s=1.0, failures=None, **kwargs):  # noqa: ANN001, ANN003, ANN202
+        model_id = str(models[0])
+        if failures is not None:
+            failures[model_id] = "model failed during extraction: OSError('no space left on device')"
+        return {model_id: []}
+
+    monkeypatch.setattr(est_api, "extract_per_window_embeddings", fake)
+    monkeypatch.setattr(
+        est_api, "_resolve_embedding_model", lambda model: ("speechbrain/spkrec-ecapa-voxceleb", "f" * 40, None)
+    )
+
+    with pytest.raises(ValueError, match="no space left on device"):
+        estimate_speaker_embedding_from_audios([_audio()])
+
+
+def test_file_ids_replace_the_positional_placeholder(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """Caller-supplied ids must key every per-file block, not the `audio-0`/`audio-1` fallback.
+
+    Regression: `Audio.filepath()` is empty for any in-memory or preprocessed audio (this module's
+    own docstring recommends `resample_audios`, which drops `filepath`), so the positional fallback
+    made `source_files`, `vectors_per_file`, `within_file` and `leave_one_file_out_cos` all
+    unmappable back to a real recording.
+    """
+    target, _ = axes
+    _patch_extraction(monkeypatch, [_cone(target, 10, 0.03, 1), _cone(target, 10, 0.03, 2)])
+
+    result = estimate_speaker_embedding_from_audios([_audio(), _audio()], file_ids=["patient-01", "patient-02"])
+
+    assert result.provenance.source_files == ["patient-01", "patient-02"]
+    assert result.distribution is not None
+    assert set(result.distribution.within_file) == {"patient-01", "patient-02"}
+
+
+def test_file_ids_length_mismatch_raises(monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ANN001
+    """A miscounted id list must fail loudly rather than silently mis-map files to ids."""
+    with pytest.raises(ValueError, match="file_ids"):
+        estimate_speaker_embedding_from_audios([_audio(), _audio()], file_ids=["only-one"])
+
+
 def test_the_real_extraction_boundary_is_crossed_correctly(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
     """Regression test for a boundary bug the other tests structurally cannot see.
 

--- a/src/tests/audio/tasks/speaker_embeddings_estimate_test.py
+++ b/src/tests/audio/tasks/speaker_embeddings_estimate_test.py
@@ -1,0 +1,158 @@
+"""Estimate one speaker embedding from files that may contain that speaker.
+
+No model is loaded anywhere here: the per-window extraction is monkeypatched to return controlled
+vectors, so these tests exercise the aggregation, provenance and rejection logic deterministically
+and without downloading a snapshot.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from senselab.audio.data_structures import Audio
+from senselab.audio.tasks.speaker_embeddings import estimate_speaker_embedding_from_audios
+
+_DIM = 48
+
+
+def _audio(seconds: float = 8.0, sr: int = 16000) -> Audio:
+    return Audio(waveform=torch.rand(1, int(seconds * sr)), sampling_rate=sr)
+
+
+def _cone(axis: np.ndarray, n: int, spread: float, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    v = axis[None, :] + spread * rng.normal(size=(n, axis.size))
+    return v / np.linalg.norm(v, axis=1, keepdims=True)
+
+
+@pytest.fixture
+def axes() -> tuple[np.ndarray, np.ndarray]:
+    """Two near-orthogonal directions: a target speaker and an intruder."""
+    rng = np.random.default_rng(41)
+    a = rng.normal(size=_DIM)
+    a /= np.linalg.norm(a)
+    b = rng.normal(size=_DIM)
+    b -= (b @ a) * a
+    b /= np.linalg.norm(b)
+    return a, b
+
+
+def _patch_extraction(monkeypatch: pytest.MonkeyPatch, per_audio_vectors: list[np.ndarray]) -> None:
+    """Make per-window extraction return the given vectors, one array per input audio."""
+    from senselab.audio.tasks.speaker_embeddings import api as est_api
+
+    calls = {"i": 0}
+
+    def fake(audio, models, device=None, window_s=2.0, hop_s=1.0, **kwargs):  # noqa: ANN001, ANN003, ANN202
+        vectors = per_audio_vectors[calls["i"]]
+        calls["i"] += 1
+        model_id = str(models[0].path_or_uri) if models else "stub/model"
+        return {
+            model_id: [
+                est_api.WindowEmbedding(start_s=float(i) * hop_s, end_s=float(i) * hop_s + window_s, vector=v)
+                for i, v in enumerate(vectors)
+            ]
+        }
+
+    monkeypatch.setattr(est_api, "extract_per_window_embeddings", fake)
+    monkeypatch.setattr(
+        est_api, "_resolve_embedding_model", lambda model: ("speechbrain/spkrec-ecapa-voxceleb", "c" * 40, None)
+    )
+
+
+def test_the_estimate_is_a_unit_vector_with_provenance(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """A vector without provenance cannot be interpreted later, so both come back together."""
+    target, _ = axes
+    _patch_extraction(monkeypatch, [_cone(target, 20, 0.03, 1), _cone(target, 20, 0.03, 2)])
+
+    result = estimate_speaker_embedding_from_audios([_audio(), _audio()])
+
+    assert np.linalg.norm(np.asarray(result.vector)) == pytest.approx(1.0)
+    assert result.provenance.model_id == "speechbrain/spkrec-ecapa-voxceleb"
+    assert result.provenance.model_commit_sha == "c" * 40
+    assert result.provenance.method == "spherical_mean"
+    assert result.provenance.window_s == 2.0
+    assert result.provenance.hop_s == 1.0
+    assert result.provenance.n_windows_used == 40
+    assert result.provenance.n_windows_dropped == 0
+
+
+def test_the_distribution_is_attached(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """The statistics are the whole point of the estimator.
+
+    Without them the caller cannot judge how well-supported the centroid is.
+    """
+    target, _ = axes
+    _patch_extraction(monkeypatch, [_cone(target, 20, 0.03, 1), _cone(target, 20, 0.03, 2)])
+
+    result = estimate_speaker_embedding_from_audios([_audio(), _audio()])
+
+    assert result.distribution is not None
+    assert result.distribution.counts.n_files == 2
+    assert result.distribution.nulls.cos_sd_null == pytest.approx(1.0 / np.sqrt(_DIM))
+    assert set(result.distribution.within_file) == set(result.distribution.cross_file.cos_file_centroid_to_pooled)
+
+
+def test_contamination_is_visible_without_rejection(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """With the flag off nothing is dropped.
+
+    The intruder shows up in the per-file statistics -- which is how a caller curates its input
+    instead of us deciding.
+    """
+    target, intruder = axes
+    _patch_extraction(
+        monkeypatch, [_cone(target, 20, 0.03, 1), _cone(target, 20, 0.03, 2), _cone(intruder, 20, 0.03, 3)]
+    )
+
+    result = estimate_speaker_embedding_from_audios([_audio(), _audio(), _audio()])
+
+    assert result.provenance.n_windows_dropped == 0
+    assert result.provenance.method == "spherical_mean"
+    # Narrows `Optional[EmbeddingDistribution]` for mypy: the estimator always attaches a
+    # distribution, so this never actually fires, but a bare `result.distribution.x` would
+    # leave the access unchecked against the field's declared type.
+    assert result.distribution is not None
+    lofo = result.distribution.centroid_robustness.leave_one_file_out_cos
+    worst = min(lofo, key=lambda k: lofo[k])
+    assert lofo[worst] < max(lofo.values())
+
+
+def test_rejection_drops_the_intruder_and_records_it(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """Rejection is a decision, so it must never be silent.
+
+    The method string and the dropped count both say it happened.
+    """
+    target, intruder = axes
+    _patch_extraction(
+        monkeypatch, [_cone(target, 20, 0.03, 1), _cone(target, 20, 0.03, 2), _cone(intruder, 20, 0.03, 3)]
+    )
+
+    result = estimate_speaker_embedding_from_audios([_audio(), _audio(), _audio()], reject_contamination=True)
+
+    assert result.provenance.method == "spherical_mean+dominant_cluster"
+    assert result.provenance.n_windows_dropped == 20
+    assert result.provenance.n_windows_used == 40
+    assert np.asarray(result.vector) @ target > 0.9
+
+
+def test_rejection_is_off_by_default(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """The default path decides nothing."""
+    import inspect
+
+    assert inspect.signature(estimate_speaker_embedding_from_audios).parameters["reject_contamination"].default is False
+
+
+def test_an_empty_input_raises(monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ANN001
+    """No files means no estimate. Returning a zero vector would look like a measurement."""
+    with pytest.raises(ValueError, match="at least one"):
+        estimate_speaker_embedding_from_audios([])
+
+
+def test_source_files_are_recorded_when_available(monkeypatch: pytest.MonkeyPatch, axes) -> None:  # noqa: ANN001
+    """Provenance has to name what the estimate came from, or it cannot be reproduced."""
+    target, _ = axes
+    _patch_extraction(monkeypatch, [_cone(target, 10, 0.03, 1)])
+    audio = _audio()
+    audio.metadata["source"] = "unused"
+    result = estimate_speaker_embedding_from_audios([audio])
+    assert isinstance(result.provenance.source_files, list)

--- a/src/tests/audio/tasks/speaker_embeddings_windowing_revision_test.py
+++ b/src/tests/audio/tasks/speaker_embeddings_windowing_revision_test.py
@@ -1,0 +1,102 @@
+"""Regression tests: `extract_per_window_embeddings` must load the model at a resolved commit SHA.
+
+Finding: `windowing.py` used to construct ``SpeechBrainModel(path_or_uri=model_id, revision="main")``
+unconditionally, discarding any resolved commit SHA a caller (e.g.
+``estimate_speaker_embedding_from_audios``) had already computed for its own provenance. A caller
+pinning an old commit therefore got that SHA recorded in ``SpeakerEmbeddingProvenance`` while
+current-``main`` weights actually loaded -- "confidently wrong" provenance, the exact failure
+CLAUDE.md names ("Recording a SHA while loading through a ref is the one outcome worse than
+recording nothing").
+
+Neither test constructs a real ``SpeechBrainModel``: the class is stubbed out entirely so
+construction is a pure capture of its kwargs, and the one network-touching leaf
+(``extract_speaker_embeddings_from_audios``) is stubbed to hand back deterministic vectors.
+"""
+
+from typing import Any
+
+import pytest
+import torch
+
+from senselab.audio.data_structures import Audio
+from senselab.audio.tasks.speaker_embeddings import windowing
+
+
+def _audio(seconds: float = 3.0, sr: int = 16000) -> Audio:
+    return Audio(waveform=torch.rand(1, int(seconds * sr)), sampling_rate=sr)
+
+
+def _stub_model_and_extraction(monkeypatch: pytest.MonkeyPatch, captured: dict[str, Any]) -> None:
+    class _FakeSpeechBrainModel:
+        def __init__(self, *, path_or_uri: str, revision: str) -> None:
+            captured["path_or_uri"] = path_or_uri
+            captured["revision"] = revision
+
+    monkeypatch.setattr(windowing, "SpeechBrainModel", _FakeSpeechBrainModel)
+    monkeypatch.setattr(
+        windowing,
+        "extract_speaker_embeddings_from_audios",
+        lambda audios, model, device=None: [torch.rand(8) for _ in audios],  # noqa: ANN001, ANN202
+    )
+
+
+def test_a_caller_supplied_revision_reaches_model_construction_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The exact SHA passed in must be the one the model is constructed with -- not "main".
+
+    Uses a well-formed 40-hex SHA so `resolve_revision`'s own short-circuit for an already-resolved
+    ref fires with no network call; nothing about revision resolution needs mocking here.
+    """
+    captured: dict[str, Any] = {}
+    _stub_model_and_extraction(monkeypatch, captured)
+
+    sha = "a" * 40
+    windowing.extract_per_window_embeddings(
+        audio=_audio(), models=["some/model"], window_s=1.0, hop_s=0.5, revision=sha
+    )
+
+    assert captured["revision"] == sha
+    assert captured["path_or_uri"] == "some/model"
+
+
+def test_a_stale_revision_does_not_get_silently_replaced_by_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bug this guards: an old pinned SHA used to be discarded in favor of a hardcoded "main".
+
+    Two distinct SHAs stand in for "the commit the caller resolved a while ago" and "what main
+    would resolve to today" -- the fix must load the former, never silently upgrade to the latter.
+    """
+    captured: dict[str, Any] = {}
+    _stub_model_and_extraction(monkeypatch, captured)
+
+    old_pinned_sha = "1" * 40
+    windowing.extract_per_window_embeddings(
+        audio=_audio(), models=["some/model"], window_s=1.0, hop_s=0.5, revision=old_pinned_sha
+    )
+
+    assert captured["revision"] == old_pinned_sha
+    assert captured["revision"] != "main"
+
+
+def test_no_revision_supplied_falls_back_to_resolving_main_per_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Existing callers that pass no `revision` (both `audio_analysis` callers) must keep working.
+
+    `None` resolves each model's own "main" -- through `resolve_revision`, never a bare literal
+    handed straight to `SpeechBrainModel`, which is what made the ref-load bug possible in the
+    first place: a ref that never touches a resolver cannot become a SHA anywhere on the path.
+    """
+    from senselab.utils import model_revision as model_revision_module
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_resolve_revision(repo_id: str, ref: str = "main", **kwargs: Any) -> str:  # noqa: ANN003, ANN401
+        calls.append((repo_id, ref))
+        return "b" * 40
+
+    monkeypatch.setattr(model_revision_module, "resolve_revision", fake_resolve_revision)
+
+    captured: dict[str, Any] = {}
+    _stub_model_and_extraction(monkeypatch, captured)
+
+    windowing.extract_per_window_embeddings(audio=_audio(), models=["some/model"], window_s=1.0, hop_s=0.5)
+
+    assert calls == [("some/model", "main")]
+    assert captured["revision"] == "b" * 40

--- a/src/tests/audio/tasks/task_layer_guard_test.py
+++ b/src/tests/audio/tasks/task_layer_guard_test.py
@@ -1,0 +1,52 @@
+"""Nothing under audio/tasks/ may import from audio/workflows/.
+
+Workflows compose tasks; a task importing a workflow inverts that. The rule matters here because
+this change promotes two primitives *down* from the workflow into the task layer, and without a
+guard they drift back the first time someone needs a workflow helper in a task.
+
+An AST sweep rather than a text search: an import inside a function body or guarded by
+TYPE_CHECKING is still an import, and a commented-out one is not.
+"""
+
+import ast
+from pathlib import Path
+
+_TASKS = Path("src/senselab/audio/tasks")
+_FORBIDDEN_PREFIX = "senselab.audio.workflows"
+
+
+def _imported_modules(path: Path) -> list[str]:
+    """Every module name imported anywhere in a file, including inside function bodies."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            names.append(node.module)
+    return names
+
+
+def test_no_task_imports_a_workflow() -> None:
+    """The dependency direction is one-way, and this is what keeps it that way."""
+    offenders: list[str] = []
+    for path in sorted(_TASKS.rglob("*.py")):
+        for module in _imported_modules(path):
+            if module.startswith(_FORBIDDEN_PREFIX):
+                offenders.append(f"{path}: imports {module}")
+    assert not offenders, "audio/tasks must not import audio/workflows:\n" + "\n".join(offenders)
+
+
+def test_the_guard_can_actually_see_a_violation() -> None:
+    """A guard that cannot fail is not a guard.
+
+    Proves the AST sweep detects the pattern it is meant to catch, including an import nested
+    inside a function, which a naive top-of-file scan would miss.
+    """
+    import tempfile
+
+    source = "def f():\n    from senselab.audio.workflows.audio_analysis import embeddings\n    return embeddings\n"
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "offender.py"
+        p.write_text(source, encoding="utf-8")
+        assert any(m.startswith(_FORBIDDEN_PREFIX) for m in _imported_modules(p))

--- a/src/tests/audio/tasks/task_layer_guard_test.py
+++ b/src/tests/audio/tasks/task_layer_guard_test.py
@@ -1,4 +1,4 @@
-"""Nothing under audio/tasks/ may import from audio/workflows/.
+"""Nothing under audio/tasks/ may import from audio/workflows/, with one documented exception.
 
 Workflows compose tasks; a task importing a workflow inverts that. The rule matters here because
 this change promotes two primitives *down* from the workflow into the task layer, and without a
@@ -6,13 +6,35 @@ guard they drift back the first time someone needs a workflow helper in a task.
 
 An AST sweep rather than a text search: an import inside a function body or guarded by
 TYPE_CHECKING is still an import, and a commented-out one is not.
+
+One file already violates the rule and predates this branch (confirmed against
+``origin/alpha``), so a bare assertion here would make this test's own addition the thing that
+breaks CI for debt this branch did not create. ``KNOWN_LAYERING_VIOLATIONS`` documents that
+exception the same way ``hf_load_coverage_test.py`` and ``revision_pinning_guard_test.py``
+document theirs: an explicit, reviewed set rather than a silent pass, with a companion test
+that fails the moment an entry stops describing reality.
 """
 
 import ast
 from pathlib import Path
 
-_TASKS = Path("src/senselab/audio/tasks")
+_SRC = Path("src/senselab")
+_TASKS = _SRC / "audio/tasks"
 _FORBIDDEN_PREFIX = "senselab.audio.workflows"
+
+# Per-file exceptions to the audio/tasks -> audio/workflows layering rule, tolerated for now
+# rather than fixed here. A new violation must not be added to this set to make the guard
+# pass -- it must be reviewed and justified the way the entry below was.
+#
+# audio/tasks/speech_to_text_ensemble/api.py imports one constant, MIN_EVIDENCE_WEIGHT, from
+# the leaf module audio/workflows/audio_analysis/floors.py -- a model-independent ROVER-fusion
+# corroboration floor with no home outside that workflow module yet. Predates this branch
+# (present on origin/alpha before the windowing-primitives move this test file was added for).
+# Moving `floors.py`, or just the constant, down a layer is a separate change with its own
+# justification -- restructuring speech_to_text_ensemble is not what this task is for.
+KNOWN_LAYERING_VIOLATIONS = {
+    "audio/tasks/speech_to_text_ensemble/api.py",
+}
 
 
 def _imported_modules(path: Path) -> list[str]:
@@ -28,13 +50,44 @@ def _imported_modules(path: Path) -> list[str]:
 
 
 def test_no_task_imports_a_workflow() -> None:
-    """The dependency direction is one-way, and this is what keeps it that way."""
+    """The dependency direction is one-way, and this is what keeps it that way.
+
+    Skips files in ``KNOWN_LAYERING_VIOLATIONS`` -- the *only* files exempt, and only because
+    they are individually reviewed and recorded above, not because the rule bends for them.
+    """
     offenders: list[str] = []
     for path in sorted(_TASKS.rglob("*.py")):
+        if str(path.relative_to(_SRC)) in KNOWN_LAYERING_VIOLATIONS:
+            continue
         for module in _imported_modules(path):
             if module.startswith(_FORBIDDEN_PREFIX):
                 offenders.append(f"{path}: imports {module}")
     assert not offenders, "audio/tasks must not import audio/workflows:\n" + "\n".join(offenders)
+
+
+def test_known_layering_violations_are_not_stale() -> None:
+    """Every allowlist entry must still exist and must still actually violate the rule.
+
+    Mirrors the stale-entry checks in ``hf_load_coverage_test.py`` and
+    ``revision_pinning_guard_test.py``: an allowlist that is never pruned silently stops
+    meaning "reviewed, tolerated debt" and starts meaning "nobody looked since." Two ways an
+    entry goes stale -- the file it names was moved or deleted, or the file was fixed and no
+    longer imports anything under ``audio/workflows`` -- and either would let the allowlist
+    keep exempting a file the *general* test above would otherwise cover again, which is
+    exactly the gap that lets a genuinely new violation hide behind an old, no-longer-true one.
+    """
+    missing = [f for f in sorted(KNOWN_LAYERING_VIOLATIONS) if not (_SRC / f).is_file()]
+    assert not missing, "allowlist entr(ies) name files that no longer exist:\n" + "\n".join(f"  {f}" for f in missing)
+
+    fixed = [
+        relpath
+        for relpath in sorted(KNOWN_LAYERING_VIOLATIONS)
+        if not any(m.startswith(_FORBIDDEN_PREFIX) for m in _imported_modules(_SRC / relpath))
+    ]
+    assert not fixed, (
+        "allowlist entr(ies) no longer import audio/workflows -- remove them from "
+        "KNOWN_LAYERING_VIOLATIONS so the general guard covers the file again:\n" + "\n".join(f"  {f}" for f in fixed)
+    )
 
 
 def test_the_guard_can_actually_see_a_violation() -> None:

--- a/src/tests/audio/workflows/audio_analysis/embeddings_defects_test.py
+++ b/src/tests/audio/workflows/audio_analysis/embeddings_defects_test.py
@@ -9,7 +9,11 @@ import inspect
 import re
 from pathlib import Path
 
+import yaml
+
+from senselab.audio.tasks.speaker_embeddings import windowing
 from senselab.audio.workflows.audio_analysis import embeddings as emb
+from senselab.audio.workflows.audio_analysis.run_config import DEFAULT_CONFIG_PATH
 
 _SOURCE = Path(emb.__file__).read_text(encoding="utf-8")
 
@@ -49,3 +53,28 @@ def test_the_module_docstring_agrees_with_the_signature() -> None:
         f"docstring claims window_s default {doc_window_s}, signature default is {window_default}"
     )
     assert doc_hop_s == hop_default, f"docstring claims hop_s default {doc_hop_s}, signature default is {hop_default}"
+
+
+def test_windowing_docstring_cites_the_real_production_setting_not_its_own_fallback() -> None:
+    """Check that windowing.py's docstring cites the real production setting, not its own fallback.
+
+    `windowing.py`'s 1.0/0.5 defaults are never exercised in production; its module docstring must
+    say so and cite the config values that are, rather than presenting 1.0/0.5 as *the* measured
+    detection setting.
+
+    Regression: the docstring used to open with "The defaults here are the detection defaults, and
+    they are deliberate", naming ``window_s=1.0``/``hop_s=0.5`` as the measured production setting.
+    Both real callers (`compute.harvest_pass`, `adaptive.backends.embed_windows`) actually pass
+    explicit values sourced from `data/run_config/default.yaml`'s `embeddings:` block, and that
+    file's own derivation measured 1.0 s as *worse* (ARI 0.70 at 0.5 s against 0.48 at 1.0 s). This
+    reads the values straight out of the packaged config so a future config change that isn't
+    mirrored into the docstring fails here rather than silently drifting again.
+    """
+    config = yaml.safe_load(DEFAULT_CONFIG_PATH.read_text())
+    window_s = config["embeddings"]["window_s"]
+    hop_s = config["embeddings"]["hop_s"]
+
+    doc = windowing.__doc__ or ""
+    assert str(window_s) in doc, f"docstring does not cite the production window_s ({window_s}) from default.yaml"
+    assert str(hop_s) in doc, f"docstring does not cite the production hop_s ({hop_s}) from default.yaml"
+    assert "fallback" in doc.lower(), "docstring must not present its own 1.0/0.5 defaults as the measured setting"

--- a/src/tests/audio/workflows/audio_analysis/embeddings_defects_test.py
+++ b/src/tests/audio/workflows/audio_analysis/embeddings_defects_test.py
@@ -1,0 +1,51 @@
+"""Guards for two defects this change fixes.
+
+Both are the kind that reappear: a silhouette coefficient renamed back into a probability, and a
+docstring drifting from the signature it describes.
+"""
+
+import ast
+import inspect
+import re
+from pathlib import Path
+
+from senselab.audio.workflows.audio_analysis import embeddings as emb
+
+_SOURCE = Path(emb.__file__).read_text(encoding="utf-8")
+
+
+def test_no_silhouette_is_rescaled_into_a_probability() -> None:
+    """0.5*(s+1) turns a clustering-geometry index into something that reads as a probability.
+
+    CLAUDE.md names this defect class, and the L1 register documents its cost here: the signal
+    produced 0.4022-0.4996 doubt across 214 buckets with stdev 0.0227 and earned the highest
+    fusion weight of fifteen signals *because* it was near-constant; removing its consumer moved
+    published presence doubt from 0.0682 to 0.0385.
+    """
+    assert "p_voice" not in _SOURCE, "p_voice reads as a probability; name it what it measures"
+
+
+def test_the_module_docstring_agrees_with_the_signature() -> None:
+    r"""A docstring claiming different defaults than the code is worse than none.
+
+    A reader trusts it and passes nothing, expecting the documented behaviour. The original
+    version of this guard (``doc.split("\\n")[2]`` plus a loose ``in`` check) could not fail: it
+    would pass whether the docstring's numbers matched the signature's or not, because it never
+    checked that the *specific pair of numbers* it found were the ones being claimed as defaults.
+    This version extracts the "default X s with Y s hop" claim from the docstring as floats and
+    compares each one against ``inspect.signature``'s actual default — so a docstring edited to
+    say e.g. 2.0/1.0 while the signature stays 1.0/0.5 fails here, not silently in production.
+    """
+    sig = inspect.signature(emb.extract_per_window_embeddings)
+    window_default = float(sig.parameters["window_s"].default)
+    hop_default = float(sig.parameters["hop_s"].default)
+
+    doc = ast.get_docstring(ast.parse(_SOURCE)) or ""
+    match = re.search(r"default\s+([\d.]+)\s*s\s+with\s+([\d.]+)\s*s\s+hop", doc)
+    assert match is not None, "module docstring no longer states a 'default X s with Y s hop' claim"
+    doc_window_s, doc_hop_s = float(match.group(1)), float(match.group(2))
+
+    assert doc_window_s == window_default, (
+        f"docstring claims window_s default {doc_window_s}, signature default is {window_default}"
+    )
+    assert doc_hop_s == hop_default, f"docstring claims hop_s default {doc_hop_s}, signature default is {hop_default}"

--- a/src/tests/audio/workflows/audio_analysis/speech_presence_link_test.py
+++ b/src/tests/audio/workflows/audio_analysis/speech_presence_link_test.py
@@ -441,7 +441,7 @@ def test_derive_window_clusters_exposes_the_whole_result() -> None:
     derived = derive_window_clusters({"ecapa": _two_speaker_windows()})
     assert derived is not None
     assert derived["model"] == "ecapa"
-    assert set(derived["clusters"]) >= {"n_speakers", "labels", "p_voice"}
+    assert set(derived["clusters"]) >= {"n_speakers", "labels", "best_silhouette"}
     assert derived["clusters"]["n_speakers"] == 2
 
 

--- a/src/tests/utils/data_structures/device_test.py
+++ b/src/tests/utils/data_structures/device_test.py
@@ -1,0 +1,65 @@
+"""Device selection helpers.
+
+The concrete-device-string tests exist because a bare ``"cuda"`` is not a device string
+some libraries can parse, and the failure is silent: SpeechBrain logs a warning and picks
+device 0 on its own. On a cluster that has to respect the allocation rather than guess.
+"""
+
+import pytest
+
+# ── Concrete device strings for library run_opts ─────────────────────
+
+
+def test_cuda_resolves_to_an_indexed_device_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SpeechBrain parses its ``run_opts["device"]`` with ``device.split(":")``.
+
+    Handing it a bare ``"cuda"`` makes that unpack fail, and it logs "Could not parse CUDA
+    device string" and silently calls ``torch.cuda.set_device(0)``. On a single-GPU
+    allocation that lands on the right card by luck; on a node where the caller selected a
+    different one it moves the model somewhere the caller did not ask for.
+    """
+    import torch
+
+    from senselab.utils.data_structures.device import DeviceType, device_run_opt
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 3)
+    assert device_run_opt(DeviceType.CUDA) == "cuda:3"
+
+
+def test_cuda_respects_the_currently_selected_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The index must come from ``torch.cuda.current_device()``, not a hardcoded 0.
+
+    That is what makes this correct under Slurm: ``CUDA_VISIBLE_DEVICES`` masks the
+    allocation so the granted GPU is index 0 inside the process, while a caller who called
+    ``set_device`` on a multi-GPU box gets the card they chose.
+    """
+    import torch
+
+    from senselab.utils.data_structures.device import DeviceType, device_run_opt
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    assert device_run_opt(DeviceType.CUDA) == "cuda:0"
+
+
+def test_cpu_and_mps_are_passed_through_unindexed() -> None:
+    """Only CUDA is indexed. ``cpu:0``/``mps:0`` are not valid device strings."""
+    from senselab.utils.data_structures.device import DeviceType, device_run_opt
+
+    assert device_run_opt(DeviceType.CPU) == "cpu"
+    assert device_run_opt(DeviceType.MPS) == "mps"
+
+
+def test_cuda_without_a_visible_gpu_does_not_invent_an_index(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Asking for an index when CUDA is unavailable would raise inside torch.
+
+    Returning the bare name lets the downstream library produce its own, clearer error
+    rather than this helper failing first with a less useful one.
+    """
+    import torch
+
+    from senselab.utils.data_structures.device import DeviceType, device_run_opt
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert device_run_opt(DeviceType.CUDA) == "cuda"

--- a/src/tests/utils/embedding_distribution_files_test.py
+++ b/src/tests/utils/embedding_distribution_files_test.py
@@ -1,0 +1,172 @@
+"""Per-file structure of an embedding set.
+
+Within-file and cross-file dispersion are kept strictly separate because prior measurement on
+this pipeline puts essentially the whole error budget cross-file: within-file cosine stability
+0.984 against cross-file 0.891. A single pooled dispersion number would average those into
+something uninterpretable and destroy the most informative split known about this data.
+"""
+
+import numpy as np
+import pytest
+
+from senselab.utils.tasks.embedding_distribution import describe_embedding_distribution
+
+
+def _file_of_vectors(axis: np.ndarray, n: int, spread: float, seed: int) -> np.ndarray:
+    """N unit vectors tightly around `axis`."""
+    rng = np.random.default_rng(seed)
+    x = axis[None, :] + spread * rng.normal(size=(n, axis.size))
+    return x / np.linalg.norm(x, axis=1, keepdims=True)
+
+
+def _two_files_same_speaker(d: int = 64) -> tuple[np.ndarray, list[str]]:
+    """Two files whose directions differ slightly -- one speaker, two sessions.
+
+    The nudge has to clear the per-row noise, not just be nonzero: each row's noise vector has
+    ``d`` independent components of scale ``spread``, so its norm grows as ``spread * sqrt(d)``
+    (~0.16 at d=64, spread=0.02) while the nudge -- added as a single ``d``-dim unit vector scaled
+    by a scalar -- does not get that boost. A nudge weight of 0.05 (this fixture's first draft)
+    put the file-centroid separation *below* the per-row noise, so cross-file cosine came out
+    higher than within-file and the intended inequality failed for a correct implementation.
+    Verified numerically (see task-3-report.md): 0.2 is the smallest weight in
+    {0.05, 0.1, 0.2, 0.3, 0.4, 0.5} that flips it; 0.3 keeps a comfortable margin without
+    threatening the ``rbar > 0.95`` bound the other test on this fixture relies on.
+    """
+    rng = np.random.default_rng(11)
+    axis = rng.normal(size=d)
+    axis /= np.linalg.norm(axis)
+    nudge = rng.normal(size=d)
+    nudge -= (nudge @ axis) * axis
+    nudge /= np.linalg.norm(nudge)
+
+    a = _file_of_vectors(axis + 0.3 * nudge, 40, 0.02, seed=1)
+    b = _file_of_vectors(axis - 0.3 * nudge, 40, 0.02, seed=2)
+    return np.vstack([a, b]), ["fileA"] * 40 + ["fileB"] * 40
+
+
+def test_within_file_is_reported_per_file() -> None:
+    """Each file gets its own coherence figure, not a pooled one."""
+    x, ids = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x, ids)
+
+    assert set(dist.within_file) == {"fileA", "fileB"}
+    assert dist.within_file["fileA"].n_vectors == 40
+    assert dist.within_file["fileA"].rbar > 0.95
+
+
+def test_within_file_is_tighter_than_cross_file() -> None:
+    """The measured error budget on this pipeline is cross-file.
+
+    So the two must be separable and must actually differ on data built that way.
+    """
+    x, ids = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x, ids)
+
+    within = min(dist.within_file[f].cos_to_own_centroid_q50 for f in dist.within_file)
+    cross = min(dist.cross_file.cos_file_centroid_to_pooled.values())
+    assert within > cross
+
+
+def test_cross_file_reports_each_file_centroid_against_the_pooled_one() -> None:
+    """A contaminated file shows up here as a low cosine, which is what lets a caller curate."""
+    d = 64
+    rng = np.random.default_rng(7)
+    target = rng.normal(size=d)
+    target /= np.linalg.norm(target)
+    intruder = rng.normal(size=d)
+    intruder -= (intruder @ target) * target
+    intruder /= np.linalg.norm(intruder)
+
+    x = np.vstack(
+        [
+            _file_of_vectors(target, 40, 0.02, seed=1),
+            _file_of_vectors(target, 40, 0.02, seed=2),
+            _file_of_vectors(intruder, 40, 0.02, seed=3),
+        ]
+    )
+    ids = ["t1"] * 40 + ["t2"] * 40 + ["bad"] * 40
+    _, dist = describe_embedding_distribution(x, ids)
+
+    assert dist.cross_file.cos_file_centroid_to_pooled["bad"] < 0.5
+    assert dist.cross_file.cos_file_centroid_to_pooled["t1"] > 0.8
+
+
+def test_pairwise_file_centroid_cosines_are_summarised() -> None:
+    """With three or more files the pairwise spread is itself informative.
+
+    ``-1 <= q50 <= 1`` alone holds for *any* number claiming to be a cosine, including a
+    mutated implementation that ignores the real geometry and reports a constant -- mutation-
+    checked directly against this fixture. fileC is built from a single realised row of fileA
+    (see the line below), so its centroid over 30 fresh draws must land close to fileA's and far
+    from fileB's: the min pairwise cosine (fileA/fileB or fileB/fileC) has to be visibly lower
+    than the max (fileA/fileC), or the statistic is not reading the actual pair structure.
+    """
+    x, ids = _two_files_same_speaker()
+    third = _file_of_vectors(np.asarray(x[0]), 30, 0.02, seed=4)
+    x = np.vstack([x, third])
+    ids = ids + ["fileC"] * 30
+
+    _, dist = describe_embedding_distribution(x, ids)
+    pairwise = dist.cross_file.file_centroid_pairwise_cos
+    assert pairwise is not None
+    assert -1.0 <= pairwise.q50 <= 1.0
+    assert pairwise.max > 0.95  # fileA/fileC: near-duplicate centroids
+    assert pairwise.min < 0.9  # fileA/fileB or fileB/fileC: the real, constructed separation
+
+
+def test_a_single_file_has_no_pairwise_spread() -> None:
+    """One file means no pair exists. Reporting a number would be inventing one."""
+    x, _ = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x, ["only"] * x.shape[0])
+    assert dist.cross_file.file_centroid_pairwise_cos is None
+    assert set(dist.cross_file.cos_file_centroid_to_pooled) == {"only"}
+
+
+def test_no_file_ids_leaves_the_per_file_blocks_empty() -> None:
+    """Without ids there is no per-file structure to report, and inventing one would be a lie."""
+    x, _ = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x)
+    assert dist.within_file == {}
+    assert dist.cross_file.cos_file_centroid_to_pooled == {}
+
+
+def test_within_file_q05_reflects_a_tail_the_median_hides() -> None:
+    """A handful of off-axis rows inside one file must show up in q05 even though the median hides them.
+
+    Added beyond the brief: no test here exercised ``cos_to_own_centroid_q05`` at all, and
+    mutation-checking confirmed the gap -- swapping the q05/q50 quantile arguments in
+    ``_per_file_stats`` left every other test in this file green, because none of them read the
+    q05 field. A file that is mostly tight (95 rows) with a small off-axis tail (5 rows) is built
+    so the median stays high (the tail is a minority) while q05 -- the 5th percentile over 100
+    rows -- lands measurably lower, since it is dominated by the tail.
+    """
+    d = 64
+    rng = np.random.default_rng(3)
+    axis = rng.normal(size=d)
+    axis /= np.linalg.norm(axis)
+    core = axis[None, :] + 0.02 * rng.normal(size=(95, d))
+    core /= np.linalg.norm(core, axis=1, keepdims=True)
+
+    off_axis = rng.normal(size=d)
+    off_axis -= (off_axis @ axis) * axis
+    off_axis /= np.linalg.norm(off_axis)
+    tail = (axis[None, :] + 1.5 * off_axis[None, :]) + 0.02 * rng.normal(size=(5, d))
+    tail /= np.linalg.norm(tail, axis=1, keepdims=True)
+
+    x = np.vstack([core, tail])
+    _, dist = describe_embedding_distribution(x, ["f"] * 100)
+    w = dist.within_file["f"]
+
+    assert w.cos_to_own_centroid_q05 < w.cos_to_own_centroid_q50
+    assert w.cos_to_own_centroid_q05 < 0.97  # the tail pulls the 5th percentile down
+    assert w.cos_to_own_centroid_q50 > 0.98  # the tight majority keeps the median high
+
+
+def test_a_file_with_one_vector_still_reports_without_crashing() -> None:
+    """Singleton files are ordinary in real corpora; rbar of one vector is 1.0 by definition."""
+    x, ids = _two_files_same_speaker()
+    x = np.vstack([x, x[:1]])
+    ids = ids + ["singleton"]
+    _, dist = describe_embedding_distribution(x, ids)
+    assert dist.within_file["singleton"].n_vectors == 1
+    assert dist.within_file["singleton"].rbar == pytest.approx(1.0)

--- a/src/tests/utils/embedding_distribution_files_test.py
+++ b/src/tests/utils/embedding_distribution_files_test.py
@@ -170,3 +170,97 @@ def test_a_file_with_one_vector_still_reports_without_crashing() -> None:
     _, dist = describe_embedding_distribution(x, ids)
     assert dist.within_file["singleton"].n_vectors == 1
     assert dist.within_file["singleton"].rbar == pytest.approx(1.0)
+
+
+def test_auc_is_half_when_files_carry_no_effect() -> None:
+    """Exchangeable data must land on the exact null, 0.5.
+
+    That the null is exact -- not fitted, not simulated -- is why this statistic replaces
+    silhouette, whose value depends on whether you call it with cosine or Euclidean.
+
+    The ``< 0.99`` bound on the permutation quantile is not decorative: mutation-checking found
+    that a broken ``_eta_squared_between_files`` which returns a constant (ignoring ``ids``
+    entirely) makes the observed statistic equal every shuffled one, so ``exceeded`` counts every
+    permutation and the quantile saturates at 1.0 -- a value indistinguishable from a real strong
+    effect. Exchangeable data must *not* look extreme, so this bound is the one place that gap is
+    closed.
+    """
+    rng = np.random.default_rng(3)
+    d, n = 48, 200
+    x = rng.normal(size=(n, d))
+    x /= np.linalg.norm(x, axis=1, keepdims=True)
+    ids = ["a" if i % 2 == 0 else "b" for i in range(n)]
+
+    _, dist = describe_embedding_distribution(x, ids, n_permutations=200, seed=0)
+    assert dist.file_effect.auc_same_file_vs_diff_file == pytest.approx(0.5, abs=0.06)
+    assert dist.file_effect.permutation_quantile is not None
+    assert dist.file_effect.permutation_quantile < 0.99
+
+
+def test_auc_is_high_when_each_file_is_its_own_speaker() -> None:
+    """Same-file pairs then really are more similar, and the statistic should say so loudly."""
+    d = 48
+    rng = np.random.default_rng(4)
+    a_axis = rng.normal(size=d)
+    a_axis /= np.linalg.norm(a_axis)
+    b_axis = rng.normal(size=d)
+    b_axis -= (b_axis @ a_axis) * a_axis
+    b_axis /= np.linalg.norm(b_axis)
+
+    x = np.vstack([_file_of_vectors(a_axis, 60, 0.05, 1), _file_of_vectors(b_axis, 60, 0.05, 2)])
+    ids = ["a"] * 60 + ["b"] * 60
+
+    _, dist = describe_embedding_distribution(x, ids, n_permutations=200, seed=0)
+    assert dist.file_effect.auc_same_file_vs_diff_file is not None
+    assert dist.file_effect.auc_same_file_vs_diff_file > 0.95
+    assert dist.file_effect.permutation_quantile is not None
+    assert dist.file_effect.permutation_quantile > 0.99
+
+
+def test_the_permutation_block_length_follows_the_window_geometry() -> None:
+    """Blocks of ceil(window_s/hop_s), so the recorded length matches the window geometry.
+
+    Windows overlap, so a per-vector shuffle destroys dependence the observed statistic keeps
+    and the quantile comes out anti-conservative. The length used is recorded so the number is
+    auditable.
+
+    ``window_s=2.0, hop_s=1.0`` gives an exact ratio of 2, which a ``ceil`` and a ``floor``
+    (or a bare truncating ``int()``) both round to -- mutation-checking confirmed that swapping
+    ``ceil`` for ``floor`` in the implementation leaves that assertion green. The second call
+    below uses ``window_s=2.5`` where ``ceil(2.5) = 3 != floor(2.5) = 2``, which is the case that
+    actually distinguishes rounding directions.
+    """
+    x, ids = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x, ids, window_s=2.0, hop_s=1.0, n_permutations=50)
+    assert dist.file_effect.permutation_block_len == 2
+    assert dist.file_effect.n_permutations == 50
+
+    _, dist_fractional = describe_embedding_distribution(x, ids, window_s=2.5, hop_s=1.0, n_permutations=50)
+    assert dist_fractional.file_effect.permutation_block_len == 3
+
+
+def test_the_guard_band_needs_window_times_and_says_so_when_absent() -> None:
+    """No window start times, no guard band -- reported as absent, not silently skipped.
+
+    At 50% overlap a window's neighbour is a near-duplicate, so same-file pairs drawn from
+    adjacent windows would inflate same-file similarity toward 1.0 for any input -- the statistic
+    would measure the hop size. Excluding them needs times; without times the guard is skipped and
+    reported as absent rather than silently not applied.
+    """
+    x, ids = _two_files_same_speaker()
+    _, without = describe_embedding_distribution(x, ids, window_s=2.0, hop_s=1.0, n_permutations=20)
+    assert without.file_effect.guard_band_s is None
+
+    starts = [float(i) for i in range(40)] * 2
+    _, with_times = describe_embedding_distribution(
+        x, ids, window_s=2.0, hop_s=1.0, window_starts_s=starts, n_permutations=20
+    )
+    assert with_times.file_effect.guard_band_s == 2.0
+
+
+def test_file_effect_is_absent_without_file_ids() -> None:
+    """No files, no file effect."""
+    x, _ = _two_files_same_speaker()
+    _, dist = describe_embedding_distribution(x)
+    assert dist.file_effect.auc_same_file_vs_diff_file is None
+    assert dist.file_effect.permutation_quantile is None

--- a/src/tests/utils/embedding_distribution_selection_test.py
+++ b/src/tests/utils/embedding_distribution_selection_test.py
@@ -1,0 +1,159 @@
+"""Optional contamination rejection.
+
+This is the one component in the feature that makes a decision, so it is opt-in and everything it
+did is recorded. The cut has no numeric default: it is either supplied by the caller or derived
+from the data by a stated rule, and whichever was used is reported.
+"""
+
+import numpy as np
+import pytest
+
+from senselab.utils.tasks.embedding_distribution import select_dominant_vectors
+
+
+def _cone(axis: np.ndarray, n: int, spread: float, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    v = axis[None, :] + spread * rng.normal(size=(n, axis.size))
+    return v / np.linalg.norm(v, axis=1, keepdims=True)
+
+
+def _two_speakers(n_target: int = 60, n_intruder: int = 20, d: int = 48) -> tuple[np.ndarray, list[str]]:
+    rng = np.random.default_rng(13)
+    a = rng.normal(size=d)
+    a /= np.linalg.norm(a)
+    b = rng.normal(size=d)
+    b -= (b @ a) * a
+    b /= np.linalg.norm(b)
+    x = np.vstack([_cone(a, n_target, 0.03, 1), _cone(b, n_intruder, 0.03, 2)])
+    ids = ["target"] * n_target + ["intruder"] * n_intruder
+    return x, ids
+
+
+def test_the_intruder_group_is_dropped() -> None:
+    """The measured property this exists for: a contaminating recording leaves the estimate."""
+    x, ids = _two_speakers()
+    sel = select_dominant_vectors(x, ids)
+
+    assert len(sel.kept_indices) == 60
+    assert len(sel.dropped_indices) == 20
+    assert sel.dropped_per_file == {"intruder": 20}
+
+
+def test_no_numeric_cut_default_exists() -> None:
+    """A fitted literal here is exactly what this repository forbids.
+
+    The signature must not carry one: the cut is caller-supplied or derived by a stated rule.
+    """
+    import inspect
+
+    default = inspect.signature(select_dominant_vectors).parameters["cut_theta"].default
+    assert default is None
+
+
+def test_the_derived_cut_is_recorded_as_derived() -> None:
+    """Auditable means a reader can tell where the number came from."""
+    x, ids = _two_speakers()
+    sel = select_dominant_vectors(x, ids)
+    assert sel.rule_used.cut_source == "largest_merge_gap"
+    assert sel.rule_used.cut_theta > 0
+    assert len(sel.rule_used.merge_heights) == x.shape[0] - 1
+
+
+def test_an_explicit_cut_overrides_and_is_recorded_verbatim() -> None:
+    """A caller who disagrees with the rule must be able to say so, and see that it took."""
+    x, ids = _two_speakers()
+    sel = select_dominant_vectors(x, ids, cut_theta=3.0)  # larger than pi: one cluster
+    assert sel.rule_used.cut_source == "caller"
+    assert sel.rule_used.cut_theta == 3.0
+    assert len(sel.clusters) == 1
+    assert sel.dropped_indices == []
+
+
+def test_selection_is_deterministic() -> None:
+    """Shares are a reported field, so they must be reproducible.
+
+    AHC takes no seed; spectral clustering with k-means assignment would, and pinning it only
+    hides the variance.
+    """
+    x, ids = _two_speakers()
+    a = select_dominant_vectors(x, ids)
+    b = select_dominant_vectors(x, ids)
+    assert a.kept_indices == b.kept_indices
+    assert a.rule_used.merge_heights == b.rule_used.merge_heights
+
+
+def test_file_balanced_share_beats_raw_duration() -> None:
+    """The target is the speaker present in most files, not the one occupying most seconds.
+
+    One long off-target recording must not outvote several short on-target ones, so selection is
+    by file-balanced share -- and both shares are reported so the disagreement stays visible.
+    """
+    rng = np.random.default_rng(23)
+    d = 48
+    target = rng.normal(size=d)
+    target /= np.linalg.norm(target)
+    other = rng.normal(size=d)
+    other -= (other @ target) * target
+    other /= np.linalg.norm(other)
+
+    # Three short target files (10 each) against one long off-target file (200).
+    x = np.vstack(
+        [_cone(target, 10, 0.02, 1), _cone(target, 10, 0.02, 2), _cone(target, 10, 0.02, 3), _cone(other, 200, 0.02, 4)]
+    )
+    ids = ["t1"] * 10 + ["t2"] * 10 + ["t3"] * 10 + ["long"] * 200
+
+    sel = select_dominant_vectors(x, ids)
+    dominant = next(c for c in sel.clusters if c.cluster_id == sel.dominant_cluster_id)
+
+    assert dominant.n_files_contributing == 3
+    assert dominant.file_balanced_share > 0.5
+    assert dominant.window_share < 0.5  # raw duration disagrees, and both are reported
+
+
+def test_the_runner_up_is_reported_with_its_distance() -> None:
+    """'0.52/0.46 at cos 0.31' and '0.94/0.05 at cos 0.88' are different situations.
+
+    Both must stay legible without this function deciding which matters.
+    """
+    x, ids = _two_speakers()
+    sel = select_dominant_vectors(x, ids)
+    assert sel.runner_up_cluster_id is not None
+    assert sel.cos_dominant_to_runner_up is not None
+    assert sel.cos_dominant_to_runner_up < 0.5
+
+
+def test_the_cut_scales_with_this_datas_own_geometry() -> None:
+    """A derived cut must track the data's own scale, not read as a fitted constant in disguise.
+
+    ``_two_speakers`` happens to place its two cones almost orthogonal, so a hardcoded cut anywhere
+    below that gap silently reproduces the right answer without being derived from anything -- a
+    mutation to ``resolved_cut = 1.0`` passes every other test in this file untouched. Here the two
+    cones sit only 0.35 rad apart (all merge heights measured well under 1.0), so a fixed literal
+    cut that happens to work at orthogonal separation instead merges the intruder straight back in.
+    """
+    rng = np.random.default_rng(7)
+    d = 48
+    a = rng.normal(size=d)
+    a /= np.linalg.norm(a)
+    e2 = rng.normal(size=d)
+    e2 -= (e2 @ a) * a
+    e2 /= np.linalg.norm(e2)
+    b = np.cos(0.35) * a + np.sin(0.35) * e2  # 0.35 rad from `a`, not orthogonal
+    x = np.vstack([_cone(a, 40, 0.02, 11), _cone(b, 15, 0.02, 12)])
+    ids = ["target"] * 40 + ["intruder"] * 15
+
+    sel = select_dominant_vectors(x, ids)
+    assert sel.rule_used.cut_theta < 1.0  # the whole merge tree sits well under this
+    assert len(sel.kept_indices) == 40
+    assert sel.dropped_indices != []
+
+
+def test_a_single_coherent_group_keeps_everything() -> None:
+    """Nothing to reject is a perfectly ordinary outcome and must not drop rows."""
+    rng = np.random.default_rng(29)
+    axis = rng.normal(size=32)
+    axis /= np.linalg.norm(axis)
+    x = _cone(axis, 50, 0.02, 5)
+    sel = select_dominant_vectors(x, ["one"] * 50)
+    assert len(sel.kept_indices) == 50
+    assert sel.dropped_indices == []

--- a/src/tests/utils/embedding_distribution_selection_test.py
+++ b/src/tests/utils/embedding_distribution_selection_test.py
@@ -5,12 +5,14 @@ did is recorded. The cut has no numeric default: it is either supplied by the ca
 from the data by a stated rule, and whichever was used is reported.
 """
 
+from pathlib import Path
 from typing import Union
 
 import numpy as np
 import pytest
 
-from senselab.utils.tasks.embedding_distribution import select_dominant_vectors
+import senselab.utils.tasks.embedding_distribution as embedding_distribution_module
+from senselab.utils.tasks.embedding_distribution import _load_gap_significance_margin, select_dominant_vectors
 
 
 def _cone(axis: np.ndarray, n: int, spread: float, seed: Union[int, np.random.Generator]) -> np.ndarray:
@@ -46,6 +48,31 @@ def test_the_intruder_group_is_dropped() -> None:
     assert len(sel.kept_indices) == 60
     assert len(sel.dropped_indices) == 20
     assert sel.dropped_per_file == {"intruder": 20}
+
+
+def test_a_missing_bundled_profile_raises_instead_of_silently_substituting(tmp_path: Path) -> None:
+    """A missing profile must fail loudly, not silently patch in an unfitted constant.
+
+    Regression: `_load_gap_significance_margin` used to return `DEFAULT_GAP_SIGNIFICANCE_MARGIN`
+    when the bundled JSON was absent, while `select_dominant_vectors` still recorded
+    `gap_significance_margin_source="profile"` -- an undocumented, unfitted constant labelled as
+    if it had been measured. Raising is what makes a broken install visible instead of shipping
+    that mislabeled provenance.
+    """
+    with pytest.raises(ValueError, match="missing from this install"):
+        _load_gap_significance_margin(path=tmp_path / "does-not-exist.json")
+
+
+def test_select_dominant_vectors_raises_when_the_bundled_profile_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The same failure must surface end-to-end through the public entry point, not just the loader."""
+    monkeypatch.setattr(
+        embedding_distribution_module, "_GAP_SIGNIFICANCE_PROFILE_PATH", tmp_path / "embedding_gap_significance.json"
+    )
+    x, ids = _two_speakers()
+    with pytest.raises(ValueError, match="missing from this install"):
+        select_dominant_vectors(x, ids)
 
 
 def test_no_numeric_cut_default_exists() -> None:

--- a/src/tests/utils/embedding_distribution_selection_test.py
+++ b/src/tests/utils/embedding_distribution_selection_test.py
@@ -5,13 +5,22 @@ did is recorded. The cut has no numeric default: it is either supplied by the ca
 from the data by a stated rule, and whichever was used is reported.
 """
 
+from typing import Union
+
 import numpy as np
 import pytest
 
 from senselab.utils.tasks.embedding_distribution import select_dominant_vectors
 
 
-def _cone(axis: np.ndarray, n: int, spread: float, seed: int) -> np.ndarray:
+def _cone(axis: np.ndarray, n: int, spread: float, seed: Union[int, np.random.Generator]) -> np.ndarray:
+    """Draw ``n`` unit vectors from a tight vMF-like cone around ``axis``.
+
+    ``seed`` accepts an existing ``Generator`` as well as an int: several tests need the cone draw
+    to continue the same stream that generated ``axis``, rather than starting a fresh, independent
+    one -- ``np.random.default_rng`` returns a passed-in ``Generator`` unchanged, so this is the
+    same call either way.
+    """
     rng = np.random.default_rng(seed)
     v = axis[None, :] + spread * rng.normal(size=(n, axis.size))
     return v / np.linalg.norm(v, axis=1, keepdims=True)
@@ -157,3 +166,55 @@ def test_a_single_coherent_group_keeps_everything() -> None:
     sel = select_dominant_vectors(x, ["one"] * 50)
     assert len(sel.kept_indices) == 50
     assert sel.dropped_indices == []
+
+
+def test_kept_and_dropped_indices_index_the_original_prefilter_rows() -> None:
+    """A zero-norm row shifts every later row's position; kept/dropped must track that shift.
+
+    The caller uses these indices to subset its own parallel file-id and window-time arrays, so
+    they must reference rows in the array the caller actually passed in -- before the zero-norm
+    row is dropped internally -- not positions in some already-filtered view. No fixture up to this
+    point ever produces a zero-norm row, so this property went completely untested.
+    """
+    x, ids = _two_speakers()
+    zero_row_original_index = 30  # inside the 60 target rows, before any intruder row
+    x_with_zero = np.insert(x, zero_row_original_index, 0.0, axis=0)
+    ids_with_zero = ids[:zero_row_original_index] + ["silent"] + ids[zero_row_original_index:]
+
+    sel = select_dominant_vectors(x_with_zero, ids_with_zero)
+
+    assert zero_row_original_index not in sel.kept_indices
+    assert zero_row_original_index not in sel.dropped_indices
+    assert len(sel.kept_indices) + len(sel.dropped_indices) == x_with_zero.shape[0] - 1
+    # Every kept index must land on an original "target" row and every dropped index on
+    # "intruder" -- if the indices were computed against the post-filter array instead of the
+    # original one, everything from `zero_row_original_index` onward would be off by one and this
+    # would catch it directly.
+    assert all(ids_with_zero[i] == "target" for i in sel.kept_indices)
+    assert all(ids_with_zero[i] == "intruder" for i in sel.dropped_indices)
+
+
+def test_false_split_rate_on_coherent_groups_stays_at_the_stated_target() -> None:
+    """Pins the property the fitted margin exists for, not a specific margin value.
+
+    `data/embedding_gap_significance.json` derives the bundled margin from a 1600-draw sweep
+    holding the false-split rate on genuinely single-coherent groups at or below 1%. This is a
+    fast, seeded re-check of that guarantee at a representative (n=50, d=32) scale, cycling
+    through the same spreads used in the derivation sweep -- if a future change to the margin (or
+    to the derivation it reads from) lets false splits back in, this notices without needing the
+    full sweep.
+    """
+    n, d = 50, 32
+    n_draws = 60
+    spreads = [0.01, 0.02, 0.05, 0.1]
+    false_splits = 0
+    for i in range(n_draws):
+        rng = np.random.default_rng(500000 + i)
+        axis = rng.normal(size=d)
+        axis /= np.linalg.norm(axis)
+        x = _cone(axis, n, spreads[i % len(spreads)], rng)
+        sel = select_dominant_vectors(x, ["one"] * n)
+        if sel.dropped_indices:
+            false_splits += 1
+
+    assert false_splits / n_draws <= 0.01

--- a/src/tests/utils/embedding_distribution_test.py
+++ b/src/tests/utils/embedding_distribution_test.py
@@ -11,8 +11,8 @@ import pytest
 from senselab.utils.tasks.embedding_distribution import describe_embedding_distribution
 
 
-def _tight_cone(n: int, d: int, spread: float, seed: int = 0) -> np.ndarray:
-    """N vectors clustered around one random direction, with angular spread confined to a few axes.
+def _tight_cone(n: int, d: int, spread: float, seed: int = 0, rank: int = 5) -> np.ndarray:
+    """N vectors clustered around one random direction, with angular spread confined to `rank` axes.
 
     Noise isotropic across all d dimensions would leave the centred participation ratio pinned at
     its Marchenko-Pastur null no matter how small ``spread`` is -- PR is scale-invariant, so an
@@ -20,12 +20,14 @@ def _tight_cone(n: int, d: int, spread: float, seed: int = 0) -> np.ndarray:
     full-rank, noise-like shape. Confirmed numerically down to spread=1e-4 at d=192, n=400: PR
     never moved off ~129.7, the same value uniform random vectors give. A cluster that genuinely
     "occupies few directions" needs the noise itself to live in a low-rank subspace, not just be
-    small.
+    small. ``rank`` is parameterised (not fixed at 5) so a caller can also use this fixture to pin
+    the participation-ratio formula against a *known* value: with exactly ``rank`` roughly-equal
+    residual eigenvalues, PR should read close to ``rank`` itself, not merely "below something".
     """
     rng = np.random.default_rng(seed)
     axis = rng.normal(size=d)
     axis /= np.linalg.norm(axis)
-    rank = min(5, d - 1)
+    rank = min(rank, d - 1)
     basis = rng.normal(size=(rank, d))
     basis /= np.linalg.norm(basis, axis=1, keepdims=True)
     coeffs = rng.normal(size=(n, rank))
@@ -63,7 +65,30 @@ def test_a_tight_cone_has_high_rbar_and_low_effective_rank() -> None:
 
     assert dist.rbar > 0.9
     assert dist.rbar > 10 * dist.nulls.rbar_null
+    # Rank-5 noise forces rank(centred) <= 5 by construction, so this bound only checks that PR
+    # counts nonzero singular values roughly right, not that it combines them correctly -- an
+    # inverted or mis-squared formula would likely still clear it. See
+    # test_participation_ratio_matches_known_closed_form_rank for the assertion that actually
+    # pins the formula.
     assert dist.spectrum.participation_ratio < 0.5 * dist.nulls.participation_ratio_null
+
+
+@pytest.mark.parametrize("k", [3, 8])
+def test_participation_ratio_matches_known_closed_form_rank(k: int) -> None:
+    """A residual with k roughly-equal non-zero eigenvalues must give PR close to k, exactly.
+
+    ``test_a_tight_cone_has_high_rbar_and_low_effective_rank`` only bounds participation_ratio
+    from above (``< 0.5 * null``), and a rank-5 residual satisfies that bound almost regardless of
+    whether the formula is right -- the bound constrains the *count* of nonzero singular values,
+    not their combination. This pins the value instead: for a centred covariance with exactly k
+    equal eigenvalues, ``PR = (sum lambda)^2 / sum(lambda^2) = k`` exactly, so confining the
+    residual to k roughly-equal-variance directions gives a number the formula has to *hit*, which
+    catches an inverted, mis-squared, or accidentally-uncentred computation that the looser bound
+    would miss.
+    """
+    x = _tight_cone(n=400, d=192, spread=0.15, rank=k, seed=k)
+    _, dist = describe_embedding_distribution(x)
+    assert dist.spectrum.participation_ratio == pytest.approx(k, rel=0.15)
 
 
 def test_the_centroid_is_unit_norm() -> None:
@@ -143,27 +168,33 @@ def test_n_effective_is_none_without_window_information() -> None:
 
 
 def test_pc1_share_is_computed_on_centred_data() -> None:
-    """Uncentred, PC1 is just the mean direction and explains almost everything for any coherent set.
+    """Centring must actually run, or PC1 share reads near-1.0 for any coherent cluster regardless of shape.
 
-    That would make it a field that always reads the same. Centred, a high PC1 share is the
-    signature of bimodality, which is what makes it worth reporting.
+    Uncentred, PC1 of a tight, unimodal cluster *is* the mean direction and swallows nearly all the
+    variance -- a field that would read the same whether the residual is isotropic or structured,
+    so on its own it carries no information. Centred, that dominant direction is subtracted out and
+    what is left is the residual: an isotropic residual spreads its variance over ~d-1 directions
+    roughly equally, so a correctly centred PC1 share is small. A dropped centring step would
+    report the *uncentred* number here instead of the centred one -- both cleared a bare ``> 0.8``
+    bound on an earlier (bimodal) fixture for this test, which is why this version computes the
+    uncentred share explicitly with numpy and asserts the reported centred share sits far below it,
+    rather than asserting either number in isolation.
     """
-    d = 64
+    n, d = 400, 192
     rng = np.random.default_rng(5)
     axis = rng.normal(size=d)
     axis /= np.linalg.norm(axis)
-    perp = rng.normal(size=d)
-    perp -= (perp @ axis) * axis
-    perp /= np.linalg.norm(perp)
-
-    # Two lobes displaced along one perpendicular direction: one dominant axis of variation.
-    a = axis[None, :] + 0.35 * perp[None, :] + 0.02 * rng.normal(size=(100, d))
-    b = axis[None, :] - 0.35 * perp[None, :] + 0.02 * rng.normal(size=(100, d))
-    x = np.vstack([a, b])
+    x = axis[None, :] + 0.02 * rng.normal(size=(n, d))
     x /= np.linalg.norm(x, axis=1, keepdims=True)
 
+    sv_uncentred = np.linalg.svd(x, compute_uv=False)
+    lam_uncentred = sv_uncentred**2
+    uncentred_share = float(lam_uncentred[0] / lam_uncentred.sum())
+
     _, dist = describe_embedding_distribution(x)
-    assert dist.spectrum.pc1_share_centred > 0.8
+
+    assert uncentred_share > 0.8  # the mean direction dominates, as it does for any tight cluster
+    assert dist.spectrum.pc1_share_centred < 0.1 * uncentred_share
     assert len(dist.spectrum.eigenvalue_shares_top5) == 5
 
 

--- a/src/tests/utils/embedding_distribution_test.py
+++ b/src/tests/utils/embedding_distribution_test.py
@@ -167,6 +167,30 @@ def test_n_effective_is_none_without_window_information() -> None:
     assert dist.counts.n_effective is None
 
 
+def test_n_effective_sums_per_file_duration_for_multi_file_input() -> None:
+    """A pooled multi-file set has no single timeline, so `n_effective` must sum per file.
+
+    Regression for a defect where `n_effective` was `(hop*(n-1)+window)/window` over the *pooled*
+    row count -- correct for one contiguous recording, wrong once the rows come from several
+    independent files. 100 single-window files (one embedding each) is the sharpest case: the
+    pooled-timeline formula reports 50.5 (as if 100 rows were one recording with 99 hops between
+    them), while the correct answer -- this estimator's only real use case -- is 100.0 (100 files,
+    one full `window_s` of coverage each). ``CountsInfo.n_effective``'s own contract is
+    `total_windowed_duration / window_s`, and 100 independent single-window files cover 100 *
+    window_s seconds, not 50.5 * window_s.
+    """
+    rng = np.random.default_rng(0)
+    axis = rng.normal(size=16)
+    axis /= np.linalg.norm(axis)
+    n_files = 100
+    x = np.stack([axis + 0.01 * rng.normal(size=16) for _ in range(n_files)])
+    file_ids = [f"file-{i}" for i in range(n_files)]
+
+    _, dist = describe_embedding_distribution(x, file_ids, window_s=1.0, hop_s=0.5)
+
+    assert dist.counts.n_effective == pytest.approx(100.0)
+
+
 def test_pc1_share_is_computed_on_centred_data() -> None:
     """Centring must actually run, or PC1 share reads near-1.0 for any coherent cluster regardless of shape.
 

--- a/src/tests/utils/embedding_distribution_test.py
+++ b/src/tests/utils/embedding_distribution_test.py
@@ -8,7 +8,7 @@ measured and maintained, while 1/sqrt(d) is true by construction.
 import numpy as np
 import pytest
 
-from senselab.utils.tasks.embedding_distribution import describe_embedding_distribution
+from senselab.utils.tasks.embedding_distribution import _medoid, describe_embedding_distribution
 
 
 def _tight_cone(n: int, d: int, spread: float, seed: int = 0, rank: int = 5) -> np.ndarray:
@@ -211,3 +211,119 @@ def test_too_few_vectors_raises_rather_than_returning_a_meaningless_block() -> N
     """One vector has no distribution. Returning a block of zeros would look like a measurement."""
     with pytest.raises(ValueError, match="at least 2"):
         describe_embedding_distribution(np.ones((1, 8)))
+
+
+def test_the_aggregator_selects_the_returned_centroid() -> None:
+    """A tool parameter, not a decision -- but it must actually take effect."""
+    x = _tight_cone(n=60, d=32, spread=0.2, seed=9)
+    mean_c, mean_d = describe_embedding_distribution(x, aggregator="spherical_mean")
+    medoid_c, medoid_d = describe_embedding_distribution(x, aggregator="medoid")
+
+    assert mean_d.geometry.centroid_rule == "spherical_mean"
+    assert medoid_d.geometry.centroid_rule == "medoid"
+    assert not np.allclose(mean_c, medoid_c)
+    # The medoid is one of the input rows; the spherical mean generally is not.
+    assert np.isclose(np.abs(np.asarray(medoid_c) @ x.T).max(), 1.0, atol=1e-9)
+
+
+def test_an_unknown_aggregator_is_rejected() -> None:
+    """Silently falling back would make the reported centroid_rule a lie."""
+    with pytest.raises(ValueError, match="aggregator"):
+        describe_embedding_distribution(_tight_cone(n=5, d=8, spread=0.1), aggregator="median")
+
+
+def test_contamination_opens_a_gap_between_mean_and_trimmed_mean() -> None:
+    """With no clustering to reject contamination, this gap is how a caller learns the estimate.
+
+    It is contamination-sensitive -- a robustness statement carrying no threshold and no verdict.
+    """
+    d = 48
+    rng = np.random.default_rng(21)
+    target = rng.normal(size=d)
+    target /= np.linalg.norm(target)
+    other = rng.normal(size=d)
+    # Orthogonalise against target (Gram-Schmidt) rather than merely "keep it independent-ish": a
+    # contaminating direction that leaked component along target would understate the gap the
+    # test is meant to demonstrate.
+    other -= (other @ target) * target
+    other /= np.linalg.norm(other)
+
+    clean = _tight_cone(n=80, d=d, spread=0.05, seed=1)
+    dirty = np.vstack([clean, np.repeat(other[None, :], 20, axis=0)])
+
+    _, clean_dist = describe_embedding_distribution(clean)
+    _, dirty_dist = describe_embedding_distribution(dirty)
+
+    assert clean_dist.centroid_robustness.cos_mean_vs_trimmed10 > 0.999
+    # A bare "<" here is float64-noise-sensitive precisely when trimming is a no-op: mutation
+    # testing showed that disabling the trim (so both sides read the untrimmed mean against
+    # itself) still passed a plain "<", because rounding put the clean side a few ULPs above 1.0
+    # and the dirty side exactly at 1.0 -- the assertion was measuring rounding order, not
+    # trimming. Requiring a fixed gap fails closed instead: 1e-3 sits far above the ~1e-16 noise
+    # floor and far below the ~8e-3 gap this fixture actually produces, so it can only pass when
+    # trimming changed the centroid.
+    gap = clean_dist.centroid_robustness.cos_mean_vs_trimmed10 - dirty_dist.centroid_robustness.cos_mean_vs_trimmed10
+    assert gap > 1e-3
+
+
+def test_medoid_minimises_total_geodesic_distance() -> None:
+    """Pins the medoid to its definition rather than merely "some input row".
+
+    ``test_the_aggregator_selects_the_returned_centroid`` only checks that the dispatched centroid
+    is *a* row of ``x`` -- returning an arbitrary row (e.g. ``x[0]``) would also clear that check on
+    most seeds. This recomputes the minimiser by brute force and requires an exact match.
+    """
+    x = _tight_cone(n=40, d=16, spread=0.3, seed=6)
+    medoid = _medoid(x)
+
+    theta = np.arccos(np.clip(x @ x.T, -1.0, 1.0))
+    expected = x[int(np.argmin(theta.sum(axis=1)))]
+
+    assert np.allclose(medoid, expected)
+    # And a plain "first row" or "last row" shortcut would not generally coincide with the minimiser.
+    assert not np.allclose(medoid, x[0]) or np.argmin(theta.sum(axis=1)) == 0
+
+
+def test_leave_one_file_out_finds_the_file_driving_the_centroid() -> None:
+    """A jackknife along the cross-file axis, which is where the measured error budget sits.
+
+    It answers a caller's real question -- is this centroid an artefact of one file -- more
+    directly than any dispersion number.
+    """
+    d = 48
+    rng = np.random.default_rng(31)
+    target = rng.normal(size=d)
+    target /= np.linalg.norm(target)
+    intruder = rng.normal(size=d)
+    intruder -= (intruder @ target) * target
+    intruder /= np.linalg.norm(intruder)
+
+    def cone(axis: np.ndarray, n: int, seed: int) -> np.ndarray:
+        r = np.random.default_rng(seed)
+        v = axis[None, :] + 0.03 * r.normal(size=(n, d))
+        return v / np.linalg.norm(v, axis=1, keepdims=True)
+
+    x = np.vstack([cone(target, 30, 1), cone(target, 30, 2), cone(intruder, 30, 3)])
+    ids = ["good1"] * 30 + ["good2"] * 30 + ["bad"] * 30
+
+    _, dist = describe_embedding_distribution(x, ids, n_permutations=20)
+    lofo = dist.centroid_robustness.leave_one_file_out_cos
+    assert set(lofo) == {"good1", "good2", "bad"}
+    # Removing the intruder moves the centroid most, so its LOFO cosine is the lowest.
+    assert lofo["bad"] < lofo["good1"]
+    assert lofo["bad"] < lofo["good2"]
+
+    # Pins the *quantity*, not just its ordering: mutation testing found that swapping the mask
+    # (comparing the full centroid to file f's own centroid, instead of to the centroid recomputed
+    # with f *excluded*) still gets the ordering above right by coincidence on this fixture -- the
+    # intruder file's own centroid is also far from the pooled one. A direct recomputation with
+    # `!=` is the only thing that catches that swap.
+    ids_arr = np.asarray(ids)
+    mean_centroid = np.asarray(
+        describe_embedding_distribution(x)[0]
+    )  # pooled centroid over all rows, independent of file grouping
+    for f in ("good1", "good2", "bad"):
+        rest = x[ids_arr != f]
+        naive = rest.sum(axis=0)
+        naive /= np.linalg.norm(naive)
+        assert lofo[f] == pytest.approx(float(mean_centroid @ naive), abs=1e-9)

--- a/src/tests/utils/embedding_distribution_test.py
+++ b/src/tests/utils/embedding_distribution_test.py
@@ -1,0 +1,182 @@
+"""Core statistics of one set of embedding vectors.
+
+Every reference scale here is analytic, so these tests check the statistics against closed forms
+rather than against recorded numbers. That is the point: a fitted literal would have to be
+measured and maintained, while 1/sqrt(d) is true by construction.
+"""
+
+import numpy as np
+import pytest
+
+from senselab.utils.tasks.embedding_distribution import describe_embedding_distribution
+
+
+def _tight_cone(n: int, d: int, spread: float, seed: int = 0) -> np.ndarray:
+    """N vectors clustered around one random direction, with angular spread confined to a few axes.
+
+    Noise isotropic across all d dimensions would leave the centred participation ratio pinned at
+    its Marchenko-Pastur null no matter how small ``spread`` is -- PR is scale-invariant, so an
+    isotropic cone can be made arbitrarily tight (high rbar) while its residual still spans a
+    full-rank, noise-like shape. Confirmed numerically down to spread=1e-4 at d=192, n=400: PR
+    never moved off ~129.7, the same value uniform random vectors give. A cluster that genuinely
+    "occupies few directions" needs the noise itself to live in a low-rank subspace, not just be
+    small.
+    """
+    rng = np.random.default_rng(seed)
+    axis = rng.normal(size=d)
+    axis /= np.linalg.norm(axis)
+    rank = min(5, d - 1)
+    basis = rng.normal(size=(rank, d))
+    basis /= np.linalg.norm(basis, axis=1, keepdims=True)
+    coeffs = rng.normal(size=(n, rank))
+    x = axis[None, :] + spread * (coeffs @ basis)
+    return x / np.linalg.norm(x, axis=1, keepdims=True)
+
+
+def test_uniform_random_vectors_land_on_the_analytic_nulls() -> None:
+    """Random directions must reproduce the closed forms, or the nulls are wrong.
+
+    This is the test that keeps the block free of fitted numbers: sd of pairwise cosines -> 1/sqrt(d),
+    mean resultant length -> 1/sqrt(n), participation ratio -> d*n/(d+n).
+    """
+    n, d = 800, 192
+    rng = np.random.default_rng(17)
+    x = rng.normal(size=(n, d))
+    x /= np.linalg.norm(x, axis=1, keepdims=True)
+
+    _, dist = describe_embedding_distribution(x)
+
+    assert dist.nulls.cos_sd_null == pytest.approx(1.0 / np.sqrt(d))
+    assert dist.nulls.rbar_null == pytest.approx(1.0 / np.sqrt(n))
+    assert dist.nulls.participation_ratio_null == pytest.approx(d * n / (d + n))
+    assert dist.nulls.auc_null == 0.5
+
+    # And the data actually sits near them.
+    assert dist.rbar == pytest.approx(1.0 / np.sqrt(n), abs=0.02)
+    assert dist.spectrum.participation_ratio == pytest.approx(d * n / (d + n), rel=0.1)
+
+
+def test_a_tight_cone_has_high_rbar_and_low_effective_rank() -> None:
+    """One coherent speaker points one way and occupies few directions."""
+    x = _tight_cone(n=400, d=192, spread=0.15)
+    _, dist = describe_embedding_distribution(x)
+
+    assert dist.rbar > 0.9
+    assert dist.rbar > 10 * dist.nulls.rbar_null
+    assert dist.spectrum.participation_ratio < 0.5 * dist.nulls.participation_ratio_null
+
+
+def test_the_centroid_is_unit_norm() -> None:
+    """The returned vector is a direction. Callers compare it by cosine."""
+    centroid, _ = describe_embedding_distribution(_tight_cone(n=50, d=64, spread=0.2))
+    assert np.linalg.norm(np.asarray(centroid)) == pytest.approx(1.0)
+
+
+def test_zero_norm_rows_are_dropped_and_counted() -> None:
+    """A zero vector has no direction, so it cannot contribute.
+
+    But silence about it would make n_scored unexplainable.
+    """
+    x = _tight_cone(n=20, d=32, spread=0.1)
+    x = np.vstack([x, np.zeros((3, 32))])
+    _, dist = describe_embedding_distribution(x)
+
+    assert dist.counts.n_vectors_total == 23
+    assert dist.counts.n_scored == 20
+    assert dist.counts.n_zero_norm_dropped == 3
+
+
+def test_input_is_normalised_even_when_the_caller_did_not() -> None:
+    """ECAPA embeddings are not unit norm, and the norm covaries with window occupancy.
+
+    Left alone it would inject a loudness nuisance into every statistic, so normalisation is
+    unconditional and the block says so.
+    """
+    x = _tight_cone(n=40, d=64, spread=0.1)
+    scaled = x * np.linspace(0.1, 50.0, x.shape[0])[:, None]
+
+    c_plain, d_plain = describe_embedding_distribution(x)
+    c_scaled, d_scaled = describe_embedding_distribution(scaled)
+
+    assert d_scaled.geometry.l2_normalised is True
+    assert np.allclose(c_plain, c_scaled, atol=1e-6)
+    assert d_scaled.rbar == pytest.approx(d_plain.rbar, abs=1e-6)
+
+
+def test_loo_cosines_match_a_naive_recomputation() -> None:
+    """Scoring a vector against a centroid it helped define is optimistically biased.
+
+    The closed form x_i . (S - x_i) / ||S - x_i|| must equal recomputing the centroid without i,
+    which this checks directly on a small input.
+    """
+    x = _tight_cone(n=12, d=16, spread=0.3, seed=3)
+    _, dist = describe_embedding_distribution(x)
+
+    naive = []
+    for i in range(x.shape[0]):
+        others = np.delete(x, i, axis=0)
+        c = others.sum(axis=0)
+        c /= np.linalg.norm(c)
+        naive.append(float(x[i] @ c))
+    naive_arr = np.sort(np.asarray(naive))
+
+    assert dist.cos_to_centroid_loo.min == pytest.approx(naive_arr.min(), abs=1e-9)
+    assert dist.cos_to_centroid_loo.max == pytest.approx(naive_arr.max(), abs=1e-9)
+    assert dist.cos_to_centroid_loo.q50 == pytest.approx(float(np.quantile(naive_arr, 0.5)), abs=1e-9)
+
+
+def test_n_effective_discounts_overlapping_windows() -> None:
+    """At a 2.0 s window on a 1.0 s hop, adjacent windows share half their audio.
+
+    So independent information is about n/2. Reporting it lets a consumer discount nulls that
+    scale as n^-1/2 instead of us pretending independence.
+    """
+    x = _tight_cone(n=100, d=32, spread=0.2)
+    _, dist = describe_embedding_distribution(x, window_s=2.0, hop_s=1.0)
+    assert dist.counts.n_effective == pytest.approx(50.0, rel=0.05)
+
+
+def test_n_effective_is_none_without_window_information() -> None:
+    """It cannot be derived from vectors alone, and a guessed value would be worse than none."""
+    _, dist = describe_embedding_distribution(_tight_cone(n=10, d=8, spread=0.1))
+    assert dist.counts.n_effective is None
+
+
+def test_pc1_share_is_computed_on_centred_data() -> None:
+    """Uncentred, PC1 is just the mean direction and explains almost everything for any coherent set.
+
+    That would make it a field that always reads the same. Centred, a high PC1 share is the
+    signature of bimodality, which is what makes it worth reporting.
+    """
+    d = 64
+    rng = np.random.default_rng(5)
+    axis = rng.normal(size=d)
+    axis /= np.linalg.norm(axis)
+    perp = rng.normal(size=d)
+    perp -= (perp @ axis) * axis
+    perp /= np.linalg.norm(perp)
+
+    # Two lobes displaced along one perpendicular direction: one dominant axis of variation.
+    a = axis[None, :] + 0.35 * perp[None, :] + 0.02 * rng.normal(size=(100, d))
+    b = axis[None, :] - 0.35 * perp[None, :] + 0.02 * rng.normal(size=(100, d))
+    x = np.vstack([a, b])
+    x /= np.linalg.norm(x, axis=1, keepdims=True)
+
+    _, dist = describe_embedding_distribution(x)
+    assert dist.spectrum.pc1_share_centred > 0.8
+    assert len(dist.spectrum.eigenvalue_shares_top5) == 5
+
+
+def test_geometry_records_what_was_done() -> None:
+    """A consumer reading a stored block has to know the geometry to interpret any number in it."""
+    _, dist = describe_embedding_distribution(_tight_cone(n=10, d=8, spread=0.1))
+    assert dist.geometry.metric == "cosine"
+    assert dist.geometry.distance == "angular"
+    assert dist.geometry.dim == 8
+    assert dist.geometry.centroid_rule == "spherical_mean"
+
+
+def test_too_few_vectors_raises_rather_than_returning_a_meaningless_block() -> None:
+    """One vector has no distribution. Returning a block of zeros would look like a measurement."""
+    with pytest.raises(ValueError, match="at least 2"):
+        describe_embedding_distribution(np.ones((1, 8)))


### PR DESCRIPTION
Draft. Design spec only so far — implementation follows once the spec is reviewed.

Spec: `specs/20260814-153013-audio-hints-speaker-embedding/design.md`

## What this will add

Two things, neither of which changes any existing output:

1. **Declared hints on an `Audio`** — `may_contain`, `targeted_speaker_count`, `environment`, `expected_speech` (verbatim prompt + id + reference set, for read tasks), and a `target_speaker` embedding with provenance.
2. **`estimate_speaker_embedding_from_audios`** — takes files that *may* contain a speaker, returns one embedding plus statistics describing the distribution it came from.

## Design decisions worth reviewing

- **Hints are carried, never consumed.** No task changes behaviour because a hint is present. How a hint should inform a decision is itself a decision, and gets its own derivation later.
- **Hints live on `Audio`, not on #543's `AudioPlus`.** That layer's metadata is *resolved by lookup*; a hint is *asserted by a declarer*. Different trust, different failure modes — and hints must work with no dataset provider at all. So `AudioPlus`, `MetadataProvider` and the b2ai provider are not cherry-picked.
- **No clustering.** #543 rejected contamination by keeping the dominant cluster (measured: 24 of 32 non-speech recordings dropped, centroid held at cos ≥ 0.99). This design gives that up deliberately — selecting a dominant cluster is a decision inside a function whose job is to describe. Instead the descriptor reports per-file centroids, their cosine to the pooled centroid, and leave-one-file-out stability, so a contaminated file is visible and the caller curates.
- **Every reference scale in the statistics block is analytic**, so no fitted literal appears: sd null `1/√d`, R̄ null `1/√n`, participation-ratio null `d·n/(d+n)`, AUC null exactly `0.5`.

## Statistics choices that may be non-obvious

- **Silhouette is rejected.** `silhouette(metric="cosine")` and `silhouette(metric="euclidean")` return different numbers for *identical* geometry on unit vectors, so any threshold on it is a threshold on a parameterisation choice.
- **k-NN purity is rejected.** Hubness is severe at d=192 (k-occurrence skew 3.29; 64 of 1000 points in no neighbour list), and at 50% window overlap the 1-NN is almost always the adjacent window — the statistic would measure the hop size.
- **A small sd of cosines is not evidence of coherence.** At d=192 random vectors give sd ≈ 0.072, so an observed 0.05 is *below* the null. sd is only ever reported next to `1/√d`.
- **Within-file and cross-file dispersion stay separate**, because the prior measurement on this pipeline puts essentially the whole error budget cross-file (0.984 within vs 0.891 cross).

## Two pre-existing defects folded in

Both in `audio/workflows/audio_analysis/embeddings.py`:

1. `p_voice = 0.5·(silhouette + 1)` — a silhouette coefficient read as a probability, the class `CLAUDE.md` names. The L1 register closed its item 12 by removing the *consumer*, not the computation.
2. A stale docstring line claiming a 2.0 s/1.0 s default where the signature and the module's own rationale section both say 1.0 s/0.5 s.

The `1.0/0.5` detection default is kept — not for cache compatibility, which alpha does not owe, but because that value is tied to the workflow's 0.5 s bucket grid by a written derivation. The estimator uses the separately measured `2.0/1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.3.1-alpha.42`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - audio hints + target-speaker embedding estimation (design) [#552](https://github.com/sensein/senselab/pull/552) ([@satra](https://github.com/satra))
  - feat: model integrations — diarization backends, capabilities, DriftSE, unasdiff, PII, Qwen3-TTS, plus shared-cache locking and HF commit pinning [#550](https://github.com/sensein/senselab/pull/550) ([@satra](https://github.com/satra))
  - Per-speaker identity and scene: one grid, one fold, and the decisions in the config [#547](https://github.com/sensein/senselab/pull/547) ([@satra](https://github.com/satra))
  - fix(asr): CrisperWhisper ct2 venv needs torch+transformers for HF→CT2 conversion [#540](https://github.com/sensein/senselab/pull/540) ([@wilke0818](https://github.com/wilke0818))
  - hf-cache: stop HF Hub 429s under parallel batch (resolve-once + SHA-pin) [#539](https://github.com/sensein/senselab/pull/539) ([@wilke0818](https://github.com/wilke0818))
  - fix(adaptive): guard None history in convergence improvement delta [#541](https://github.com/sensein/senselab/pull/541) ([@wilke0818](https://github.com/wilke0818))
  - refactor(cache): cached-inference layer out of analyze_audio.py (T051, parts 1-2) [#538](https://github.com/sensein/senselab/pull/538) ([@satra](https://github.com/satra))
  - Scene-aware presence/quality axis + ASR transcription overhaul (CrisperWhisper 2.0, Qwen) [#536](https://github.com/sensein/senselab/pull/536) ([@satra](https://github.com/satra) [@claude](https://github.com/claude))
  - feat(canary): split long audio at pauses to avoid the ~40s truncation [#534](https://github.com/sensein/senselab/pull/534) ([@wilke0818](https://github.com/wilke0818))
  - ScriptLine: accept empty text as "model produced no transcript" signal [#520](https://github.com/sensein/senselab/pull/520) ([@wilke0818](https://github.com/wilke0818))
  - Feat/pii subprocess venv [#519](https://github.com/sensein/senselab/pull/519) ([@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: route torch/torchaudio via CUDA-aware PyTorch index [#516](https://github.com/sensein/senselab/pull/516) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: two-stage install to fix torch/torchaudio CUDA-tag s… [#518](https://github.com/sensein/senselab/pull/518) ([@wilke0818](https://github.com/wilke0818))
  - Fix/ser wav2vec2 regression head [#511](https://github.com/sensein/senselab/pull/511) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818) [@claude](https://github.com/claude))
  - comparison & uncertainty stage for analyze_audio.py [#512](https://github.com/sensein/senselab/pull/512) ([@satra](https://github.com/satra))
  - audio analysis script + multilingual MMS aligner + 4 new ASR backends [#510](https://github.com/sensein/senselab/pull/510) ([@satra](https://github.com/satra))
  
  #### ⚠️ Pushed to `alpha`
  
  - feat: restructure outputs as L1/L2/final, add the run summary and L1 evidence plot ([@satra](https://github.com/satra))
  - refactor: separate L1 from L2, and name each statistic for its own mathematics ([@satra](https://github.com/satra))
  - fix(mask): uncertainty is distance from the decision, not spread between questions ([@satra](https://github.com/satra))
  - fix(fuse): stop shadowing a dict-of-lists with a dict-of-floats ([@satra](https://github.com/satra))
  - feat(invariance): opt-in probes for perturbations a correct model must survive ([@satra](https://github.com/satra))
  - fix(mask): mark regions of non-task interest, and stop committing while unsure ([@satra](https://github.com/satra))
  - feat(fuse): split level 1 (signals) from level 2 (final uncertainty maps) ([@satra](https://github.com/satra))
  - refactor(posterior): weight speaker-count claims by measurement, not declared kind ([@satra](https://github.com/satra))
  - fix(support): admit only evidence that can withhold support ([@satra](https://github.com/satra))
  - refactor(identity): measure signal weight instead of declaring it ([@satra](https://github.com/satra))
  - style: import order and docstring formatting ([@satra](https://github.com/satra))
  - fix(identity): apply the derivation gate where the axis is aggregated ([@satra](https://github.com/satra))
  - style: docstring formatting in the reliability tests ([@satra](https://github.com/satra))
  - feat(identity): weight each signal's vote by its own measured reliability ([@satra](https://github.com/satra))
  - fix(identity): calibrate on the comparison the harvester actually makes ([@satra](https://github.com/satra))
  - fix(identity): report the empirical calibration band on every clusterer path ([@satra](https://github.com/satra))
  - docs: calibration script, LS tracks, and the three id namespaces ([@satra](https://github.com/satra))
  - fix(labelstudio): build regions before mutating, and read parquet list columns ([@satra](https://github.com/satra))
  - fix(types): give the test helpers explicit keyword parameters ([@satra](https://github.com/satra))
  - fix(types): unwrap optional measurements at their assertion sites ([@satra](https://github.com/satra))
  - test: assert the recorded cache schema version against the constant ([@satra](https://github.com/satra))
  - chore: drop scripts/profile_imports.py from this branch ([@satra](https://github.com/satra))
  - style: docstring formatting in the per-speaker convergence test ([@satra](https://github.com/satra))
  - fix(identity): pass the policy so the derived-source gate is actually in force ([@satra](https://github.com/satra))
  - feat(calibration): emit detection-margin profiles from measured verdicts ([@satra](https://github.com/satra))
  - feat(sources): separate presence from extent, and add modulation depth ([@satra](https://github.com/satra))
  - feat(labelstudio): surface the background mask and per-speaker presence for review ([@satra](https://github.com/satra))
  - fix(identity): attribute speakers to their actual backers and separate the id namespaces ([@satra](https://github.com/satra))
  - test(identity): guard the axes against the per-speaker change and pin reproducibility ([@satra](https://github.com/satra))
  - feat(identity): derive per-speaker structure from the per-bucket evidence ([@satra](https://github.com/satra))
  - test(scene): cover recovery delta, mask discounting, and cross-level ranking ([@satra](https://github.com/satra))
  - feat: excision routing; two fixes found by running the file as a cough task ([@satra](https://github.com/satra))
  - feat: wire per-speaker identity end to end; discard bracketed non-lexical tokens ([@satra](https://github.com/satra))
  - feat(plot): background mask on the main timeline, per-speaker presence on the adaptive one ([@satra](https://github.com/satra))
  - docs: background scene characterization and per-speaker identity (T107, T108) ([@satra](https://github.com/satra))
  - feat(adaptive): final per-speaker outputs; bump cache schema 3 -> 4 ([@satra](https://github.com/satra))
  - feat(audio_analysis): wire background sources into run_pass; fix band resolvability ([@satra](https://github.com/satra))
  - feat(identity): derive source reliability from perturbation evidence, not assignment ([@satra](https://github.com/satra))
  - refactor(identity): source kind is a policy declaration, not a hardcoded constant ([@satra](https://github.com/satra))
  - feat(audio_analysis): per-speaker identity uncertainty framework (T086-T097) ([@satra](https://github.com/satra))
  - feat(audio_analysis): foreground suppression, depth measurement, writers (T050-T052, T059, T064-T065, T069) ([@satra](https://github.com/satra))
  - feat(noise_floor): foreground-referenced SNR + cross-recording baseline ([@satra](https://github.com/satra))
  - feat(noise_floor): detect stationary sources present throughout the clip (T068, FR-021i) ([@satra](https://github.com/satra))
  - feat(audio_analysis): margin ladder + fabrication guards; mask restricted to unmodified pass ([@satra](https://github.com/satra))
  - feat(audio_analysis): per-band noise-floor estimator (T039-T045, T056-T058, T111) ([@satra](https://github.com/satra))
  - fix(level): peak-limited gain policy, found on a real recording ([@satra](https://github.com/satra))
  - feat(adaptive): mutual-influence guards, ahead of the paths they protect (T073-T084) ([@satra](https://github.com/satra))
  - feat(audio_analysis): wire background mask into run_pass + CLI (T033, T035, T037, T038) ([@satra](https://github.com/satra))
  - feat(audio_analysis): background mask with per-region uncertainty (T024-T032, T034, T034a, T036) ([@satra](https://github.com/satra))
  - feat(classification): lossless YAMNet input path + probe script + measured guard (T015-T016, T018, T020-T023) ([@satra](https://github.com/satra))
  - feat(classification): amplitude-invariance probe + AudioSet score fix (T012-T014, T017, T019) ([@satra](https://github.com/satra))
  - feat(audio_analysis): StageContext carries audio variant + gain (T009) ([@satra](https://github.com/satra))
  - feat(audio_analysis): detection-margin profile + level provenance (T005-T008, T010-T011) ([@satra](https://github.com/satra))
  - feat(deps): declare librosa + pyloudnorm; bump cache schema (T001-T004) ([@satra](https://github.com/satra))
  
  #### Authors: 3
  
  - Claude ([@claude](https://github.com/claude))
  - Jordan Wilke ([@wilke0818](https://github.com/wilke0818))
  - Satrajit Ghosh ([@satra](https://github.com/satra))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
