### PR TITLE
Triage graph Phase 1: the Estimate type and a RunConfig liveness guard

### DIFF
--- a/specs/20260816-143540-triage-graph/plan-phase1.md
+++ b/specs/20260816-143540-triage-graph/plan-phase1.md
@@ -1,0 +1,278 @@
+# Triage graph, Phase 1: the `Estimate` type and the config-discipline guard
+
+> **For agentic workers:** implement task-by-task. Steps use `- [ ]` for tracking.
+
+**Goal:** ship the two foundations the rest of the triage graph depends on, neither of which
+requires a package-boundary decision.
+
+**Architecture:** one new leaf data structure under `utils/data_structures/`, and one deletion +
+guard test under `audio_analysis/`. The two tasks touch disjoint files.
+
+**Tech stack:** pydantic v2, pytest. `uv run` for everything.
+
+## Global Constraints
+
+- **Every Python command goes through `uv run`.** Never bare `python`/`pip`.
+- **Never construct an unmocked `HFModel`** in a test — it downloads a full snapshot.
+- **Never run `pytest -n auto`.** Run the directory you changed.
+- **Never `git add -A` or `git add .`** — add named paths only.
+- Google-style docstrings, line length 120, type hints required (mypy + pydantic plugin).
+- Tests live in `src/tests/` mirroring the package, named `*_test.py`.
+- **Explain *why*, not *what*.** A docstring that restates a readable signature earns nothing.
+  Record the measurement or failure behind a non-obvious choice.
+- **Pre-alpha: rename and replace outright.** No parallel fields, no aliases, no deprecation shims.
+- Run `uv run pre-commit run --all-files` before declaring done — `ruff` + `mypy` alone is *not*
+  the CI gate; it also runs codespell and JSON formatting.
+
+---
+
+### Task 1: the `Estimate` type
+
+**Files:**
+- Create: `src/senselab/utils/data_structures/estimate.py`
+- Modify: `src/senselab/utils/data_structures/__init__.py`
+- Test: `src/tests/utils/data_structures/estimate_test.py`
+
+**Interfaces produced:** `Estimate` (pydantic `BaseModel`), importable as
+`from senselab.utils.data_structures import Estimate`.
+
+**Why this exists.** A statistical review of `analyze_audio`
+(`specs/20260815-215106-analyze-audio-audit/statistical-review.md`, finding N10) measured three
+defects that share one cause — a number published without the count of things that produced it:
+
+- adding a *low-reliability* signal moved published confidence from 0.800 to 0.420;
+- a bucket backed by 4 unanimous sources and one backed by 20 both published `P = 1.000`;
+- a crashed diarizer produced a confidence indistinguishable from an agreeing one.
+
+This type makes all three unrepresentable. It has no consumers yet; wiring is Phases 2 and 3.
+
+**The model.** `value` is a **computed property, never a field** — so a caller cannot publish a
+value inconsistent with the evidence behind it.
+
+```python
+class Estimate(BaseModel):
+    raw: Optional[float]      # the unshrunk sample statistic; None iff n_evidence == 0
+    n_evidence: int           # independent contributing sources; >= 0, 0 is legal and meaningful
+    prior: float              # what `value` collapses to as n_evidence -> 0
+    prior_key: str            # config key naming the prior, so its derivation is findable
+    prior_weight: float       # pseudo-count k; > 0
+    population: str           # the population this was validated on, e.g. "adult-read-speech"
+```
+
+with
+
+```
+value = prior                                             if n_evidence == 0
+value = (n_evidence*raw + prior_weight*prior) / (n_evidence + prior_weight)   otherwise
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Tests for the Estimate type."""
+
+import pytest
+from pydantic import ValidationError
+
+from senselab.utils.data_structures import Estimate
+
+
+def _est(**kw: object) -> Estimate:
+    base = dict(raw=1.0, n_evidence=1, prior=0.5, prior_key="k", prior_weight=1.0, population="p")
+    base.update(kw)
+    return Estimate(**base)  # type: ignore[arg-type]
+
+
+def test_no_evidence_collapses_to_the_prior() -> None:
+    e = Estimate(raw=None, n_evidence=0, prior=0.42, prior_key="k", prior_weight=2.0, population="p")
+    assert e.value == 0.42
+
+
+def test_a_raw_value_without_evidence_is_rejected() -> None:
+    """F-156: a fabricated number and a measured one must not be the same object."""
+    with pytest.raises(ValidationError):
+        _est(raw=0.5, n_evidence=0)
+
+
+def test_evidence_without_a_raw_value_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _est(raw=None, n_evidence=3)
+
+
+def test_negative_evidence_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _est(n_evidence=-1)
+
+
+def test_a_non_positive_prior_weight_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _est(prior_weight=0.0)
+
+
+def test_an_empty_population_is_rejected() -> None:
+    """An unstated population is how an adult-derived threshold reaches a child recording."""
+    with pytest.raises(ValidationError):
+        _est(population="  ")
+
+
+def test_four_and_twenty_unanimous_sources_differ() -> None:
+    """Statistical review N3: both published P = 1.000 before this type existed."""
+    four = _est(raw=1.0, n_evidence=4, prior=0.5, prior_weight=1.0)
+    twenty = _est(raw=1.0, n_evidence=20, prior=0.5, prior_weight=1.0)
+    assert four.value != twenty.value
+    assert four.value < twenty.value < 1.0
+
+
+def test_more_evidence_moves_the_value_toward_raw() -> None:
+    values = [_est(raw=1.0, n_evidence=n, prior=0.0, prior_weight=1.0).value for n in (1, 2, 8, 64)]
+    assert values == sorted(values)
+    assert values[-1] < 1.0
+
+
+def test_shrinkage_reports_how_much_of_the_value_is_prior() -> None:
+    assert _est(n_evidence=1, prior_weight=1.0).shrinkage == pytest.approx(0.5)
+    assert _est(n_evidence=9, prior_weight=1.0).shrinkage == pytest.approx(0.1)
+    assert Estimate(
+        raw=None, n_evidence=0, prior=0.1, prior_key="k", prior_weight=3.0, population="p"
+    ).shrinkage == 1.0
+
+
+def test_value_is_not_settable() -> None:
+    """A published value that disagrees with its own evidence is the defect this type prevents."""
+    with pytest.raises((ValidationError, AttributeError, TypeError)):
+        Estimate(  # type: ignore[call-arg]
+            raw=1.0, n_evidence=1, prior=0.0, prior_key="k",
+            prior_weight=1.0, population="p", value=0.999,
+        )
+```
+
+- [ ] **Step 2: Run the tests, confirm they fail**
+
+`uv run pytest src/tests/utils/data_structures/estimate_test.py -v`
+Expected: collection error / ImportError — `Estimate` does not exist.
+
+- [ ] **Step 3: Implement `estimate.py`**
+
+Write the module. Requirements, all load-bearing:
+
+- `model_config = ConfigDict(frozen=True, extra="forbid")` — `extra="forbid"` is what makes
+  `test_value_is_not_settable` pass, and `frozen=True` keeps a published estimate immutable.
+- `n_evidence: int = Field(ge=0)`, `prior_weight: float = Field(gt=0)`.
+- A `model_validator(mode="after")` enforcing `raw is None` **iff** `n_evidence == 0`, with an
+  error message naming both fields.
+- A `field_validator` on `population` rejecting blank/whitespace-only strings.
+- `value` and `shrinkage` as `@property` — **not** pydantic computed fields, so they cannot be
+  supplied by a caller.
+- `shrinkage` = `prior_weight / (n_evidence + prior_weight)`.
+- Module docstring records *why* (the three measured defects above, cited to the review), not
+  *what* the fields are.
+
+Also add a convenience constructor, since "no evidence" is the case callers will most often build
+and the one most easily got wrong:
+
+```python
+@classmethod
+def no_evidence(cls, *, prior: float, prior_key: str, prior_weight: float, population: str) -> "Estimate":
+```
+
+- [ ] **Step 4: Export it**
+
+Add to `src/senselab/utils/data_structures/__init__.py`, matching the existing
+`from .module import Name  # noqa: F401` style, in alphabetical position.
+
+- [ ] **Step 5: Tests pass, gate is green**
+
+```bash
+uv run pytest src/tests/utils/data_structures/estimate_test.py -v
+uv run pre-commit run --all-files
+```
+
+- [ ] **Step 6: Commit** (named paths only)
+
+---
+
+### Task 2: delete the dead `RunConfig` policy fields, and guard against new ones
+
+**Files:**
+- Modify: `src/senselab/audio/workflows/audio_analysis/run_config.py`
+- Test: `src/tests/audio/workflows/audio_analysis/run_config_liveness_test.py` (create)
+
+**Why.** `remediation-config.md` found 14 dead config keys, 9 of which share one root cause:
+`RunConfig` fields that `_build()` assigns and nothing ever reads. A key that advertises control it
+does not have is worse than a bare literal — an operator sets `quality.floor_percentile: 25.0`,
+the run reports the config hash as changed, and the value that actually governs is
+`acoustic.py:116`'s `FLOOR_PERCENTILE = 10.0`.
+
+**Candidates** (from `remediation-config.md` D5–D14): `rounds_policy`, `quality_policy`,
+`labelstudio_policy`, `support_policy` — assigned at `run_config.py:480-484`.
+
+**A discrepancy you must resolve rather than inherit.** That document's summary counts **four**
+dead fields plus "two orphaned keys inside `speaker_policy`", but its own D3 and D4 rows state that
+`RunConfig.speaker_policy` "is built and never read anywhere else in the tree". Those cannot both
+be right. **Verify each candidate yourself before touching it**, and report what you actually
+found — including whether `speaker_policy` is a fifth dead field or has a live reader the inventory
+missed. Do not delete a field you have not personally confirmed is unread.
+
+- [ ] **Step 1: Verify liveness for each candidate**
+
+For each of `rounds_policy`, `quality_policy`, `labelstudio_policy`, `support_policy`,
+`speaker_policy`, search the whole tree — `src/`, `scripts/`, `src/tests/` — for reads outside
+`run_config.py`'s own assignment. Check **both** attribute access (`.rounds_policy`) and dynamic
+access (`getattr(`, `asdict(`, `.raw`, `dataclasses.fields`, `**`-unpacking, serialization). A
+field read only by a test still counts as read — say so and leave it.
+
+Record the evidence per field; it goes in the report and the commit message.
+
+- [ ] **Step 2: Write the guard test**
+
+```python
+"""Every RunConfig field must have a reader.
+
+remediation-config.md found four policy fields that `_build()` assigned and nothing consumed.
+An operator setting such a key gets a changed config hash and no behaviour change, which is
+worse than a bare literal because it looks like control. This test fails when a new one appears.
+"""
+```
+
+The test enumerates `dataclasses.fields(RunConfig)` and asserts each name is read somewhere under
+`src/senselab/` or `scripts/` outside `run_config.py`. Implement the search by AST or by scanning
+source text for the field name — your choice, but it must not match the assignment inside
+`_build()` itself, and it must not match a name appearing only in a comment or docstring.
+
+`KNOWN_UNREAD` starts **empty**. If a field survives Step 1 as genuinely unread but you judge it
+should not be deleted, put it in `KNOWN_UNREAD` with a comment naming the reason and the register
+id — do not weaken the assertion.
+
+- [ ] **Step 3: Run it, confirm it fails** naming exactly the fields Step 1 found unread.
+
+- [ ] **Step 4: Delete the confirmed-dead fields**
+
+Remove each from the `RunConfig` dataclass declaration **and** from `_build()`'s constructor call.
+Pre-alpha rule: delete outright, no alias, no shim.
+
+Leave the corresponding YAML sections in `default.yaml` **in place** — `rounds:` holds the live
+`max_rounds`, and the other sections' keys are the subject of separate register findings whose fix
+is to thread them to a real call site, not to delete them. Deleting the YAML would destroy the
+record of what was supposed to be configurable. Say this in the commit message.
+
+- [ ] **Step 5: Full local gate**
+
+```bash
+uv run pytest src/tests/audio/workflows/audio_analysis/ -x -q
+uv run pre-commit run --all-files
+```
+
+The workflow suite is the blast radius for a `RunConfig` change; run all of it, not just the new
+test.
+
+- [ ] **Step 6: Commit** (named paths only)
+
+---
+
+## Out of scope for Phase 1
+
+- The layer-1 extraction lift. Deferred to Phase 2 — measured 2026-08-16, its stated justification
+  did not survive: the package's lazy `__getattr__` already prevents the import cost cited, and the
+  real closure is 14 modules / 5,523 lines reaching `axes.py`, not 2 files.
+- Wiring `Estimate` into any existing output. Phases 2 and 3.
+- Threading the *live-but-dead* keys (D1–D13) to real call sites. Each is its own register finding.

