### PR TITLE
fix(hf-cache): bare-loader backends must stage via the ref so refs/<ref> is written

### DIFF
--- a/src/senselab/audio/tasks/speaker_diarization/diarizen.py
+++ b/src/senselab/audio/tasks/speaker_diarization/diarizen.py
@@ -256,12 +256,23 @@ def diarize_audios_with_diarizen(
         # Stage via the *ref*, not a resolved SHA. DiariZenPipeline.from_pretrained() loads bare
         # (no revision parameter) and resolves the "main" ref inside the offline cache, so its only
         # link to the run's commit is the refs/<ref> pointer that hf_subprocess_env -> resolve_model
-        # -> _point_ref_at writes at the manifest-pinned commit. Passing a SHA here makes
-        # _point_ref_at a no-op -- its ref argument is already a SHA -- leaving the bare offline load
-        # with no pointer to resolve, so it fails outright under HF_HUB_OFFLINE=1 (reproduced on a
-        # cold cache). resolve_model still pins through the run manifest either way, so the staged
-        # commit is unchanged; only whether refs/<ref> is written differs. The embedding-model
-        # dependency (pyannote/wespeaker-voxceleb-resnet34-LM) is staged at "main" as before, since
+        # -> _point_ref_at re-points at the manifest-pinned commit. Passing a SHA here makes
+        # _point_ref_at return immediately -- its ref argument is already a SHA -- so refs/<ref> is
+        # never re-pointed and keeps whatever "main" resolved to when it was last written on this
+        # host.
+        #
+        # The severe form needs no unusual cache state. On node B of a multi-node sweep where the
+        # manifest pins sha1 and upstream has since moved to sha2: the HFModel *field* validator
+        # runs first and stages live "main" (refs/main = sha2), the *model* validator then sets
+        # commit_sha = sha1 from the manifest, this backend stages sha1 by SHA, _point_ref_at
+        # no-ops, and the bare worker loads sha2 while provenance records sha1 -- the
+        # confidently-wrong provenance model_revision.py exists to prevent, in exactly the sweep
+        # the manifest was built for. Where no refs/main exists at all (a cache reached only as
+        # snapshots/<sha>), the same defect fails loudly instead: the bare offline load has no
+        # pointer to resolve and dies under HF_HUB_OFFLINE=1 (reproduced on a cold cache).
+        # resolve_model still pins through the run manifest either way, so the staged commit is
+        # unchanged; only where refs/<ref> points differs. The embedding-model dependency
+        # (pyannote/wespeaker-voxceleb-resnet34-LM) is staged at "main" as before, since
         # DiariZenPipeline resolves it internally with no hook for the caller to pin it. Matches
         # text_to_speech/qwen_tts.py and revision_pinning_guard_test's
         # LOADER_CANNOT_PIN_SUBPROCESS_FILES invariant.

--- a/src/senselab/audio/tasks/speaker_diarization/diarizen.py
+++ b/src/senselab/audio/tasks/speaker_diarization/diarizen.py
@@ -253,26 +253,20 @@ def diarize_audios_with_diarizen(
             }
         )
 
-        # Forward the resolved commit SHA to hf_subprocess_env, never the ref -- so the
-        # parent's staging pins the exact run-agreed commit, even though
-        # DiariZenPipeline.from_pretrained() cannot be pointed at it (see the
-        # worker-script's own from_pretrained comment / the module docstring's license
-        # note). The embedding-model dependency has no revision concept of its own here
-        # either -- pyannote/wespeaker-voxceleb-resnet34-LM is staged at "main" like
-        # before, since DiariZenPipeline.from_pretrained() resolves it internally with no
-        # hook for the caller to pin it. Deferred import (not at module top) keeps this
-        # monkeypatch-friendly at senselab.utils.model_revision.resolve_revision,
-        # matching the rest of the codebase.
-        from senselab.utils.model_revision import resolve_revision
-
-        revision = model.commit_sha or resolve_revision(model_name, model.revision)
-
-        # Stage both the main checkpoint and its internal embedding-model
-        # dependency once (cross-process, via the heartbeat lock) + run the
-        # worker offline so from_pretrained/snapshot_download calls make no
-        # per-call Hub version check — the 429 source under parallel batch load.
+        # Stage via the *ref*, not a resolved SHA. DiariZenPipeline.from_pretrained() loads bare
+        # (no revision parameter) and resolves the "main" ref inside the offline cache, so its only
+        # link to the run's commit is the refs/<ref> pointer that hf_subprocess_env -> resolve_model
+        # -> _point_ref_at writes at the manifest-pinned commit. Passing a SHA here makes
+        # _point_ref_at a no-op -- its ref argument is already a SHA -- leaving the bare offline load
+        # with no pointer to resolve, so it fails outright under HF_HUB_OFFLINE=1 (reproduced on a
+        # cold cache). resolve_model still pins through the run manifest either way, so the staged
+        # commit is unchanged; only whether refs/<ref> is written differs. The embedding-model
+        # dependency (pyannote/wespeaker-voxceleb-resnet34-LM) is staged at "main" as before, since
+        # DiariZenPipeline resolves it internally with no hook for the caller to pin it. Matches
+        # text_to_speech/qwen_tts.py and revision_pinning_guard_test's
+        # LOADER_CANNOT_PIN_SUBPROCESS_FILES invariant.
         env = hf_subprocess_env(
-            model_name, revision, also=[(_DIARIZEN_EMBEDDING_MODEL, "main")], base_env=_clean_subprocess_env()
+            model_name, model.revision, also=[(_DIARIZEN_EMBEDDING_MODEL, "main")], base_env=_clean_subprocess_env()
         )
         result = subprocess.run(
             [python, "-c", _WORKER_SCRIPT],

--- a/src/senselab/audio/tasks/speaker_diarization/nvidia.py
+++ b/src/senselab/audio/tasks/speaker_diarization/nvidia.py
@@ -165,19 +165,17 @@ def diarize_audios_with_nvidia_sortformer(
             }
         )
 
