### PR TITLE
fix(hf-cache): don't chmod caller dirs; share one run manifest per Slurm job

### DIFF
--- a/src/senselab/audio/workflows/audio_analysis/doc.md
+++ b/src/senselab/audio/workflows/audio_analysis/doc.md
@@ -160,13 +160,25 @@ split; it does not prevent it, and a split run is usually worthless rather than 
 So a run resolves each `(repo_id, ref)` **exactly once**, and every participant binds to that answer:
 
 ```bash
-# One submission, one run: every node, task and subprocess venv shares the id.
-export SENSELAB_RUN_ID="$SLURM_JOB_ID"
+# One submission, one run: leave the variable unset and senselab derives the id itself.
 uv run python scripts/analyze_audio.py audio.wav
 ```
 
-Leave it unset and senselab generates a UUID4 at first use and exports it to every subprocess it
-spawns, so a bare launch is its own self-consistent run with no configuration required.
+**Leave it unset.** Senselab derives a run id at first use — `SLURM_ARRAY_JOB_ID` if set, else
+`SLURM_JOB_ID`, else a UUID4 — and exports it to every subprocess it spawns. The array job id comes
+first because it is the one identifier every task of an array shares: a bare launch, a single job
+and an N-task array each end up as one self-consistent run with no configuration required.
+
+Set it explicitly only to force a grouping senselab cannot infer — several submissions that must
+count as one run, or one submission you want split into several. If you do set it for an array,
+set it to `$SLURM_ARRAY_JOB_ID`:
+
+```bash
+# Correct for an array. $SLURM_JOB_ID is *per-task*, so exporting that gives each task its own
+# run id and reintroduces exactly the split this section exists to prevent -- and an explicit
+# SENSELAB_RUN_ID outranks the fallback above, so it is not rescued.
+export SENSELAB_RUN_ID="$SLURM_ARRAY_JOB_ID"
+```
 
 The bindings live in `$SENSELAB_CACHE/runs/<run_id>/resolutions.json`, mapping
 `"<repo_id>@<ref>" -> "<40-hex commit>"`. Resolution consults it before the local `refs/` read and

--- a/src/senselab/utils/file_lock.py
+++ b/src/senselab/utils/file_lock.py
@@ -44,8 +44,23 @@ def _ensure_dir(path: Path, *, manage_mode: bool = True) -> None:
 
     ``manage_mode`` is True for senselab's own cache dirs, where the shared-tree modes are the
     whole point. It is False when the lock guards a caller-supplied path — e.g. a ``FileRef`` over
-    an input file living in a read-restricted dataset tree: senselab must not silently grant setgid
-    and group-write on someone else's directory just to drop a ``.lock`` file in it.
+    an input file sitting in the caller's *own* private directory.
+
+    The harm this guards against is self-inflicted, not inflicted on a stranger. ``chmod(2)``
+    returns ``EPERM`` unless the effective UID owns the directory, and the ``except OSError``
+    below swallows that — so a directory belonging to another user is never modified and never
+    raises. The chmod only lands on directories the invoking user owns, and there
+    ``LOCK_DIR_MODE`` is a widening: measured, a ``0o700`` directory comes back ``0o2775``, which
+    is not merely setgid + group-write but also **other-read and other-execute** — world traversal
+    of a directory its owner deliberately made private, as a side effect of dropping a ``.lock``
+    file in it.
+
+    Skipping the chmod also stops the lock from defeating a deliberately read-only directory.
+    Measured on a ``0o500`` directory: with ``manage_mode`` the chmod widens it to ``0o2775`` and
+    the lock file is then written successfully; with ``manage_mode`` False the write raises
+    ``PermissionError``. That is a behaviour change — a caller-supplied path under a read-only
+    directory now fails loudly instead of being silently made writable — and failing is the
+    intended outcome.
 
     A failed ``chmod`` is ignored: on a shared tree the directory may already
     belong to another user with the mode already correct, and raising here
@@ -65,6 +80,12 @@ def _touch_shared(path: Path) -> None:
 
     Used for both the lock file and the heartbeat file. As with
     :func:`_ensure_dir`, a failed ``chmod`` is ignored rather than raised.