--- a/src/senselab/audio/workflows/audio_analysis/run_config.py
+++ b/src/senselab/audio/workflows/audio_analysis/run_config.py
@@ -191,6 +191,15 @@ class RunConfig:
     # Each was a module constant with a written rationale and no way to change it but editing Python.
     # Grouped by the question they answer rather than by the module they came from, since a reader
     # asking "how is support measured" should not have to know it lived in ``support.py``.
+    #
+    # None of these five is threaded to a production call site (remediation-config.md D5-D14, D3-D4):
+    # each is read exactly once outside this module, by run_config_liveness_test.py's regression test
+    # for the D2 migration -- not by anything that changes pipeline behaviour. They are kept rather
+    # than deleted because that test reads them; deleting one would break real, currently-passing
+    # coverage, not just a config knob nobody uses. `speaker_policy` is not a fifth dead field beyond
+    # the other four, despite the audit summary's phrasing -- it has the identical status, resolved in
+    # run_config_liveness_test.py's KNOWN_UNREAD comment. Threading them to real call sites is its own
+    # register finding, out of scope for triage-graph Phase 1 (see plan-phase1.md).
     rounds_policy: Mapping[str, Any]
     speaker_policy: Mapping[str, Any]
     quality_policy: Mapping[str, Any]

--- a/src/senselab/utils/data_structures/__init__.py
+++ b/src/senselab/utils/data_structures/__init__.py
@@ -2,6 +2,7 @@
 
 from .dataset import Participant, SenselabDataset, Session  # noqa: F401
 from .device import DeviceType, _select_device_and_dtype, device_run_opt  # noqa: F401