-        # Forward the resolved commit SHA to hf_subprocess_env, never the ref -- so the
-        # parent's staging pins the exact run-agreed commit, even though the worker's own
-        # from_pretrained call cannot be pointed at it (see the worker-script comment).
-        # Deferred import (not at module top) keeps this monkeypatch-friendly at
-        # senselab.utils.model_revision.resolve_revision, matching the rest of the codebase.
-        from senselab.utils.model_revision import resolve_revision
-
-        revision = model.commit_sha or resolve_revision(model_name, model.revision)
-
-        # Stage the model once (cross-process, via the heartbeat lock) + run the
-        # worker offline so its SortformerEncLabelModel.from_pretrained makes no
-        # per-call Hub version check — the 429 source under parallel batch.
-        env = hf_subprocess_env(model_name, revision, base_env=_clean_subprocess_env())
+        # Stage via the *ref*, not a resolved SHA. This worker loads bare
+        # (SortformerEncLabelModel.from_pretrained takes no revision and always resolves the "main"
+        # ref inside the offline cache), so its only link to the run's commit is the refs/<ref>
+        # pointer that hf_subprocess_env -> resolve_model -> _point_ref_at writes at the
+        # manifest-pinned commit. Passing a SHA here makes _point_ref_at a no-op -- its ref
+        # argument is already a SHA -- leaving the bare offline load with no pointer to resolve, so
+        # it fails outright under HF_HUB_OFFLINE=1 (reproduced on a cold cache). resolve_model still
+        # pins through the run manifest either way, so the staged commit is unchanged; only whether
+        # refs/<ref> is written differs. Matches text_to_speech/qwen_tts.py and the invariant in
+        # revision_pinning_guard_test.LOADER_CANNOT_PIN_SUBPROCESS_FILES.
+        env = hf_subprocess_env(model_name, model.revision, base_env=_clean_subprocess_env())
         result = subprocess.run(
             [python, "-c", _WORKER_SCRIPT],
             input=input_json,

--- a/src/senselab/audio/tasks/speaker_diarization/nvidia.py
+++ b/src/senselab/audio/tasks/speaker_diarization/nvidia.py
@@ -168,13 +168,23 @@ def diarize_audios_with_nvidia_sortformer(
         # Stage via the *ref*, not a resolved SHA. This worker loads bare
         # (SortformerEncLabelModel.from_pretrained takes no revision and always resolves the "main"
         # ref inside the offline cache), so its only link to the run's commit is the refs/<ref>
-        # pointer that hf_subprocess_env -> resolve_model -> _point_ref_at writes at the
-        # manifest-pinned commit. Passing a SHA here makes _point_ref_at a no-op -- its ref
-        # argument is already a SHA -- leaving the bare offline load with no pointer to resolve, so
-        # it fails outright under HF_HUB_OFFLINE=1 (reproduced on a cold cache). resolve_model still
-        # pins through the run manifest either way, so the staged commit is unchanged; only whether
-        # refs/<ref> is written differs. Matches text_to_speech/qwen_tts.py and the invariant in
-        # revision_pinning_guard_test.LOADER_CANNOT_PIN_SUBPROCESS_FILES.
+        # pointer that hf_subprocess_env -> resolve_model -> _point_ref_at re-points at the
+        # manifest-pinned commit. Passing a SHA here makes _point_ref_at return immediately -- its
+        # ref argument is already a SHA -- so refs/<ref> is never re-pointed and keeps whatever
+        # "main" resolved to when it was last written on this host.
+        #
+        # The severe form needs no unusual cache state. On node B of a multi-node sweep where the
+        # manifest pins sha1 and upstream has since moved to sha2: the HFModel *field* validator
+        # runs first and stages live "main" (refs/main = sha2), the *model* validator then sets
+        # commit_sha = sha1 from the manifest, this backend stages sha1 by SHA, _point_ref_at
+        # no-ops, and the bare worker loads sha2 while provenance records sha1 -- the
+        # confidently-wrong provenance model_revision.py exists to prevent, in exactly the sweep
+        # the manifest was built for. Where no refs/main exists at all (a cache reached only as
+        # snapshots/<sha>), the same defect fails loudly instead: the bare offline load has no
+        # pointer to resolve and dies under HF_HUB_OFFLINE=1 (reproduced on a cold cache).
+        # resolve_model still pins through the run manifest either way, so the staged commit is
+        # unchanged; only where refs/<ref> points differs. Matches text_to_speech/qwen_tts.py and
+        # the invariant in revision_pinning_guard_test.LOADER_CANNOT_PIN_SUBPROCESS_FILES.
         env = hf_subprocess_env(model_name, model.revision, base_env=_clean_subprocess_env())
         result = subprocess.run(
             [python, "-c", _WORKER_SCRIPT],

--- a/src/senselab/audio/tasks/speech_to_text/nemo.py
+++ b/src/senselab/audio/tasks/speech_to_text/nemo.py
@@ -160,12 +160,22 @@ class NeMoASR:
             # Stage via the *ref*, not a resolved SHA. This worker loads bare
             # (ASRModel.from_pretrained takes no revision and always resolves the "main" ref
             # inside the offline cache), so its only link to the run's commit is the refs/<ref>
-            # pointer that hf_subprocess_env -> resolve_model -> _point_ref_at writes at the
-            # manifest-pinned commit. Passing a SHA here makes _point_ref_at a no-op -- its ref
-            # argument is already a SHA -- leaving the bare offline load with no pointer to
-            # resolve, so it fails outright under HF_HUB_OFFLINE=1 (reproduced on a cold cache).
-            # resolve_model still pins through the run manifest either way, so the staged commit is
-            # unchanged; only whether refs/<ref> is written differs. Matches
+            # pointer that hf_subprocess_env -> resolve_model -> _point_ref_at re-points at the
+            # manifest-pinned commit. Passing a SHA here makes _point_ref_at return immediately --
+            # its ref argument is already a SHA -- so refs/<ref> is never re-pointed and keeps
+            # whatever "main" resolved to when it was last written on this host.
+            #
+            # The severe form needs no unusual cache state. On node B of a multi-node sweep where
+            # the manifest pins sha1 and upstream has since moved to sha2: the HFModel *field*
+            # validator runs first and stages live "main" (refs/main = sha2), the *model* validator
+            # then sets commit_sha = sha1 from the manifest, this backend stages sha1 by SHA,
+            # _point_ref_at no-ops, and the bare worker loads sha2 while provenance records sha1 --
+            # the confidently-wrong provenance model_revision.py exists to prevent, in exactly the
+            # sweep the manifest was built for. Where no refs/main exists at all (a cache reached
+            # only as snapshots/<sha>), the same defect fails loudly instead: the bare offline load
+            # has no pointer to resolve and dies under HF_HUB_OFFLINE=1 (reproduced on a cold
+            # cache). resolve_model still pins through the run manifest either way, so the staged
+            # commit is unchanged; only where refs/<ref> points differs. Matches
             # text_to_speech/qwen_tts.py and revision_pinning_guard_test's
             # LOADER_CANNOT_PIN_SUBPROCESS_FILES invariant.
             env = hf_subprocess_env(model_name, model.revision, base_env=_clean_subprocess_env())

--- a/src/senselab/audio/tasks/speech_to_text/nemo.py
+++ b/src/senselab/audio/tasks/speech_to_text/nemo.py
@@ -157,20 +157,18 @@ class NeMoASR:
                 }
             )
 
-            # Forward the resolved commit SHA to hf_subprocess_env, never the ref -- so the
-            # parent's staging pins the exact run-agreed commit, even though the worker's
-            # own from_pretrained call cannot be pointed at it (see the worker-script
-            # comment). Deferred import (not at module top) keeps this monkeypatch-friendly
-            # at senselab.utils.model_revision.resolve_revision, matching the rest of the
-            # codebase.
-            from senselab.utils.model_revision import resolve_revision
-
-            revision = model.commit_sha or resolve_revision(model_name, model.revision)
-
-            # Stage the model once (cross-process, via the heartbeat lock) + run the
-            # worker offline so its from_pretrained makes no per-call Hub version
-            # check — the 429 source under parallel batch.
-            env = hf_subprocess_env(model_name, revision, base_env=_clean_subprocess_env())
+            # Stage via the *ref*, not a resolved SHA. This worker loads bare
+            # (ASRModel.from_pretrained takes no revision and always resolves the "main" ref
+            # inside the offline cache), so its only link to the run's commit is the refs/<ref>
+            # pointer that hf_subprocess_env -> resolve_model -> _point_ref_at writes at the
+            # manifest-pinned commit. Passing a SHA here makes _point_ref_at a no-op -- its ref
+            # argument is already a SHA -- leaving the bare offline load with no pointer to
+            # resolve, so it fails outright under HF_HUB_OFFLINE=1 (reproduced on a cold cache).
+            # resolve_model still pins through the run manifest either way, so the staged commit is
+            # unchanged; only whether refs/<ref> is written differs. Matches
+            # text_to_speech/qwen_tts.py and revision_pinning_guard_test's
+            # LOADER_CANNOT_PIN_SUBPROCESS_FILES invariant.
+            env = hf_subprocess_env(model_name, model.revision, base_env=_clean_subprocess_env())
             result = subprocess.run(
                 [python, "-c", _ASR_WORKER_SCRIPT],
                 input=input_json,

--- a/src/senselab/audio/tasks/speech_to_text/qwen.py
+++ b/src/senselab/audio/tasks/speech_to_text/qwen.py
@@ -240,9 +240,10 @@ class QwenASR:
         python = venv_python(venv_dir)
 
         # Resolve both the ASR model and (when requested) its forced-aligner companion to
-        # immutable commit SHAs before staging -- never the ref -- so the worker's
-        # Qwen3ASRModel.from_pretrained(..., revision=...) pins the exact run-agreed
-        # commit rather than whatever this host's mutable "main" ref currently points at.
+        # immutable commit SHAs for the *worker payload*, so the loads that do take a revision
+        # (Qwen3ASRModel/Qwen3ForcedAligner.from_pretrained) pin the exact run-agreed commit
+        # rather than whatever this host's mutable "main" ref currently points at. Staging is a
+        # separate decision and goes via the ref -- see the hf_subprocess_env call below.
         # Deferred import (not at module top) keeps this monkeypatch-friendly at
         # senselab.utils.model_revision.resolve_revision, matching the rest of the codebase.
         from senselab.utils.model_revision import resolve_revision
@@ -276,8 +277,28 @@ class QwenASR:
             # from_pretrained loads from cache with no per-call Hub version check (the 429
             # source under many parallel jobs). The child imports fresh, so the offline
             # flag is honored (unlike an in-process toggle).
-            also = [(aligner_name, aligner_revision)] if return_timestamps and aligner_revision is not None else None
-            env = hf_subprocess_env(model_name, revision, also=also, base_env=_clean_subprocess_env())
+            #
+            # Stage via the *ref*, not the resolved SHA, even though the payload below still
+            # carries the SHA (see the worker script): both wrappers' internal
+            # AutoProcessor.from_pretrained(path, fix_mistral_regex=True) calls take no revision,
+            # so the processor/tokenizer config resolves refs/<ref> inside the offline cache, and
+            # the only thing that re-points that ref at the commit this run pinned is
+            # _point_ref_at, reached through hf_subprocess_env -> resolve_model. Handing it a SHA
+            # makes _point_ref_at return immediately -- its ref argument is already a SHA -- so
+            # refs/<ref> keeps whatever "main" resolved to when this host last staged the repo.
+            #
+            # On node B of a multi-node sweep that is a silent mismatch rather than an error: the
+            # HFModel *field* validator stages live "main" first (refs/main = sha2), the *model*
+            # validator then adopts the manifest's sha1, the backend stages sha1 by SHA, and the
+            # bare processor load reads sha2 while provenance records sha1 -- the confidently-wrong
+            # provenance model_revision.py exists to prevent, in exactly the sweep the manifest was
+            # built for. Where no refs/<ref> exists at all (a cache reached only as
+            # snapshots/<sha>), the same defect fails loudly instead, under HF_HUB_OFFLINE=1.
+            # resolve_model still pins through the run manifest either way, so the staged commit --
+            # and the SHA in the payload -- is unchanged; only where refs/<ref> points differs.
+            # Matches text_to_speech/qwen_tts.py and the three bare-loader backends.
+            also = [(aligner_name, "main")] if return_timestamps and aligner_revision is not None else None
+            env = hf_subprocess_env(model_name, model.revision, also=also, base_env=_clean_subprocess_env())
             result = subprocess.run(
                 [python, "-c", _QWEN_WORKER_SCRIPT],
                 input=input_json,
@@ -366,10 +387,12 @@ class QwenASR:
         venv_dir = ensure_venv(_QWEN_VENV, _QWEN_REQUIREMENTS, python_version=_QWEN_PYTHON)
         python = venv_python(venv_dir)
 
-        # Resolve the ref to a commit SHA before staging, never the ref -- so the worker's
+        # Resolve the ref to a commit SHA for the worker payload, so the worker's
         # Qwen3ForcedAligner.from_pretrained(..., revision=...) pins the exact run-agreed
-        # commit. Deferred import (not at module top) keeps this monkeypatch-friendly at
-        # senselab.utils.model_revision.resolve_revision, matching the rest of the codebase.
+        # commit. Staging is a separate decision and goes via the ref -- see the
+        # hf_subprocess_env call below. Deferred import (not at module top) keeps this
+        # monkeypatch-friendly at senselab.utils.model_revision.resolve_revision, matching the
+        # rest of the codebase.
         from senselab.utils.model_revision import resolve_revision
 
         aligner_revision = resolve_revision(aligner_name, "main")
@@ -400,7 +423,20 @@ class QwenASR:
             # worker offline so its from_pretrained makes no per-call Hub version check —
             # the 429 source under parallel batch. This call previously ran with no
             # staging/offline env at all, unlike every other subprocess-venv backend.
-            env = hf_subprocess_env(aligner_name, aligner_revision, base_env=_clean_subprocess_env())
+            #
+            # Stage via the *ref* while the payload above keeps the resolved SHA (which
+            # Qwen3ForcedAligner.from_pretrained does accept): the aligner's internal
+            # AutoProcessor.from_pretrained(path, fix_mistral_regex=True) takes no revision and so
+            # resolves refs/<ref> in the offline cache. This is the sharpest instance in the
+            # codebase because aligner_name is a bare string that is never wrapped in an HFModel,
+            # so nothing anywhere stages it via "main" first: on a genuinely cold cache, staging by
+            # SHA leaves snapshots/<sha> with no refs/ entry at all and the bare processor load
+            # then dies under HF_HUB_OFFLINE=1. Where a refs/main does exist from an earlier host
+            # download, the failure is quieter and worse -- the processor silently reads whatever
+            # commit that stale pointer names while provenance records the pinned one. Passing the
+            # ref makes _point_ref_at write refs/<ref> at the pinned commit; the staged commit is
+            # unchanged.
+            env = hf_subprocess_env(aligner_name, "main", base_env=_clean_subprocess_env())
             result = subprocess.run(
                 [python, "-c", _QWEN_ALIGN_WORKER_SCRIPT],
                 input=input_json,

--- a/src/senselab/audio/tasks/text_to_speech/qwen_tts.py
+++ b/src/senselab/audio/tasks/text_to_speech/qwen_tts.py
@@ -86,10 +86,11 @@ revision=download_revision)`` — confirmed by reading the installed wheel's
 :func:`~senselab.utils.dependencies.hf_subprocess_env` — which writes ``refs/<ref>`` at
 the resolved commit — while still sending the **resolved commit SHA** to the worker for
 the actual ``from_pretrained(..., revision=...)`` call. Passing the SHA to
-``hf_subprocess_env`` instead (the pattern ``speech_to_text/qwen.py`` and
-``speaker_diarization/moss.py`` use) would skip writing that pointer entirely —
-``_point_ref_at`` no-ops once its ``ref`` argument is already a SHA — and leave those two
-unpinned reads with nothing to resolve.
+``hf_subprocess_env`` instead (the pattern ``speaker_diarization/moss.py`` still uses,
+whose loader takes a revision throughout) would leave ``refs/<ref>`` un-re-pointed —
+``_point_ref_at`` returns immediately once its ``ref`` argument is already a SHA — so
+those two unpinned reads would resolve through whatever commit that ref last named on
+this host, or fail outright where no such ref exists.
 
 **This backend cannot run air-gapped, and that is measured rather than assumed.** On an
 H100, ``qwen_tts``'s ``from_pretrained`` makes a live call to

--- a/src/tests/audio/tasks/speech_to_text/qwen_resilient_test.py
+++ b/src/tests/audio/tasks/speech_to_text/qwen_resilient_test.py
@@ -49,6 +49,15 @@ def test_qwen_worker_env_built_via_hf_subprocess_env(tmp_path: Path, monkeypatch
         qwen_mod.QwenASR.transcribe_with_qwen([audio], model=model, return_timestamps=True, device=DeviceType.CPU)
 
     assert captured["repo_id"] == "Qwen/Qwen3-ASR-1.7B"
-    # A resolved commit SHA, never the mutable "main" ref -- the fix this test guards.
-    assert captured["revision"] == "f" * 40
-    assert captured["also"] == [("Qwen/Qwen3-ForcedAligner-0.6B", "f" * 40)]
+    # The *ref*, not the resolved SHA -- and this assertion is inverted from what it originally
+    # claimed, because the property it pinned was the defect. Staging is what makes
+    # resolve_model -> _point_ref_at re-point refs/<ref> at the run's pinned commit, and
+    # _point_ref_at returns immediately when its ref argument is already a SHA. Since upstream
+    # qwen_asr reads its processor config bare (AutoProcessor.from_pretrained(path,
+    # fix_mistral_regex=True), no revision passthrough), that read follows refs/<ref> whatever the
+    # payload pins: staging by SHA leaves it naming whatever "main" last resolved to on this host,
+    # or nothing at all on a cold cache. The pin itself is untouched -- the worker payload still
+    # carries the resolved SHA for the loads that accept one, which
+    # revision_pinning_guard_test.REVISION_RESOLVED_SUBPROCESS_FILES covers.
+    assert captured["revision"] == "main"
+    assert captured["also"] == [("Qwen/Qwen3-ForcedAligner-0.6B", "main")]

--- a/src/tests/audio/tasks/text_to_speech_test.py
+++ b/src/tests/audio/tasks/text_to_speech_test.py
@@ -246,11 +246,12 @@ def test_synthesis_stages_via_the_ref_but_pins_the_worker_payload_to_the_sha(
     """``hf_subprocess_env`` is staged with the caller's ref; the worker payload gets the SHA.
 
     Passing the resolved SHA to ``hf_subprocess_env`` instead (the pattern
-    ``speech_to_text/qwen.py`` and ``speaker_diarization/moss.py`` use) would skip writing
-    ``refs/<ref>`` entirely -- ``_point_ref_at`` no-ops once its ``ref`` argument is already
-    a SHA -- and strand the wrapper's own two unpinned ``cached_file()`` reads (see the
-    module docstring's "partial-pin gap" section) with nothing to resolve offline. This test
-    would fail if that ref/SHA split were collapsed back to passing the SHA everywhere.
+    ``speaker_diarization/moss.py`` still uses, whose loader takes a revision throughout)
+    would leave ``refs/<ref>`` un-re-pointed -- ``_point_ref_at`` returns immediately once its
+    ``ref`` argument is already a SHA -- so the wrapper's own two unpinned ``cached_file()``
+    reads (see the module docstring's "partial-pin gap" section) would follow whatever commit
+    that ref last named on the host, or find nothing to resolve where no such ref exists. This
+    test would fail if that ref/SHA split were collapsed back to passing the SHA everywhere.
     """
     monkeypatch.setattr("senselab.utils.data_structures.model.check_hf_repo_exists", lambda *a, **k: True)
     monkeypatch.setattr("senselab.utils.model_revision.resolve_revision", lambda *a, **k: "c" * 40)

--- a/src/tests/utils/revision_pinning_guard_test.py
+++ b/src/tests/utils/revision_pinning_guard_test.py
@@ -388,3 +388,61 @@ def test_loaders_that_cannot_pin_still_get_a_ref_pointer() -> None:
         "dependencies._point_ref_at is gone; the workers in LOADER_CANNOT_PIN_SUBPROCESS_FILES "
         "load bare and rely on it to reach the run's pinned commit"
     )
+
+
+# The bare-loader backends whose parent stages the primary model through ``hf_subprocess_env``.
+# (``crisperwhisper.py``, the fourth LOADER_CANNOT_PIN file, is pinned by a staged local snapshot
+# path rather than an ``hf_subprocess_env`` ref, so the ref-vs-SHA choice below does not apply to
+# it.) These must hand ``hf_subprocess_env`` the *ref*, not a resolved SHA.
+_BARE_LOADER_REF_STAGED_FILES = {
+    "audio/tasks/speaker_diarization/nvidia.py",
+    "audio/tasks/speech_to_text/nemo.py",
+    "audio/tasks/speaker_diarization/diarizen.py",
+}
+
+
+def _hf_subprocess_env_revision_arg(tree: ast.AST) -> "ast.expr | None":
+    """Return the node passed as ``hf_subprocess_env``'s ``revision`` argument (2nd positional)."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "hf_subprocess_env":
+            for kw in node.keywords:
+                if kw.arg == "revision":
+                    return kw.value
+            if len(node.args) >= 2:
+                return node.args[1]
+    return None
+
+
+def test_bare_loaders_stage_via_the_ref_not_a_resolved_sha() -> None:
+    """The bare-loader backends must hand ``hf_subprocess_env`` the ref, so ``refs/<ref>`` is written.
+
+    ``test_resolve_model_points_the_ref_at_the_pinned_commit`` proves ``resolve_model`` writes
+    ``refs/main`` *when called with a ref* -- but only the call site decides whether ``resolve_model``
+    ever sees one. These three previously passed ``model.commit_sha`` (a SHA), which makes
+    ``_point_ref_at`` a no-op (its ``ref`` argument is already a SHA), so ``refs/main`` was never
+    written and the bare ``from_pretrained`` failed under ``HF_HUB_OFFLINE=1`` on a cold cache --
+    reproduced end-to-end on a GPU node. This closes that gap by asserting each site passes
+    ``model.revision``, the ref.
+
+    AST, not text (the file's convention): a comment mentioning ``.revision`` cannot satisfy it --
+    only the executable argument node can.
+    """
+    from tests.utils.hf_load_coverage_test import _SRC
+
+    assert _BARE_LOADER_REF_STAGED_FILES <= LOADER_CANNOT_PIN_SUBPROCESS_FILES, (
+        "every ref-staged bare loader must also be classified as unable to pin"
+    )
+
+    wrong: list[str] = []
+    for relpath in sorted(_BARE_LOADER_REF_STAGED_FILES):
+        arg = _hf_subprocess_env_revision_arg(ast.parse((_SRC / relpath).read_text()))
+        if arg is None:
+            wrong.append(f"{relpath}: no hf_subprocess_env(...) call found")
+        elif not (isinstance(arg, ast.Attribute) and arg.attr == "revision"):
+            got = getattr(arg, "attr", type(arg).__name__)
+            wrong.append(f"{relpath}: hf_subprocess_env revision arg is {got!r}, must be model.revision (the ref)")
+
+    assert not wrong, (
+        "A bare-loader backend stages via something other than the ref, so refs/<ref> would not be "
+        "written and its offline load would fail:\n" + "\n".join(f"  {w}" for w in wrong)
+    )

--- a/src/tests/utils/revision_pinning_guard_test.py
+++ b/src/tests/utils/revision_pinning_guard_test.py
@@ -378,9 +378,16 @@ def test_the_two_revision_allowlists_are_disjoint_and_current() -> None:
 def test_loaders_that_cannot_pin_still_get_a_ref_pointer() -> None:
     """The staged-only backends depend on ``_point_ref_at``, so it must not quietly disappear.
 
-    These four load bare. Their only link to the run's commit is that ``resolve_model`` points
-    ``refs/<ref>`` at it after staging. Deleting that helper would leave them loading whatever the
-    ref last named -- or failing outright offline, since SHA-addressed staging writes no ref at all.
+    Three of these four (``nvidia.py``, ``nemo.py``, ``diarizen.py``) load bare, and their only
+    link to the run's commit is that ``resolve_model`` re-points ``refs/<ref>`` at it after
+    staging. Deleting that helper would leave them loading whatever the ref last named on the host
+    -- or failing outright offline, since SHA-addressed staging writes no ref at all.
+
+    ``crisperwhisper.py`` is the exception and is listed here for a different reason: it passes the
+    *ref* to ``resolve_model`` and hands the worker the returned local ``snapshots/<sha>`` path, so
+    the commit it loads is pinned by that path rather than by any pointer. It belongs in
+    ``LOADER_CANNOT_PIN_SUBPROCESS_FILES`` because ``CrisperWhisperModel`` takes no revision, not
+    because it depends on ``refs/<ref>``.
     """
     from senselab.utils import dependencies
 
@@ -390,59 +397,145 @@ def test_loaders_that_cannot_pin_still_get_a_ref_pointer() -> None:
     )
 
 
-# The bare-loader backends whose parent stages the primary model through ``hf_subprocess_env``.
-# (``crisperwhisper.py``, the fourth LOADER_CANNOT_PIN file, is pinned by a staged local snapshot
-# path rather than an ``hf_subprocess_env`` ref, so the ref-vs-SHA choice below does not apply to
-# it.) These must hand ``hf_subprocess_env`` the *ref*, not a resolved SHA.
-_BARE_LOADER_REF_STAGED_FILES = {
+# Subprocess backends that must stage through ``hf_subprocess_env`` with a *ref*, because some load
+# inside their worker resolves ``refs/<ref>`` instead of taking a revision. Two shapes qualify, and
+# both belong here:
+#
+#   * the fully bare loaders -- ``nvidia.py`` / ``nemo.py`` / ``diarizen.py``, whose upstream
+#     ``from_pretrained`` has no revision parameter at all;
+#   * the *partially* pinned wrappers -- ``qwen.py`` and ``qwen_tts.py``, which do pin the weights
+#     by SHA but whose upstream reads of the small config/processor files ignore revision
+#     (``AutoProcessor.from_pretrained(path, fix_mistral_regex=True)`` in ``qwen_asr``;
+#     ``cached_file(..., revision=kwargs.pop("revision", None))`` in ``qwen_tts``), so those reads
+#     go through the ref regardless of what the payload carries.
+#
+# ``crisperwhisper.py`` -- the remaining LOADER_CANNOT_PIN file -- is deliberately absent: it hands
+# the worker the staged local ``snapshots/<sha>`` path, so it is pinned by that path and no ref is
+# involved.
+_REF_STAGED_SUBPROCESS_FILES = {
     "audio/tasks/speaker_diarization/nvidia.py",
     "audio/tasks/speech_to_text/nemo.py",
     "audio/tasks/speaker_diarization/diarizen.py",
+    "audio/tasks/speech_to_text/qwen.py",
+    "audio/tasks/text_to_speech/qwen_tts.py",
 }
 
 
-def _hf_subprocess_env_revision_arg(tree: ast.AST) -> "ast.expr | None":
-    """Return the node passed as ``hf_subprocess_env``'s ``revision`` argument (2nd positional)."""
+def _hf_subprocess_env_revision_args(tree: ast.AST) -> list[tuple[int, "ast.expr | None"]]:
+    """Return ``(lineno, revision-argument)`` for **every** ``hf_subprocess_env(...)`` call.
+
+    Every call, not the first match: ``qwen.py`` makes two (the ASR worker and the standalone
+    forced aligner), and a checker that stopped at the first would have declared that file clean
+    while the second site staged by SHA -- which is precisely how a site added later escapes a
+    guard that was green when it was written.
+
+    Blind spot, stated rather than half-covered: the ``also=`` companion models are not inspected.
+    Their argument is often a local name or a conditional expression rather than a literal, so a
+    check over literals alone would pass silently on the cases that matter most.
+    """
+    calls: list[tuple[int, "ast.expr | None"]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "hf_subprocess_env":
-            for kw in node.keywords:
-                if kw.arg == "revision":
-                    return kw.value
-            if len(node.args) >= 2:
-                return node.args[1]
-    return None
+            arg: "ast.expr | None" = next((kw.value for kw in node.keywords if kw.arg == "revision"), None)
+            if arg is None and len(node.args) >= 2:
+                arg = node.args[1]
+            calls.append((node.lineno, arg))
+    return sorted(calls, key=lambda c: c[0])
 
 
-def test_bare_loaders_stage_via_the_ref_not_a_resolved_sha() -> None:
-    """The bare-loader backends must hand ``hf_subprocess_env`` the ref, so ``refs/<ref>`` is written.
+def _stages_via_a_ref(node: ast.expr) -> bool:
+    """Whether an ``hf_subprocess_env`` revision argument is a ref rather than a resolved commit.
 
-    ``test_resolve_model_points_the_ref_at_the_pinned_commit`` proves ``resolve_model`` writes
-    ``refs/main`` *when called with a ref* -- but only the call site decides whether ``resolve_model``
-    ever sees one. These three previously passed ``model.commit_sha`` (a SHA), which makes
-    ``_point_ref_at`` a no-op (its ``ref`` argument is already a SHA), so ``refs/main`` was never
-    written and the bare ``from_pretrained`` failed under ``HF_HUB_OFFLINE=1`` on a cold cache --
-    reproduced end-to-end on a GPU node. This closes that gap by asserting each site passes
-    ``model.revision``, the ref.
+    Three shapes pass, all of which reach ``_point_ref_at`` with a name it will actually write:
+
+    * ``model.revision`` -- an attribute access on a plain name, so a stray ``foo().revision`` or
+      ``args["x"].revision`` still has to be looked at by a human;
+    * ``model.revision or "main"`` -- the idiom ``qwen_tts.py`` uses for an optional field. Handled
+      as a general ``or``: every branch must itself be a ref, so ``model.commit_sha or ...`` fails;
+    * a literal ref string that is not 40-hex, for a companion model with no ``HFModel`` of its own
+      (``qwen.py``'s forced aligner is a bare id).
+
+    Everything else fails -- notably a local variable, which is how the pre-fix sites read
+    (``revision = model.commit_sha or resolve_revision(...)``) and which no static check can prove
+    holds a ref.
+    """
+    if isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or):
+        return all(_stages_via_a_ref(value) for value in node.values)
+    if isinstance(node, ast.Attribute) and node.attr == "revision":
+        return isinstance(node.value, ast.Name)
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return not SHA_RE.match(node.value)
+    return False
+
+
+def test_ref_staged_backends_stage_via_the_ref_not_a_resolved_sha() -> None:
+    """These backends must hand ``hf_subprocess_env`` the ref, so ``refs/<ref>`` names the pinned commit.
+
+    ``test_resolve_model_points_the_ref_at_the_pinned_commit`` proves ``resolve_model`` re-points
+    ``refs/<ref>`` *when called with a ref* -- but only the call site decides whether it ever sees
+    one. These sites previously passed a resolved SHA, and ``_point_ref_at`` returns immediately
+    once its ``ref`` argument is already a SHA. The ref is not thereby absent (``HFModel``
+    construction writes it, via ``validate_hf_model_id`` -> ``check_hf_repo_exists`` ->
+    ``ensure_hf_model(repo, "main")``); it is simply never *re-pointed*, so it keeps whatever
+    ``main`` resolved to on that host.
+
+    That distinction is the severity of the bug. The loud failure -- a bare load dying under
+    ``HF_HUB_OFFLINE=1`` -- needs a cache holding ``snapshots/<sha>`` with no ``refs/`` entry.
+    The silent one needs nothing unusual: on node B of a multi-node sweep the field validator
+    stages live ``main`` (``refs/main`` = sha2), the model validator adopts the manifest's sha1,
+    the backend stages sha1 by SHA, and the worker's unpinned load reads sha2 while provenance
+    records sha1 -- the confidently-wrong provenance ``model_revision.py`` exists to prevent.
 
     AST, not text (the file's convention): a comment mentioning ``.revision`` cannot satisfy it --
     only the executable argument node can.
     """
     from tests.utils.hf_load_coverage_test import _SRC
 
-    assert _BARE_LOADER_REF_STAGED_FILES <= LOADER_CANNOT_PIN_SUBPROCESS_FILES, (
-        "every ref-staged bare loader must also be classified as unable to pin"
+    unclassified = _REF_STAGED_SUBPROCESS_FILES - (
+        REVISION_RESOLVED_SUBPROCESS_FILES | LOADER_CANNOT_PIN_SUBPROCESS_FILES
     )
+    assert not unclassified, f"ref-staged backend(s) missing from both revision allowlists: {sorted(unclassified)}"
 
     wrong: list[str] = []
-    for relpath in sorted(_BARE_LOADER_REF_STAGED_FILES):
-        arg = _hf_subprocess_env_revision_arg(ast.parse((_SRC / relpath).read_text()))
-        if arg is None:
+    for relpath in sorted(_REF_STAGED_SUBPROCESS_FILES):
+        calls = _hf_subprocess_env_revision_args(ast.parse((_SRC / relpath).read_text()))
+        if not calls:
             wrong.append(f"{relpath}: no hf_subprocess_env(...) call found")
-        elif not (isinstance(arg, ast.Attribute) and arg.attr == "revision"):
-            got = getattr(arg, "attr", type(arg).__name__)
-            wrong.append(f"{relpath}: hf_subprocess_env revision arg is {got!r}, must be model.revision (the ref)")
+        for lineno, arg in calls:
+            if arg is None:
+                wrong.append(f"{relpath}:{lineno}: hf_subprocess_env called with no revision argument")
+            elif not _stages_via_a_ref(arg):
+                wrong.append(
+                    f"{relpath}:{lineno}: hf_subprocess_env revision arg is {ast.unparse(arg)!r}, "
+                    'must be a ref (model.revision, model.revision or "main", or a literal ref)'
+                )
 
     assert not wrong, (
-        "A bare-loader backend stages via something other than the ref, so refs/<ref> would not be "
-        "written and its offline load would fail:\n" + "\n".join(f"  {w}" for w in wrong)
+        "A backend whose worker has an unpinned load stages via something other than the ref, so "
+        "refs/<ref> would keep naming whatever commit it last named on the host:\n" + "\n".join(f"  {w}" for w in wrong)
     )
+
+
+def test_the_ref_check_accepts_refs_and_rejects_resolved_commits() -> None:
+    """The guard above is only as good as ``_stages_via_a_ref``, so pin its verdicts directly.
+
+    A checker asserting a property of five real files passes for two reasons -- the files are
+    correct, or the checker accepts everything -- and the suite cannot tell them apart. The
+    rejected list below is the pre-fix source of these very call sites; the accepted list is every
+    shape currently in use, including the ``or "main"`` idiom a stricter attribute-only check would
+    have wrongly failed.
+    """
+    accepted = ["model.revision", 'model.revision or "main"', '"main"', '"refs/pr/7"']
+    rejected = [
+        "model.commit_sha",
+        "revision",  # the pre-fix local: commit_sha or resolve_revision(...)
+        "aligner_revision",
+        'resolve_revision(model_name, "main")',
+        'model.commit_sha or "main"',
+        f'"{"a" * 40}"',  # a SHA literal is not a ref, however it is spelled
+    ]
+
+    for expr in accepted:
+        assert _stages_via_a_ref(ast.parse(expr, mode="eval").body), f"{expr} is a ref and must pass"
+    for expr in rejected:
+        assert not _stages_via_a_ref(ast.parse(expr, mode="eval").body), f"{expr} is not a ref and must fail"


### PR DESCRIPTION
## Summary

Finding **#1** of the local #550 review — the offline/cold-cache one. Sibling PRs #553
(finding #6), #554 (#3/#5/#7) and #555 (#8/#9) cover the rest. Findings #2 and #4 turned
out already fixed on `alpha` (`_snapshot_is_present` gating the result-cache fast paths;
`is_hf_model_cached` no longer returns `True` unconditionally offline), so this is all that
remained.

## The defect

The NeMo/Sortformer/DiariZen workers load **bare** — `ASRModel.from_pretrained(model_name)`,
`SortformerEncLabelModel.from_pretrained(model_name)`, `DiariZenPipeline.from_pretrained(model_name)`
take no revision and resolve the `main` ref inside the offline cache. Their only link to the
run's pinned commit is the `refs/main` pointer that `resolve_model` → `_point_ref_at` writes
after staging. `revision_pinning_guard_test.py` documents this exact invariant
(`LOADER_CANNOT_PIN_SUBPROCESS_FILES`, lines 65-69) and
`test_resolve_model_points_the_ref_at_the_pinned_commit` verifies `resolve_model` writes
`refs/main` — **when called with a ref**.

But all three call sites passed a resolved **SHA**:

```python
revision = model.commit_sha or resolve_revision(model_name, model.revision)
env = hf_subprocess_env(model_name, revision, ...)
```

`_point_ref_at` no-ops when its `ref` argument is already a SHA (`if _SHA_RE.match(ref): return`),
so `refs/main` was never written on the path these backends actually use. Nothing tested that
the call sites pass a ref, so the guard stayed green while the real path was broken.
`qwen_tts.py` already documents the correct pattern and names these three as the counter-example.

## Reproduced end-to-end (GPU, cold `HF_HUB_CACHE`)

A 3-phase harness on a fresh cache:

| phase | result |
|---|---|
| **P1** construct `HFModel("nvidia/diar_sortformer_4spk-v1")` | `refs/main` **present** — construction stages via `main` first |
| **P2** normal offline diarization | **SUCCEEDS** (1 segment) — only because P1 wrote `refs/main` |
| **P3** delete `refs/main` (leave `snapshots/<sha>/`), diarize offline | **FAILS**: `RuntimeError: Cannot reach …/resolve/main/diar_sortformer_4spk-v1.nemo: offline mode is enabled` |

P3 is the review's exact stated precondition ("a cache reached with only `snapshots/<sha>`",
e.g. the result-cache fast path or a relocated `HF_HUB_CACHE`). The bare loader dies with a
misleading "unset `HF_HUB_OFFLINE`" message when the real cause is a missing ref pointer.

## Fix

Pass `model.revision` (the ref) to `hf_subprocess_env` in all three sites, matching `qwen_tts.py`.
`resolve_model` still pins through the run manifest, so the *staged commit is unchanged* — only
whether `refs/<ref>` is written differs. Removes the now-unnecessary local SHA resolution.

Adds `test_bare_loaders_stage_via_the_ref_not_a_resolved_sha`: an AST guard (matching the file's
convention) asserting each bare-loader site hands `hf_subprocess_env` `model.revision`, not a SHA —
so a revert to SHA-passing fails the suite.

`ruff` + `mypy` clean; `revision_pinning_guard_test.py` + `hf_load_coverage_test.py` green (16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `1.3.1-alpha.44`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - fix(hf-cache): bare-loader backends must stage via the ref so refs/<ref> is written [#556](https://github.com/sensein/senselab/pull/556) ([@wilke0818](https://github.com/wilke0818) [@satra](https://github.com/satra))
  - fix(hf-cache): don't chmod caller dirs; share one run manifest per Slurm job [#555](https://github.com/sensein/senselab/pull/555) ([@wilke0818](https://github.com/wilke0818) [@satra](https://github.com/satra))
  - fix(hf-cache): keep resolution failures survivable and correctly typed [#554](https://github.com/sensein/senselab/pull/554) ([@wilke0818](https://github.com/wilke0818) [@satra](https://github.com/satra))
  - fix(provenance): degrade an unresolvable commit to None instead of aborting the stage [#553](https://github.com/sensein/senselab/pull/553) ([@wilke0818](https://github.com/wilke0818) [@satra](https://github.com/satra))
  - audio hints + target-speaker embedding estimation (design) [#552](https://github.com/sensein/senselab/pull/552) ([@satra](https://github.com/satra))
  - feat: model integrations — diarization backends, capabilities, DriftSE, unasdiff, PII, Qwen3-TTS, plus shared-cache locking and HF commit pinning [#550](https://github.com/sensein/senselab/pull/550) ([@satra](https://github.com/satra))
  - Per-speaker identity and scene: one grid, one fold, and the decisions in the config [#547](https://github.com/sensein/senselab/pull/547) ([@satra](https://github.com/satra))
  - fix(asr): CrisperWhisper ct2 venv needs torch+transformers for HF→CT2 conversion [#540](https://github.com/sensein/senselab/pull/540) ([@wilke0818](https://github.com/wilke0818))
  - hf-cache: stop HF Hub 429s under parallel batch (resolve-once + SHA-pin) [#539](https://github.com/sensein/senselab/pull/539) ([@wilke0818](https://github.com/wilke0818))
  - fix(adaptive): guard None history in convergence improvement delta [#541](https://github.com/sensein/senselab/pull/541) ([@wilke0818](https://github.com/wilke0818))
  - refactor(cache): cached-inference layer out of analyze_audio.py (T051, parts 1-2) [#538](https://github.com/sensein/senselab/pull/538) ([@satra](https://github.com/satra))
  - Scene-aware presence/quality axis + ASR transcription overhaul (CrisperWhisper 2.0, Qwen) [#536](https://github.com/sensein/senselab/pull/536) ([@satra](https://github.com/satra) [@claude](https://github.com/claude))
  - feat(canary): split long audio at pauses to avoid the ~40s truncation [#534](https://github.com/sensein/senselab/pull/534) ([@wilke0818](https://github.com/wilke0818))
  - ScriptLine: accept empty text as "model produced no transcript" signal [#520](https://github.com/sensein/senselab/pull/520) ([@wilke0818](https://github.com/wilke0818))
  - Feat/pii subprocess venv [#519](https://github.com/sensein/senselab/pull/519) ([@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: route torch/torchaudio via CUDA-aware PyTorch index [#516](https://github.com/sensein/senselab/pull/516) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818))
  - subprocess_venv: two-stage install to fix torch/torchaudio CUDA-tag s… [#518](https://github.com/sensein/senselab/pull/518) ([@wilke0818](https://github.com/wilke0818))
  - Fix/ser wav2vec2 regression head [#511](https://github.com/sensein/senselab/pull/511) ([@satra](https://github.com/satra) [@wilke0818](https://github.com/wilke0818) [@claude](https://github.com/claude))
  - comparison & uncertainty stage for analyze_audio.py [#512](https://github.com/sensein/senselab/pull/512) ([@satra](https://github.com/satra))
  - audio analysis script + multilingual MMS aligner + 4 new ASR backends [#510](https://github.com/sensein/senselab/pull/510) ([@satra](https://github.com/satra))
  
  #### ⚠️ Pushed to `alpha`
  
  - feat: restructure outputs as L1/L2/final, add the run summary and L1 evidence plot ([@satra](https://github.com/satra))
  - refactor: separate L1 from L2, and name each statistic for its own mathematics ([@satra](https://github.com/satra))
  - fix(mask): uncertainty is distance from the decision, not spread between questions ([@satra](https://github.com/satra))
  - fix(fuse): stop shadowing a dict-of-lists with a dict-of-floats ([@satra](https://github.com/satra))
  - feat(invariance): opt-in probes for perturbations a correct model must survive ([@satra](https://github.com/satra))
  - fix(mask): mark regions of non-task interest, and stop committing while unsure ([@satra](https://github.com/satra))
  - feat(fuse): split level 1 (signals) from level 2 (final uncertainty maps) ([@satra](https://github.com/satra))
  - refactor(posterior): weight speaker-count claims by measurement, not declared kind ([@satra](https://github.com/satra))
  - fix(support): admit only evidence that can withhold support ([@satra](https://github.com/satra))
  - refactor(identity): measure signal weight instead of declaring it ([@satra](https://github.com/satra))
  - style: import order and docstring formatting ([@satra](https://github.com/satra))
  - fix(identity): apply the derivation gate where the axis is aggregated ([@satra](https://github.com/satra))
  - style: docstring formatting in the reliability tests ([@satra](https://github.com/satra))
  - feat(identity): weight each signal's vote by its own measured reliability ([@satra](https://github.com/satra))
  - fix(identity): calibrate on the comparison the harvester actually makes ([@satra](https://github.com/satra))
  - fix(identity): report the empirical calibration band on every clusterer path ([@satra](https://github.com/satra))
  - docs: calibration script, LS tracks, and the three id namespaces ([@satra](https://github.com/satra))
  - fix(labelstudio): build regions before mutating, and read parquet list columns ([@satra](https://github.com/satra))
  - fix(types): give the test helpers explicit keyword parameters ([@satra](https://github.com/satra))
  - fix(types): unwrap optional measurements at their assertion sites ([@satra](https://github.com/satra))
  - test: assert the recorded cache schema version against the constant ([@satra](https://github.com/satra))
  - chore: drop scripts/profile_imports.py from this branch ([@satra](https://github.com/satra))
  - style: docstring formatting in the per-speaker convergence test ([@satra](https://github.com/satra))
  - fix(identity): pass the policy so the derived-source gate is actually in force ([@satra](https://github.com/satra))
  - feat(calibration): emit detection-margin profiles from measured verdicts ([@satra](https://github.com/satra))
  - feat(sources): separate presence from extent, and add modulation depth ([@satra](https://github.com/satra))
  - feat(labelstudio): surface the background mask and per-speaker presence for review ([@satra](https://github.com/satra))
  - fix(identity): attribute speakers to their actual backers and separate the id namespaces ([@satra](https://github.com/satra))
  - test(identity): guard the axes against the per-speaker change and pin reproducibility ([@satra](https://github.com/satra))
  - feat(identity): derive per-speaker structure from the per-bucket evidence ([@satra](https://github.com/satra))
  - test(scene): cover recovery delta, mask discounting, and cross-level ranking ([@satra](https://github.com/satra))
  - feat: excision routing; two fixes found by running the file as a cough task ([@satra](https://github.com/satra))
  - feat: wire per-speaker identity end to end; discard bracketed non-lexical tokens ([@satra](https://github.com/satra))
  - feat(plot): background mask on the main timeline, per-speaker presence on the adaptive one ([@satra](https://github.com/satra))
  - docs: background scene characterization and per-speaker identity (T107, T108) ([@satra](https://github.com/satra))
  - feat(adaptive): final per-speaker outputs; bump cache schema 3 -> 4 ([@satra](https://github.com/satra))
  - feat(audio_analysis): wire background sources into run_pass; fix band resolvability ([@satra](https://github.com/satra))
  - feat(identity): derive source reliability from perturbation evidence, not assignment ([@satra](https://github.com/satra))
  - refactor(identity): source kind is a policy declaration, not a hardcoded constant ([@satra](https://github.com/satra))
  - feat(audio_analysis): per-speaker identity uncertainty framework (T086-T097) ([@satra](https://github.com/satra))
  - feat(audio_analysis): foreground suppression, depth measurement, writers (T050-T052, T059, T064-T065, T069) ([@satra](https://github.com/satra))
  - feat(noise_floor): foreground-referenced SNR + cross-recording baseline ([@satra](https://github.com/satra))
  - feat(noise_floor): detect stationary sources present throughout the clip (T068, FR-021i) ([@satra](https://github.com/satra))
  - feat(audio_analysis): margin ladder + fabrication guards; mask restricted to unmodified pass ([@satra](https://github.com/satra))
  - feat(audio_analysis): per-band noise-floor estimator (T039-T045, T056-T058, T111) ([@satra](https://github.com/satra))
  - fix(level): peak-limited gain policy, found on a real recording ([@satra](https://github.com/satra))
  - feat(adaptive): mutual-influence guards, ahead of the paths they protect (T073-T084) ([@satra](https://github.com/satra))
  - feat(audio_analysis): wire background mask into run_pass + CLI (T033, T035, T037, T038) ([@satra](https://github.com/satra))
  - feat(audio_analysis): background mask with per-region uncertainty (T024-T032, T034, T034a, T036) ([@satra](https://github.com/satra))
  - feat(classification): lossless YAMNet input path + probe script + measured guard (T015-T016, T018, T020-T023) ([@satra](https://github.com/satra))
  - feat(classification): amplitude-invariance probe + AudioSet score fix (T012-T014, T017, T019) ([@satra](https://github.com/satra))
  - feat(audio_analysis): StageContext carries audio variant + gain (T009) ([@satra](https://github.com/satra))
  - feat(audio_analysis): detection-margin profile + level provenance (T005-T008, T010-T011) ([@satra](https://github.com/satra))
  - feat(deps): declare librosa + pyloudnorm; bump cache schema (T001-T004) ([@satra](https://github.com/satra))
  
  #### Authors: 3
  
  - Claude ([@claude](https://github.com/claude))
  - Jordan Wilke ([@wilke0818](https://github.com/wilke0818))
  - Satrajit Ghosh ([@satra](https://github.com/satra))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