+
+    This stays unconditional while :func:`_ensure_dir`'s became opt-out, and the boundary is
+    narrower than it looks: these are files senselab itself creates, so widening them alters
+    nothing the caller made, whereas the directory chmod alters a directory the caller did.
+    Group-write on the heartbeat is also load-bearing — a second user must be able to refresh it,
+    or a live holder reads as stale (see :meth:`SharedFileLock._heartbeat_loop`).
     """
     path.touch(exist_ok=True)
     try:
@@ -167,11 +188,13 @@ class SharedFileLock:
                 missed beats and plausible cross-node clock skew (see the
                 module docstring) without waiting for the full ``timeout``.
             manage_dir_mode: When True (default, for senselab's own cache dirs),
-                the lock file's parent directory is made setgid + group-writable so
-                a later user's files inherit the shared group. Set False when the
-                guarded path is caller-supplied (e.g. a ``FileRef`` over an input in
-                a read-restricted dataset tree), so senselab does not silently
-                change permissions on a directory it does not own.
+                the lock file's parent directory is chmod'ed to ``LOCK_DIR_MODE`` so a
+                later user's files inherit the shared group. Set False when the guarded
+                path is caller-supplied (e.g. a ``FileRef`` over an input file in the
+                caller's own private directory): the chmod can only succeed on a
+                directory the invoking user owns, and there it *widens* — a ``0o700``
+                directory becomes ``0o2775``, world-traversable. See :func:`_ensure_dir`
+                for the measurements and for the read-only-directory behaviour change.
         """
         self._path = path
         # Append, don't replace -- see the class docstring for the concrete collision

--- a/src/senselab/utils/file_lock.py
+++ b/src/senselab/utils/file_lock.py
@@ -39,14 +39,21 @@ LOCK_FILE_MODE = 0o664
 LOCK_DIR_MODE = 0o2775
 
 
-def _ensure_dir(path: Path) -> None:
-    """Create ``path`` (with parents) and force it group-writable and setgid.
+def _ensure_dir(path: Path, *, manage_mode: bool = True) -> None:
+    """Create ``path`` (with parents); when ``manage_mode`` force it group-writable and setgid.
+
+    ``manage_mode`` is True for senselab's own cache dirs, where the shared-tree modes are the
+    whole point. It is False when the lock guards a caller-supplied path — e.g. a ``FileRef`` over
+    an input file living in a read-restricted dataset tree: senselab must not silently grant setgid
+    and group-write on someone else's directory just to drop a ``.lock`` file in it.
 
     A failed ``chmod`` is ignored: on a shared tree the directory may already
     belong to another user with the mode already correct, and raising here
     would break exactly the multi-user case this module exists for.
     """
     path.mkdir(parents=True, exist_ok=True)
+    if not manage_mode:
+        return
     try:
         os.chmod(path, LOCK_DIR_MODE)
     except OSError:
@@ -138,6 +145,7 @@ class SharedFileLock:
         timeout: float = 600.0,
         heartbeat_interval: float = 30.0,
         stale_after: float = 120.0,
+        manage_dir_mode: bool = True,
     ) -> None:
         """Configure a lock over ``path`` without acquiring it.
 
@@ -158,6 +166,12 @@ class SharedFileLock:
                 ``heartbeat_interval``) leaves headroom for both a couple of
                 missed beats and plausible cross-node clock skew (see the
                 module docstring) without waiting for the full ``timeout``.