+from .estimate import Estimate  # noqa: F401
 from .file import File, from_strings_to_files, get_common_directory  # noqa: F401
 from .language import Language  # noqa: F401
 from .logging import logger  # noqa: F401

--- a/src/senselab/utils/data_structures/estimate.py
+++ b/src/senselab/utils/data_structures/estimate.py
@@ -1,0 +1,122 @@
+"""A shrinkage-aware statistical estimate.
+
+A statistical review of `analyze_audio`
+(`specs/20260815-215106-analyze-audio-audit/statistical-review.md`, finding N10) measured three
+defects that share one cause: a number published without the count of things that produced it.
+
+- Adding a single low-reliability signal moved published confidence from 0.800 to 0.420 — nothing
+  in the published number said how many sources, or how reliable, produced either value.
+- A bucket backed by 4 unanimous sources and one backed by 20 both published `P = 1.000` — the
+  raw statistic saturates at unanimity regardless of sample size, so the published number could not
+  distinguish "4 agreeing sources" from "20 agreeing sources" (statistical review N3).
+- A crashed diarizer produced a confidence indistinguishable from one that ran and agreed — with no
+  `n_evidence` field, "zero contributing sources" and "several agreeing sources" render the same.
+
+`Estimate` makes all three unrepresentable: `value` is derived from `raw`, `n_evidence`, and a
+named `prior`, never supplied directly, so a caller cannot publish a number the evidence does not
+support. It has no consumers yet; wiring into `analyze_audio` outputs is Phases 2 and 3 of the
+triage graph.
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class Estimate(BaseModel):
+    """A statistic shrunk toward a named prior by the amount of evidence behind it.
+
+    `value` collapses to `prior` when `n_evidence == 0` and moves toward `raw` as `n_evidence`
+    grows, using `prior_weight` as the pseudo-count of the prior. `value` and `shrinkage` are
+    computed on read (plain `@property`, not pydantic `computed_field`) so that a caller cannot
+    construct an `Estimate` whose published value disagrees with the evidence behind it — see
+    `test_value_is_not_settable`, which pins down that `extra="forbid"` rejects a `value=` kwarg
+    even though `value` is not a declared field.
+
+    Attributes:
+        raw: The unshrunk sample statistic. `None` iff `n_evidence == 0` — there is no sample
+            statistic when nothing was observed.
+        n_evidence: Count of independent contributing sources. `>= 0`; `0` is legal and means
+            "nothing observed," not "unknown."
+        prior: What `value` collapses to as `n_evidence -> 0`.
+        prior_key: Config key naming the prior, so its derivation is findable rather than a bare
+            literal (see the "thresholds belong in `data/`" rule this codebase enforces elsewhere).
+        prior_weight: Pseudo-count `k` given to the prior in the shrinkage blend. Must be `> 0`;
+            a zero or negative weight would make the prior either inert or sign-flipping.
+        population: The population this was validated on, e.g. `"adult-read-speech"`. Required and
+            non-blank because an unstated population is how a threshold fitted on one population
+            (e.g. adults) silently reaches a recording from a different one (e.g. children).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    raw: Optional[float]
+    n_evidence: int = Field(ge=0)
+    prior: float
+    prior_key: str
+    prior_weight: float = Field(gt=0)
+    population: str
+
+    @field_validator("population")
+    @classmethod
+    def _population_not_blank(cls, v: str) -> str:
+        """Reject a blank or whitespace-only population.
+
+        An unstated population is how an adult-derived threshold reaches a child recording without
+        anyone noticing which population actually validated the number.
+        """
+        if not v.strip():
+            raise ValueError("population must not be blank")
+        return v
+
+    @model_validator(mode="after")
+    def _raw_matches_evidence(self) -> "Estimate":
+        """Enforce `raw is None` iff `n_evidence == 0`.
+
+        A fabricated `raw` with no evidence, or evidence with no sample statistic to shrink, are
+        both the "number published without the count that produced it" defect this type exists to
+        make unrepresentable (statistical review N10, F-156).
+        """
+        if self.n_evidence == 0 and self.raw is not None:
+            raise ValueError("raw must be None when n_evidence == 0 (no evidence, nothing to report as raw)")
+        if self.n_evidence > 0 and self.raw is None:
+            raise ValueError("raw must be set when n_evidence > 0 (evidence exists but no raw statistic was given)")
+        return self
+
+    @property
+    def value(self) -> float:
+        """The shrinkage-blended estimate.
+
+        `prior` when `n_evidence == 0`; otherwise the weighted average of `raw` and `prior` with
+        `n_evidence` and `prior_weight` as weights, so more evidence moves `value` toward `raw` and
+        unanimity with few sources reads as less certain than unanimity with many.
+        """
+        if self.n_evidence == 0:
+            return self.prior
+        assert self.raw is not None  # guaranteed by _raw_matches_evidence
+        return (self.n_evidence * self.raw + self.prior_weight * self.prior) / (self.n_evidence + self.prior_weight)
+
+    @property
+    def shrinkage(self) -> float:
+        """Fraction of `value` attributable to the prior rather than the evidence.
+
+        `1.0` at `n_evidence == 0` (all prior) and falls toward `0.0` as evidence accumulates.
+        """
+        return self.prior_weight / (self.n_evidence + self.prior_weight)
+
+    @classmethod
+    def no_evidence(cls, *, prior: float, prior_key: str, prior_weight: float, population: str) -> "Estimate":
+        """Build an `Estimate` for the no-evidence case.
+
+        This is the case callers build most often (nothing observed yet) and the one most easily
+        got wrong by hand (forgetting to pair `raw=None` with `n_evidence=0`), so it gets a named
+        constructor rather than leaving every call site to spell out both fields.
+        """
+        return cls(
+            raw=None,
+            n_evidence=0,
+            prior=prior,
+            prior_key=prior_key,
+            prior_weight=prior_weight,
+            population=population,
+        )

--- a/src/senselab/utils/data_structures/estimate.py
+++ b/src/senselab/utils/data_structures/estimate.py
@@ -18,9 +18,11 @@ support. It has no consumers yet; wiring into `analyze_audio` outputs is Phases 
 triage graph.
 """
 
-from typing import Optional
+import math
+from typing import Any, Mapping, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
+from typing_extensions import Self
 
 
 class Estimate(BaseModel):
@@ -32,6 +34,16 @@ class Estimate(BaseModel):
     construct an `Estimate` whose published value disagrees with the evidence behind it — see
     `test_value_is_not_settable`, which pins down that `extra="forbid"` rejects a `value=` kwarg
     even though `value` is not a declared field.
+
+    `model_copy(update=...)` is overridden to re-validate (see below) because pydantic's own
+    implementation writes straight into `__dict__` and skips every validator, which is exactly the
+    gap that let `good.model_copy(update={"n_evidence": 0})` produce an `Estimate` with `raw` still
+    set and `n_evidence == 0` — the raw/n_evidence invariant silently broken with no error.
+    `model_construct` is *not* closed the same way: it is pydantic's documented, explicit
+    validation-skipping constructor, not an API a caller reaches for by accident, so closing it
+    would fight the library rather than the defect. A reader who calls `Estimate.model_construct`
+    directly is opting out of the invariant on purpose; `model_copy(update=...)` is the one call
+    that looks safe and isn't.
 
     Attributes:
         raw: The unshrunk sample statistic. `None` iff `n_evidence == 0` — there is no sample
@@ -69,6 +81,20 @@ class Estimate(BaseModel):
             raise ValueError("population must not be blank")
         return v
 
+    @field_validator("raw", "prior")
+    @classmethod
+    def _finite(cls, v: Optional[float], info: ValidationInfo) -> Optional[float]:
+        """Reject NaN/Inf.
+
+        Reviewer minor: a non-finite `raw` or `prior` propagates silently into `value` (e.g.
+        `nan` poisons the blend, `inf` swamps it) with no validation error to say where it came
+        from — the same "published number with no traceable evidence" defect this type exists to
+        rule out, just arriving through a different door than `n_evidence`.
+        """
+        if v is not None and not math.isfinite(v):
+            raise ValueError(f"{info.field_name} must be finite, got {v!r}")
+        return v
+
     @model_validator(mode="after")
     def _raw_matches_evidence(self) -> "Estimate":
         """Enforce `raw is None` iff `n_evidence == 0`.