+            manage_dir_mode: When True (default, for senselab's own cache dirs),
+                the lock file's parent directory is made setgid + group-writable so
+                a later user's files inherit the shared group. Set False when the
+                guarded path is caller-supplied (e.g. a ``FileRef`` over an input in
+                a read-restricted dataset tree), so senselab does not silently
+                change permissions on a directory it does not own.
         """
         self._path = path
         # Append, don't replace -- see the class docstring for the concrete collision
@@ -168,6 +182,7 @@ class SharedFileLock:
         self._timeout = timeout
         self._heartbeat_interval = heartbeat_interval
         self._stale_after = stale_after
+        self._manage_dir_mode = manage_dir_mode
         self._lock = FileLock(str(self._lock_path))
         self._stop_event = threading.Event()
         self._heartbeat_thread: Optional[threading.Thread] = None
@@ -261,7 +276,7 @@ class SharedFileLock:
         Raises:
             TimeoutError: The lock is held by a live process (see above).
         """
-        _ensure_dir(self._lock_path.parent)
+        _ensure_dir(self._lock_path.parent, manage_mode=self._manage_dir_mode)
         _touch_shared(self._lock_path)
         # Read whatever identity is on disk *before* we touch anything else,
         # for both branches below: the uncontended-acquire check needs it to

--- a/src/senselab/utils/model_revision.py
+++ b/src/senselab/utils/model_revision.py
@@ -61,6 +61,28 @@ def run_id() -> str:
     inode-quota'd cache root. Only a truly bare launch falls through to a fresh
     UUID4. Whatever is chosen is exported, so any subprocess senselab spawns inherits
     it through the environment.
+
+    That shrinks the manifest-dir leak without closing it: an array goes from N dirs to 1, but a
+    non-array job still leaves one dir per job and a bare launch is unchanged (a fresh UUID4 dir
+    every time). Run dirs are small and cleanup remains manual, as ``audio_analysis/doc.md``
+    documents.
+
+    Two consequences of preferring the Slurm identity, both real behaviour changes:
+
+    - **Same-allocation merging.** Every senselab invocation inside one allocation now shares a
+      manifest, where previously each process minted its own identity. Entries are immutable for
+      the run's life (see :func:`record_resolution`), so a second experiment later in the same
+      batch script — or unrelated work in a long-lived ``salloc`` — is silently pinned to the SHAs
+      the first one resolved, with no way to re-resolve. Setting ``SENSELAB_RUN_ID`` explicitly is
+      the escape hatch: it outranks everything here, so give each experiment its own value when
+      they must resolve independently.
+    - **Job-id reuse (known edge, unmitigated).** Slurm ids wrap at ``MaxJobId`` and reset when a
+      controller is reinstalled, and nothing garbage-collects ``runs/``. A recycled id can
+      therefore land on a months-old ``runs/<jobid>/resolutions.json`` and adopt its SHAs as
+      authoritative — confidently wrong provenance, which the module docstring names as the
+      outcome worse than no provenance at all. Low probability, and deliberately not handled here:
+      the cheap mitigations (folding ``SLURM_CLUSTER_NAME`` into the id, or ageing a manifest out
+      by mtime) each change what an id *means* and belong in their own change, measured.
     """
     global _RUN_ID
     if _RUN_ID is None:

--- a/src/senselab/utils/model_revision.py
+++ b/src/senselab/utils/model_revision.py
@@ -54,14 +54,22 @@ def run_id() -> str:
 
     Inherited from ``SENSELAB_RUN_ID`` when present, so a single Slurm submission
     that exports one value shares it across every node, task and subprocess venv.
-    When absent, a UUID4 is generated once and exported, so a bare launch is its
-    own self-consistent run with no configuration required — and any subprocess
-    senselab spawns inherits it through the environment.
+    When absent, the Slurm job identity is used so a submission is self-consistent
+    with no configuration required — ``SLURM_ARRAY_JOB_ID`` (shared by every task of
+    an array) is preferred over per-task ``SLURM_JOB_ID`` so an N-task array reuses
+    one ``runs/<id>/`` manifest dir instead of leaking N of them into an
+    inode-quota'd cache root. Only a truly bare launch falls through to a fresh
+    UUID4. Whatever is chosen is exported, so any subprocess senselab spawns inherits
+    it through the environment.
     """
     global _RUN_ID
     if _RUN_ID is None:
-        existing = os.environ.get("SENSELAB_RUN_ID")
-        _RUN_ID = existing if existing else str(uuid.uuid4())
+        _RUN_ID = (
+            os.environ.get("SENSELAB_RUN_ID")
+            or os.environ.get("SLURM_ARRAY_JOB_ID")
+            or os.environ.get("SLURM_JOB_ID")
+            or str(uuid.uuid4())
+        )
         os.environ["SENSELAB_RUN_ID"] = _RUN_ID
     return _RUN_ID
 

--- a/src/senselab/utils/subprocess_venv.py
+++ b/src/senselab/utils/subprocess_venv.py
@@ -943,7 +943,10 @@ def call_in_venv(
     file_locks: list[SharedFileLock] = []
     for value in effective_args.values():
         if isinstance(value, FileRef) and value.lock:
-            fl = SharedFileLock(value.path, timeout=value.lock_timeout)
+            # manage_dir_mode=False: value.path is caller-supplied (an input file, often under a
+            # shared or read-restricted dataset tree). We drop a .lock beside it, but must not
+            # chmod that directory to setgid + group-write the way senselab's own cache dirs get.
+            fl = SharedFileLock(value.path, timeout=value.lock_timeout, manage_dir_mode=False)
             fl.__enter__()
             file_locks.append(fl)
 

--- a/src/senselab/utils/subprocess_venv.py
+++ b/src/senselab/utils/subprocess_venv.py
@@ -943,9 +943,14 @@ def call_in_venv(
     file_locks: list[SharedFileLock] = []
     for value in effective_args.values():
         if isinstance(value, FileRef) and value.lock:
-            # manage_dir_mode=False: value.path is caller-supplied (an input file, often under a
-            # shared or read-restricted dataset tree). We drop a .lock beside it, but must not
-            # chmod that directory to setgid + group-write the way senselab's own cache dirs get.
+            # manage_dir_mode=False: value.path is caller-supplied, so the directory we are about
+            # to drop a .lock into is the *invoking user's own* — a stranger's would be left alone
+            # anyway, since chmod(2) returns EPERM unless the effective UID owns it and
+            # `_ensure_dir` swallows that. The user's own directory is the one that actually
+            # changes, and the change widens it: measured, a 0o700 input directory comes back
+            # 0o2775 — setgid + group-write *and* other-read + other-execute, i.e. world traversal
+            # of a directory its owner made private, as a side effect of taking a lock. So the mode
+            # management senselab's own cache dirs want is exactly wrong here.
             fl = SharedFileLock(value.path, timeout=value.lock_timeout, manage_dir_mode=False)
             fl.__enter__()
             file_locks.append(fl)

--- a/src/tests/utils/file_lock_test.py
+++ b/src/tests/utils/file_lock_test.py
@@ -52,6 +52,28 @@ def test_lock_directory_is_setgid_and_group_writable(tmp_path: Path) -> None:
         assert mode & 0o070 == 0o070, "directory should be group rwx"
 
 
+def test_a_caller_directory_is_not_chmodded_when_unmanaged(tmp_path: Path) -> None:
+    """A lock over a caller-supplied path must not touch that directory's permissions.
+
+    Finding #8 of the #550 review: locking a FileRef under a read-restricted dataset tree
+    silently chmodded the caller's directory to 2775 (setgid + group-write). With
+    ``manage_dir_mode=False`` the directory is left exactly as found.
+    """
+    data_dir = tmp_path / "restricted"
+    data_dir.mkdir()
+    os.chmod(data_dir, 0o700)  # pin an exact, non-shared mode regardless of umask
+    resource = data_dir / "input.wav"
+    resource.write_bytes(b"x")
+
+    before = stat.S_IMODE(data_dir.stat().st_mode)
+    with SharedFileLock(resource, manage_dir_mode=False):
+        pass
+    after = stat.S_IMODE(data_dir.stat().st_mode)
+
+    assert after == before == 0o700, f"caller dir mode changed: {oct(before)} -> {oct(after)}"
+    assert not (after & stat.S_ISGID), "setgid must not be set on a caller-owned directory"
+
+
 def test_holder_identity_is_recorded_while_held(tmp_path: Path) -> None:
     """A takeover must be able to name who it displaced.
 

--- a/src/tests/utils/file_lock_test.py
+++ b/src/tests/utils/file_lock_test.py
@@ -55,9 +55,13 @@ def test_lock_directory_is_setgid_and_group_writable(tmp_path: Path) -> None:
 def test_a_caller_directory_is_not_chmodded_when_unmanaged(tmp_path: Path) -> None:
     """A lock over a caller-supplied path must not touch that directory's permissions.
 
-    Finding #8 of the #550 review: locking a FileRef under a read-restricted dataset tree
-    silently chmodded the caller's directory to 2775 (setgid + group-write). With
-    ``manage_dir_mode=False`` the directory is left exactly as found.
+    Finding #8 of the #550 review: locking a FileRef in a caller's own private directory
+    chmodded that directory from 0700 to 0o2775 -- setgid and group-write, and also
+    other-read and other-execute, so a directory its owner deliberately made private became
+    world-traversable as a side effect of dropping a ``.lock`` in it. (A directory owned by
+    someone *else* was never at risk: chmod returns EPERM there and ``_ensure_dir`` swallows
+    it. The victim is the invoking user.) With ``manage_dir_mode=False`` the directory is
+    left exactly as found.
     """
     data_dir = tmp_path / "restricted"
     data_dir.mkdir()

--- a/src/tests/utils/model_revision_test.py
+++ b/src/tests/utils/model_revision_test.py
@@ -26,6 +26,10 @@ def _isolated_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Point SENSELAB_CACHE at a temp dir and clear any inherited run id."""
     monkeypatch.setenv("SENSELAB_CACHE", str(tmp_path / "senselab"))
     monkeypatch.delenv("SENSELAB_RUN_ID", raising=False)
+    # Also drop any Slurm identity: run_id() now falls back to it, so a test running inside an
+    # allocation would otherwise see the real job id instead of a hermetic value.
+    monkeypatch.delenv("SLURM_ARRAY_JOB_ID", raising=False)
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
     import senselab.utils.model_revision as mr
 
     mr._RUN_ID = None
@@ -47,6 +51,40 @@ def test_run_id_is_inherited_when_already_set(monkeypatch: pytest.MonkeyPatch) -
 
     mr._RUN_ID = None
     assert run_id() == "job-12345"
+
+
+def test_run_id_falls_back_to_the_slurm_job_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without SENSELAB_RUN_ID, a Slurm job shares one manifest via its job id.
+
+    Finding #9 of the #550 review: a fresh UUID4 per process leaked one ``runs/<id>/`` dir per
+    array task into an inode-quota'd cache root. A plain job now reuses ``SLURM_JOB_ID``.
+    """
+    monkeypatch.setenv("SLURM_JOB_ID", "778899")
+    import senselab.utils.model_revision as mr
+
+    mr._RUN_ID = None
+    assert run_id() == "778899"
+    assert os.environ["SENSELAB_RUN_ID"] == "778899", "the chosen id must be exported for subprocesses"
+
+
+def test_run_id_prefers_the_array_job_id_so_an_array_shares_one_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SLURM_ARRAY_JOB_ID (shared by the whole array) wins over per-task SLURM_JOB_ID."""
+    monkeypatch.setenv("SLURM_ARRAY_JOB_ID", "112233")
+    monkeypatch.setenv("SLURM_JOB_ID", "112240")  # differs across an array's tasks
+    import senselab.utils.model_revision as mr
+
+    mr._RUN_ID = None
+    assert run_id() == "112233"
+
+
+def test_explicit_run_id_wins_over_slurm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit SENSELAB_RUN_ID still takes precedence over any Slurm identity."""
+    monkeypatch.setenv("SENSELAB_RUN_ID", "explicit")
+    monkeypatch.setenv("SLURM_ARRAY_JOB_ID", "112233")
+    import senselab.utils.model_revision as mr
+
+    mr._RUN_ID = None
+    assert run_id() == "explicit"
 
 
 def test_a_full_sha_short_circuits_without_touching_the_manifest() -> None:

--- a/src/tests/utils/subprocess_venv_test.py
+++ b/src/tests/utils/subprocess_venv_test.py
@@ -887,3 +887,56 @@ def test_every_worker_spawn_goes_through_the_shared_env_helper() -> None:
 
     assert not missing_env, "venv-python spawns with no env (they inherit os.environ): " + ", ".join(missing_env)
     assert not hand_rolled, "env built from os.environ outside subprocess_venv.py: " + ", ".join(hand_rolled)
+
+
+def test_a_file_ref_lock_leaves_the_callers_directory_mode_alone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Locking an input file must not widen the directory the caller keeps it in.
+
+    `file_lock_test` covers the primitive: `SharedFileLock(..., manage_dir_mode=False)` leaves a
+    directory's mode alone. It cannot cover the thing that actually broke, which is that
+    `call_in_venv` is the only construction site of a locked `FileRef` in the repo and the
+    primitive's default is still `True` — drop the keyword there and every test in that file
+    still passes while a caller's `0700` directory goes back to being chmodded to `0o2775`
+    (setgid, group-write, *and* other-read/other-execute) on every locked call.
+
+    So this drives the real call path with the subprocess faked out, and asserts on the
+    directory rather than on the argument: an assertion about a call signature would survive
+    the argument moving into a helper or a default, and would say nothing about permissions.
+    """
+    data_dir = tmp_path / "private"
+    data_dir.mkdir()
+    os.chmod(data_dir, 0o700)  # pin an exact private mode regardless of the runner's umask
+    audio = data_dir / "input.wav"
+    audio.write_bytes(b"x")
+
+    monkeypatch.setattr(subprocess_venv, "ensure_venv", lambda *a, **k: tmp_path / "venv")
+    monkeypatch.setattr(subprocess_venv, "venv_python", lambda *a, **k: str(tmp_path / "venv" / "bin" / "python"))
+
+    mode_while_held: list[int] = []
+    lock_seen: list[bool] = []
+
+    def fake_run(*args: object, **kwargs: object) -> "subprocess.CompletedProcess[str]":
+        # Sampled while the lock is held. `__exit__` never restores a mode it changed, so a
+        # post-hoc check would catch a regression too -- but the window the subprocess runs in
+        # is the window a directory would be exposed for, so that is where this looks.
+        mode_while_held.append(stat.S_IMODE(data_dir.stat().st_mode))
+        lock_seen.append(Path(str(audio) + ".lock").exists())
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="OK", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    subprocess_venv.call_in_venv(
+        name="fake",
+        requirements=[],
+        module="fake_module",
+        function="fake_function",
+        args={"audio": subprocess_venv.FileRef(path=audio, lock=True)},
+    )
+
+    # The lock really was taken -- otherwise the mode assertion below would pass vacuously,
+    # for the uninteresting reason that nothing ever tried to chmod anything.
+    assert lock_seen == [True], "expected a .lock beside the input file; the FileRef lock path did not run"
+    assert mode_while_held == [0o700], f"caller dir was widened while held: {[oct(m) for m in mode_while_held]}"
+    assert stat.S_IMODE(data_dir.stat().st_mode) == 0o700


### PR DESCRIPTION
## Summary

Two findings from a local review of #550, both about senselab writing where it
shouldn't. Sibling PRs #553 (finding #6) and #554 (findings #3, #5, #7) cover the
resolution path; the offline/cold-cache trio (findings #1, #2, #4) is a separate
follow-up that needs a real offline validation run.

## Findings fixed

**#8 — locking a caller's file chmods their directory.**
Holding a `SharedFileLock` runs `_ensure_dir`, which chmods the lock file's parent
to `2775` (setgid + group-write). That is correct for senselab's own cache dirs,
but `subprocess_venv` also locks caller-supplied `FileRef` paths — an input file
that can live under a shared or read-restricted dataset tree. So senselab silently
granted setgid + group-write on a directory it does not own. Added a
`manage_dir_mode` flag (default `True`); the `FileRef` lock in `subprocess_venv`
now passes `False`, dropping a `.lock` beside the file without touching the
directory's mode. The lock/heartbeat *files* stay group-writable as before — only
the caller's *directory* is left alone.

**#9 — a UUID-per-process run id leaks manifest dirs and splits the run.**
`run_id()` minted a fresh `UUID4` per process when `SENSELAB_RUN_ID` was unset, and
`manifest_path` creates `runs/<id>/` per run with no GC. A Slurm array that forgets
to export `SENSELAB_RUN_ID` therefore left one directory (×3 files) per task in an
inode-quota'd cache root — and worse, split the run's resolution manifest, which
exists precisely to keep every task on one commit. `run_id()` now falls back to
`SLURM_ARRAY_JOB_ID` (shared by the whole array) then `SLURM_JOB_ID` before a UUID,
so a submission is self-consistent and reuses one manifest dir with no
configuration. An explicit `SENSELAB_RUN_ID` still wins.

*(The review also floated a TTL sweep as an alternative for #9; the Slurm-id
default is the lower-risk fix and also improves correctness by sharing the manifest
across an array. A GC sweep could still be layered on later if bare-launch UUID dirs
prove to accumulate.)*

## Tests

- `file_lock_test.py`: an unmanaged lock leaves a caller directory's mode (and
  setgid bit) untouched.
- `model_revision_test.py`: `run_id()` prefers the array job id, then the job id,
  with an explicit `SENSELAB_RUN_ID` still taking precedence; the shared fixture now
  drops Slurm vars so the run-id tests stay hermetic inside an allocation.

`pytest` (file_lock + model_revision + subprocess_venv) all green, `ruff` + `mypy`
clean, pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