@@ -93,7 +119,10 @@ class Estimate(BaseModel):
         """
         if self.n_evidence == 0:
             return self.prior
-        assert self.raw is not None  # guaranteed by _raw_matches_evidence
+        if self.raw is None:  # pragma: no cover — guaranteed by _raw_matches_evidence
+            # A plain `assert` here would vanish under `python -O`, silently returning `None` where
+            # a `float` is promised. Raise instead so the invariant holds even with optimizations on.
+            raise RuntimeError("raw is None with n_evidence > 0; _raw_matches_evidence should have rejected this")
         return (self.n_evidence * self.raw + self.prior_weight * self.prior) / (self.n_evidence + self.prior_weight)
 
     @property
@@ -120,3 +149,20 @@ class Estimate(BaseModel):
             prior_weight=prior_weight,
             population=population,
         )
+
+    def model_copy(self, *, update: Optional[Mapping[str, Any]] = None, deep: bool = False) -> Self:
+        """Copy, re-validating when `update` is given.
+
+        `BaseModel.model_copy(update=...)` writes straight into `__dict__` and never re-runs a
+        validator — the pydantic docs say so explicitly ("the data is not validated before
+        creating the new model"). For most models that is a reasonable default; for this one it
+        defeats the entire point, since `good.model_copy(update={"n_evidence": 0})` would return an
+        `Estimate` with `raw` still set and `n_evidence == 0`, silently breaking the raw/n_evidence
+        invariant with no error at the one call site most likely to be reached for by a caller who
+        wants "the same estimate, but with this field changed." Routing `update` back through the
+        constructor costs one extra validation pass and closes that gap. The no-update path is
+        unaffected and delegates to `super()`.
+        """
+        if update is None:
+            return super().model_copy(deep=deep)
+        return type(self)(**{**self.model_dump(), **update})

--- a/src/tests/audio/workflows/audio_analysis/run_config_liveness_test.py
+++ b/src/tests/audio/workflows/audio_analysis/run_config_liveness_test.py
@@ -40,12 +40,18 @@ _RUN_CONFIG_FILE = (_SRC_SENSELAB / "audio" / "workflows" / "audio_analysis" / "
 # transcribe it.
 #
 # The five ``*_policy`` fields (``rounds_policy``, ``speaker_policy``, ``quality_policy``,
-# ``labelstudio_policy``, ``support_policy``) are each read exactly once outside this module: by
-# ``run_config_test.py``'s ``getattr(cfg, section)`` / ``getattr(cfg, attr)`` (its
-# ``MOVED_CONSTANTS`` and ``probes`` dicts name all five), which is real, currently-passing
-# regression coverage of the D2 migration -- not a decorative mention. Task 2's own instruction is
-# "a field read only by a test still counts as read -- say so and leave it," so none of the five
-# are deleted here; deleting any would break that test file, which is not in this task's file list.
+# ``labelstudio_policy``, ``support_policy``) have **no production reader**. Their only reader
+# anywhere is ``run_config_test.py``'s ``getattr(cfg, section)`` / ``getattr(cfg, attr)``, and that
+# file is not scanned here at all -- the sweep covers ``src/senselab/`` and ``scripts/`` only. So
+# they are unread in the sense this test measures, and a generic ``getattr`` loop over every field
+# could not distinguish a live field from a dead one in any case.
+#
+# They are kept rather than deleted for a reason that is about the fix, not about the test: the
+# register's remedy for D5-D13 is to *thread* these keys to the call sites that currently ignore
+# them (``quality.floor_percentile`` should reach ``acoustic.py``'s ``FLOOR_PERCENTILE``,
+# ``support.min_evidence_spread`` should reach ``support.py``'s constant, and so on). The field is
+# the vehicle for that fix; deleting it now means re-adding it later. What was unacceptable was the
+# silence -- a key that advertises control it does not have -- and listing it here ends that.
 #
 # This also resolves the register's apparent contradiction. Its summary counts "four dead fields
 # plus two orphaned keys inside speaker_policy," while its D3/D4 rows say ``speaker_policy`` itself
@@ -75,10 +81,9 @@ KNOWN_UNREAD = {
     "run_features",
     "run_asr",
     "run_alignment",
-    # Same dead-predecessor-of-skipped_stages family as the six above, but with one test reader:
-    # ``src/tests/scripts/analyze_audio_test.py`` asserts ``cfg.run_comparisons is False``. Same
-    # "read only by a test still counts as read" rule as the policy fields; same out-of-scope
-    # reasoning as the six above for why it is not deleted by this task.
+    # Same dead-predecessor-of-skipped_stages family as the six above. It differs only in having a
+    # test reader (``src/tests/scripts/analyze_audio_test.py`` asserts ``cfg.run_comparisons is
+    # False``), which this sweep does not see and which would not make it live if it did.
     "run_comparisons",
 }
 

--- a/src/tests/audio/workflows/audio_analysis/run_config_liveness_test.py
+++ b/src/tests/audio/workflows/audio_analysis/run_config_liveness_test.py
@@ -1,0 +1,137 @@
+"""Every ``RunConfig`` field must have a reader.
+
+``remediation-config.md`` found four policy fields that ``_build()`` assigned and nothing
+consumed. An operator setting such a key gets a changed config hash and no behaviour change,
+which is worse than a bare literal because it looks like control. This test fails when a new
+one appears.
+
+Detection is AST-based: an attribute access ``.<field>`` or a ``getattr(obj, "<field>")`` call,
+found anywhere under ``src/senselab/`` or ``scripts/`` except ``run_config.py`` itself. Excluding
+that whole file is sufficient to skip both the field's own declaration and ``_build()``'s
+keyword-argument assignment -- neither is an ``ast.Attribute`` node nor a ``getattr`` call, so no
+extra special-casing is needed. Comments and docstring prose are invisible to ``ast``, unlike a
+plain-text grep, so a field merely *mentioned* in a comment does not count as read.
+
+One blind spot, stated rather than silently accepted: the checker matches the field *name*, not
+"``RunConfig``'s ``foo`` specifically" -- it has no type information and cannot tell whose
+``.foo`` a given access belongs to. A field whose name coincides with another class's attribute
+could therefore read as "read" without any ``RunConfig`` instance ever being touched. None of the
+fields below collide with anything else in the tree (checked by hand during Phase 1 Task 2, by
+grepping each name across the whole repository); a future field with a very generic name should
+get the same check before its "read" verdict is trusted.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+from pathlib import Path
+
+from senselab.audio.workflows.audio_analysis.run_config import RunConfig
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SRC_SENSELAB = _REPO_ROOT / "src" / "senselab"
+_SCRIPTS = _REPO_ROOT / "scripts"
+_RUN_CONFIG_FILE = (_SRC_SENSELAB / "audio" / "workflows" / "audio_analysis" / "run_config.py").resolve()
+
+# Fields ``_build()`` assigns that nothing under ``src/senselab/`` or ``scripts/`` reads. Verified
+# by hand for Phase 1 Task 2 (2026-08-16), not inherited from the audit unchecked -- see the plan's
+# own instruction to resolve the register's speaker_policy discrepancy with evidence rather than
+# transcribe it.
+#
+# The five ``*_policy`` fields (``rounds_policy``, ``speaker_policy``, ``quality_policy``,
+# ``labelstudio_policy``, ``support_policy``) are each read exactly once outside this module: by
+# ``run_config_test.py``'s ``getattr(cfg, section)`` / ``getattr(cfg, attr)`` (its
+# ``MOVED_CONSTANTS`` and ``probes`` dicts name all five), which is real, currently-passing
+# regression coverage of the D2 migration -- not a decorative mention. Task 2's own instruction is
+# "a field read only by a test still counts as read -- say so and leave it," so none of the five
+# are deleted here; deleting any would break that test file, which is not in this task's file list.
+#
+# This also resolves the register's apparent contradiction. Its summary counts "four dead fields
+# plus two orphaned keys inside speaker_policy," while its D3/D4 rows say ``speaker_policy`` itself
+# "is built and never read anywhere else in the tree." Both readings under-describe the same fact:
+# ``speaker_policy`` has *exactly* the same status as the other four -- no reader outside
+# ``run_config.py`` other than this one test file. It is not a fifth, distinctly-dead field, and it
+# is not distinctly alive either. The audit's own D14 grep ("confirmed... zero hits") missed this
+# because it matched a literal ``.rounds_policy``-shaped pattern, which does not match
+# ``getattr(cfg, attr)`` where ``attr`` is a runtime string -- the exact trap this file's docstring
+# names for AST-based detection.
+KNOWN_UNREAD = {
+    "rounds_policy",
+    "speaker_policy",
+    "quality_policy",
+    "labelstudio_policy",
+    "support_policy",
+    # Discovered during this same verification sweep, not among remediation-config.md's D5-D14/D3-D4
+    # candidates Task 2 was scoped to resolve. These six have *zero* readers anywhere in the tree --
+    # not even a test -- a stricter kind of dead than the five policy fields above.
+    # ``RunConfig.skipped_stages`` (built in the same ``_build()`` from the same ``stages:`` YAML
+    # block) is what production actually branches on; these booleans are its unused predecessor.
+    # Left here rather than deleted because deleting them was not this task's brief; flagged for its
+    # own register finding rather than folded silently into this one.
+    "run_diarization",
+    "run_ast",
+    "run_yamnet",
+    "run_features",
+    "run_asr",
+    "run_alignment",
+    # Same dead-predecessor-of-skipped_stages family as the six above, but with one test reader:
+    # ``src/tests/scripts/analyze_audio_test.py`` asserts ``cfg.run_comparisons is False``. Same
+    # "read only by a test still counts as read" rule as the policy fields; same out-of-scope
+    # reasoning as the six above for why it is not deleted by this task.
+    "run_comparisons",
+}
+
+
+def _iter_python_files() -> list[Path]:
+    """Every ``.py`` file under ``src/senselab/`` or ``scripts/``, excluding ``run_config.py`` itself."""
+    files = list(_SRC_SENSELAB.rglob("*.py")) + list(_SCRIPTS.glob("*.py"))
+    return [p for p in files if p.resolve() != _RUN_CONFIG_FILE]
+
+
+def _read_field_names(paths: list[Path]) -> set[str]:
+    """Field names obtained via ``.field`` attribute access or ``getattr(obj, "field")`` in ``paths``."""
+    found: set[str] = set()
+    for path in paths:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute):
+                found.add(node.attr)
+            elif (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "getattr"
+                and len(node.args) >= 2
+                and isinstance(node.args[1], ast.Constant)
+                and isinstance(node.args[1].value, str)
+            ):
+                found.add(node.args[1].value)
+    return found
+
+
+def test_every_runconfig_field_has_a_reader_or_is_known_unread() -> None:
+    """A ``RunConfig`` field with no reader outside ``run_config.py`` is a decision with no effect.
+
+    ``KNOWN_UNREAD`` is the escape hatch for a field Task 2's Step 1 found genuinely unread in
+    production but chose not to delete -- see its comment for why each entry is there. A field
+    landing here that is in neither the read set nor ``KNOWN_UNREAD`` is new and must be either
+    wired to a real call site or deleted, not silently left uncovered.
+    """
+    read = _read_field_names(_iter_python_files())
+    declared = {f.name for f in dataclasses.fields(RunConfig)}
+    unread = sorted(declared - read - KNOWN_UNREAD)
+    assert not unread, (
+        f"RunConfig field(s) with no reader outside run_config.py and not in KNOWN_UNREAD: {unread}. "
+        "Either thread it to a real call site or add it to KNOWN_UNREAD with the reason."
+    )
+
+
+def test_known_unread_has_no_stale_entries() -> None:
+    """A ``KNOWN_UNREAD`` entry that gained a reader (or lost its field) should be noticed, not kept quietly."""
+    read = _read_field_names(_iter_python_files())
+    declared = {f.name for f in dataclasses.fields(RunConfig)}
+    stale = sorted((KNOWN_UNREAD - declared) | (KNOWN_UNREAD & read))
+    assert not stale, f"KNOWN_UNREAD entr(ies) no longer belong here (field gone, or now read): {stale}"

--- a/src/tests/utils/data_structures/estimate_test.py
+++ b/src/tests/utils/data_structures/estimate_test.py
@@ -1,5 +1,7 @@
 """Tests for the Estimate type."""
 
+import math
+
 import pytest
 from pydantic import ValidationError
 
@@ -13,6 +15,7 @@ def _est(**kw: object) -> Estimate:
 
 
 def test_no_evidence_collapses_to_the_prior() -> None:
+    """With nothing observed, the published value must be exactly the named prior, not a blend."""
     e = Estimate(raw=None, n_evidence=0, prior=0.42, prior_key="k", prior_weight=2.0, population="p")
     assert e.value == 0.42
 
@@ -24,16 +27,19 @@ def test_a_raw_value_without_evidence_is_rejected() -> None:
 
 
 def test_evidence_without_a_raw_value_is_rejected() -> None:
+    """Evidence with nothing to shrink is the same defect as raw with no evidence, mirrored."""
     with pytest.raises(ValidationError):
         _est(raw=None, n_evidence=3)
 
 
 def test_negative_evidence_is_rejected() -> None:
+    """Evidence count is a count; a negative one is a bug upstream, not a valid estimate."""
     with pytest.raises(ValidationError):
         _est(n_evidence=-1)
 
 
 def test_a_non_positive_prior_weight_is_rejected() -> None:
+    """A zero or negative pseudo-count would make the prior inert or sign-flipping in the blend."""
     with pytest.raises(ValidationError):
         _est(prior_weight=0.0)
 
@@ -53,23 +59,57 @@ def test_four_and_twenty_unanimous_sources_differ() -> None:
 
 
 def test_more_evidence_moves_the_value_toward_raw() -> None:
+    """Value must move monotonically toward raw as evidence accumulates, never overshoot it."""
     values = [_est(raw=1.0, n_evidence=n, prior=0.0, prior_weight=1.0).value for n in (1, 2, 8, 64)]
     assert values == sorted(values)
     assert values[-1] < 1.0
 
 
 def test_shrinkage_reports_how_much_of_the_value_is_prior() -> None:
+    """Shrinkage is the prior's literal share of the blend, not a free-floating confidence score."""
     assert _est(n_evidence=1, prior_weight=1.0).shrinkage == pytest.approx(0.5)
     assert _est(n_evidence=9, prior_weight=1.0).shrinkage == pytest.approx(0.1)
-    assert Estimate(
-        raw=None, n_evidence=0, prior=0.1, prior_key="k", prior_weight=3.0, population="p"
-    ).shrinkage == 1.0
+    assert Estimate(raw=None, n_evidence=0, prior=0.1, prior_key="k", prior_weight=3.0, population="p").shrinkage == 1.0
 
 
 def test_value_is_not_settable() -> None:
     """A published value that disagrees with its own evidence is the defect this type prevents."""
     with pytest.raises((ValidationError, AttributeError, TypeError)):
         Estimate(  # type: ignore[call-arg]
-            raw=1.0, n_evidence=1, prior=0.0, prior_key="k",
-            prior_weight=1.0, population="p", value=0.999,
+            raw=1.0,
+            n_evidence=1,
+            prior=0.0,
+            prior_key="k",
+            prior_weight=1.0,
+            population="p",
+            value=0.999,
         )
+
+
+def test_model_copy_with_update_cannot_bypass_the_raw_evidence_invariant() -> None:
+    """Pydantic's own model_copy(update=...) skips validators; this type cannot allow that gap."""
+    good = _est(raw=1.0, n_evidence=1)
+    with pytest.raises(ValidationError):
+        good.model_copy(update={"n_evidence": 0})
+
+
+def test_model_copy_with_a_valid_update_still_works() -> None:
+    """Overriding model_copy to re-validate must not break the ordinary, invariant-preserving case."""
+    original = _est(population="adult-read-speech")
+    copy = original.model_copy(update={"population": "child-read-speech"})
+    assert copy.population == "child-read-speech"
+    assert copy.value == original.value
+
+
+def test_non_finite_raw_is_rejected() -> None:
+    """A NaN or infinite raw would poison value silently; reject it at construction instead."""
+    with pytest.raises(ValidationError):
+        _est(raw=math.nan)
+    with pytest.raises(ValidationError):
+        _est(raw=math.inf)
+
+
+def test_non_finite_prior_is_rejected() -> None:
+    """The prior is what value collapses to at zero evidence; it must be an ordinary finite number."""
+    with pytest.raises(ValidationError):
+        _est(prior=math.nan, n_evidence=0, raw=None)

--- a/src/tests/utils/data_structures/estimate_test.py
+++ b/src/tests/utils/data_structures/estimate_test.py
@@ -1,0 +1,75 @@
+"""Tests for the Estimate type."""
+
+import pytest
+from pydantic import ValidationError
+
+from senselab.utils.data_structures import Estimate
+
+
+def _est(**kw: object) -> Estimate:
+    base = dict(raw=1.0, n_evidence=1, prior=0.5, prior_key="k", prior_weight=1.0, population="p")
+    base.update(kw)
+    return Estimate(**base)  # type: ignore[arg-type]
+
+
+def test_no_evidence_collapses_to_the_prior() -> None:
+    e = Estimate(raw=None, n_evidence=0, prior=0.42, prior_key="k", prior_weight=2.0, population="p")
+    assert e.value == 0.42
+
+
+def test_a_raw_value_without_evidence_is_rejected() -> None:
+    """F-156: a fabricated number and a measured one must not be the same object."""
+    with pytest.raises(ValidationError):
+        _est(raw=0.5, n_evidence=0)
+
+
+def test_evidence_without_a_raw_value_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _est(raw=None, n_evidence=3)
+
+
+def test_negative_evidence_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _est(n_evidence=-1)
+
+
+def test_a_non_positive_prior_weight_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _est(prior_weight=0.0)
+
+
+def test_an_empty_population_is_rejected() -> None:
+    """An unstated population is how an adult-derived threshold reaches a child recording."""
+    with pytest.raises(ValidationError):
+        _est(population="  ")
+
+
+def test_four_and_twenty_unanimous_sources_differ() -> None:
+    """Statistical review N3: both published P = 1.000 before this type existed."""
+    four = _est(raw=1.0, n_evidence=4, prior=0.5, prior_weight=1.0)
+    twenty = _est(raw=1.0, n_evidence=20, prior=0.5, prior_weight=1.0)
+    assert four.value != twenty.value
+    assert four.value < twenty.value < 1.0
+
+
+def test_more_evidence_moves_the_value_toward_raw() -> None:
+    values = [_est(raw=1.0, n_evidence=n, prior=0.0, prior_weight=1.0).value for n in (1, 2, 8, 64)]
+    assert values == sorted(values)
+    assert values[-1] < 1.0
+
+
+def test_shrinkage_reports_how_much_of_the_value_is_prior() -> None:
+    assert _est(n_evidence=1, prior_weight=1.0).shrinkage == pytest.approx(0.5)
+    assert _est(n_evidence=9, prior_weight=1.0).shrinkage == pytest.approx(0.1)
+    assert Estimate(
+        raw=None, n_evidence=0, prior=0.1, prior_key="k", prior_weight=3.0, population="p"
+    ).shrinkage == 1.0
+
+
+def test_value_is_not_settable() -> None:
+    """A published value that disagrees with its own evidence is the defect this type prevents."""
+    with pytest.raises((ValidationError, AttributeError, TypeError)):
+        Estimate(  # type: ignore[call-arg]
+            raw=1.0, n_evidence=1, prior=0.0, prior_key="k",
+            prior_weight=1.0, population="p", value=0.999,
+        )


### PR DESCRIPTION
Phase 1 of the triage graph (`specs/20260816-143540-triage-graph/design.md`, on #557). Two foundations, disjoint files, no new outputs and no file moves.

## `Estimate` — an evidence count you cannot drop

A Bayesian review of `analyze_audio` measured three defects sharing one cause: a number published without the count of things that produced it. Adding a *low-reliability* signal moved confidence 0.800 → 0.420; buckets backed by 4 and by 20 unanimous sources both published `P = 1.000`; a crashed diarizer was indistinguishable from an agreeing one.

`Estimate` makes all three unrepresentable. `value` is a computed property, never a field, so it cannot disagree with its own evidence:

```
value = prior                                    if n_evidence == 0
value = (n*raw + k*prior) / (n + k)              otherwise
```

Measured on this branch: 4 unanimous → `0.900`, 20 unanimous → `0.976`. `raw` must be `None` exactly when `n_evidence == 0`, so a fabricated `0.5` and a measured `0.5` are different objects. `population` records what the estimate was validated on — this is where the audit's adult-derived findings will surface per-output.

Review found one Critical, now fixed: `model_copy(update={"n_evidence": 0})` bypassed the invariant entirely, since `frozen=True` blocks attribute assignment but does not re-run validators. `model_copy` now re-validates. `model_construct` is left open as pydantic's documented escape hatch, and the docstring says so.

No consumers yet — wiring is Phases 2 and 3.

## RunConfig liveness guard — 12 dead fields, none deleted

The config inventory predicted 4 dead policy fields. An AST sweep over `src/senselab/` and `scripts/` found **12**:

- the 5 `*_policy` fields. This resolves a contradiction in the inventory: `speaker_policy` is neither a distinct fifth dead field nor alive — it has *identical* status to the other four. The original "zero hits" grep missed all five the same way, matching a literal `.fieldname` pattern that cannot see `getattr(cfg, attr)` with a runtime string.
- **six `run_*` booleans the inventory never found**: `run_diarization`, `run_ast`, `run_yamnet`, `run_features`, `run_asr`, `run_alignment`. They are parsed from the `stages:` YAML and never read. **The `stages:` block still works** — production branches on `cfg.skipped_stages`, built from the same YAML — so these are a dead duplicate parse, not a broken knob.
- `run_comparisons`, same family.

**Nothing is deleted, deliberately.** The register's remedy for D5–D13 is to *thread* these keys to the call sites that currently ignore them (`quality.floor_percentile` should reach `acoustic.py`'s `FLOOR_PERCENTILE`); the field is the vehicle for that fix. What was unacceptable was the silence — a key advertising control it does not have — and the guard ends that. It fails on any new unread field.

`default.yaml` is untouched: deleting those sections would destroy the record of what was meant to be configurable.

## Scope change from the design

The layer-1 extraction lift was in Phase 1 and has moved to Phase 2. Its stated justification did not survive measurement: the package's lazy PEP-562 `__getattr__` already prevents the import cost cited (`contracts` and `adaptive` stay provably unloaded), while the real closure of `stages.py` + `stage_context.py` is 14 modules / 5,523 lines reaching `axes.py`, not the 2 files assumed. The boundary is better drawn in Phase 2 alongside the chains than first, in isolation, on a bad estimate.

## Verification

- `src/tests/utils/` — 325 passed, 5 skipped
- `src/tests/audio/workflows/audio_analysis/` — 1416 passed, 3 skipped
- `pre-commit run --all-files` — 17 hooks green, verified directly rather than on report (an earlier "green" claim in this branch's history was false and caught by two independent checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)