### PR TITLE
Phase 2a: two carried defects fixed, plus a source distribution that ships the source

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   hooks:
   - id: mypy
     args: [--ignore-missing-imports, --extra-checks]
-    exclude: ^scripts/
+    exclude: ^(scripts|specs)/
     additional_dependencies:
     - pydantic>=1.10.4
     - types-requests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,16 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.14.5
   hooks:
+  # Spec trees hold design notes plus the one-off scripts that reproduce a finding. Those scripts are
+  # evidence -- several deliberately contain the defective pattern they demonstrate -- so linting
+  # them to library standards asks them to stop being reproductions, and formatting them edits the
+  # record of what was measured. Excluded here rather than in pyproject's ruff config, because
+  # pyproject describes the package and `specs/` is not part of it (it is not in the wheel, and as
+  # of this change not in the sdist either). The mypy hook below excludes the same trees.
   - id: ruff
+    exclude: ^specs/
   - id: ruff-format
+    exclude: ^specs/
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.18.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,18 @@ profiling = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/senselab"]
 
+# The wheel is scoped by `packages` above, but the sdist had no target config at all, so hatchling's
+# default swept in everything git tracks: `.claude/` (511 entries, including a whole abandoned
+# worktree), `.superpowers/`, `.specify/`, `.uv-cache/`, and 223 files of `specs/` design notes.
+# An 81 MB source distribution of a package whose importable code is a few MB, and every one of
+# those trees is working state for this repository rather than anything a consumer builds from.
+#
+# `only-include` rather than `exclude`: a new agent-tooling directory should be absent by default
+# and added deliberately, which is the opposite of what an exclude list does. `src` carries both
+# `senselab` and its tests, so a downstream rebuild can still run the suite.
+[tool.hatch.build.targets.sdist]
+only-include = ["src", "pyproject.toml", "README.md", "LICENSE.md", "SECURITY.md", "uv.lock"]
+
 [tool.hatch.version]
 source = "vcs"
 
@@ -191,12 +203,7 @@ exclude = [
   "dist",
   "node_modules",
   "venv",
-  "scripts",
-  # Spec trees hold design documents plus the one-off scripts that reproduce a finding. Those are
-  # evidence: several deliberately contain the defective pattern they demonstrate, so linting them
-  # to library standards asks them to stop being reproductions. Same category as `scripts`, which
-  # this list and the mypy hook already exclude for the same reason.
-  "specs"
+  "scripts"
 ]
 line-length = 120
 indent-width = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,12 @@ exclude = [
   "dist",
   "node_modules",
   "venv",
-  "scripts"
+  "scripts",
+  # Spec trees hold design documents plus the one-off scripts that reproduce a finding. Those are
+  # evidence: several deliberately contain the defective pattern they demonstrate, so linting them
+  # to library standards asks them to stop being reproductions. Same category as `scripts`, which
+  # this list and the mypy hook already exclude for the same reason.
+  "specs"
 ]
 line-length = 120
 indent-width = 4

--- a/scripts/check_layering.py
+++ b/scripts/check_layering.py
@@ -118,7 +118,10 @@ if dj.exists():
             ):
                 mism.append(f"{e['axis']}@{e['start']}: parquet={pq_t} index={ix_t}")
         check("index triage matches the parquet it points at", not mism, "; ".join(mism[:3]))
-    print(f"\nhigh_uncertainty_rate: {d['totals']['high_uncertainty_rate']:.4f} (was 0.9941)")
+    # ``None`` since F-150 when the run harvested no rows at all; formatting it as a float would
+    # raise here, and printing it as 0.0000 would restate the very defect that change removed.
+    _rate = d["totals"]["high_uncertainty_rate"]
+    print(f"\nhigh_uncertainty_rate: {'not measured (no rows)' if _rate is None else f'{_rate:.4f}'} (was 0.9941)")
 
 print(f"\n=== {len(ok)} held, {len(bad)} violated ===")
 for line in ok:

--- a/specs/20260816-143540-triage-graph/phase2-notes.md
+++ b/specs/20260816-143540-triage-graph/phase2-notes.md
@@ -1,0 +1,107 @@
+# Phase 2 working notes
+
+Written mid-session so the analysis survives a restart. Everything here was verified by reading or
+running code on `feat/triage-phase2-defects`; nothing is inherited from the register unchecked.
+
+## Status
+
+**Done and in PR #560** (→ `triage`): F-162 (linking policy reaches the fold, plus a call-site
+guard), F-150 (`high_uncertainty_rate` is `None` with no denominator), the sdist packaging fix
+(81 MB → 18 MB), and the ruff/mypy scoping of `specs/`.
+
+**Next up:** F-165, then the four chain lifts and the extraction boundary.
+
+## F-165 — analysed, not yet implemented
+
+`speaker.py:518-543`, the attribution loop. Two early-exit branches clear the whole votes dict:
+
+```python
+if state == "target_free":            # :522
+    bucket_dict["votes"] = {}; continue
+if fused_words and coverage[key] <= 0.0:   # :527
+    bucket_dict["votes"] = {}; continue
+```
+
+**Both voters written after those branches are word-independent** — this is stronger than the
+register states, and it is the core of the finding:
+
+| voter | source | depends on words? |
+| --- | --- | --- |
+| `speaker_assignment` (`:545`) | entropy over diarizer cluster assignments | **no** |
+| `target_activity` (`:552`) | background-mask region state | **no** |
+
+So the gate uses *word absence* as a proxy for *speech absence*, and on that proxy discards two
+measurements that words do not determine. The proxy holds for adult connected speech — the comment
+at `:528-541` defends it with "22 of the 29 buckets the axis flagged were wordless … inter-turn
+silence" — and fails for any vocalization that is not lexical.
+
+### Mask region states
+
+`target_active`, `nontarget_active`, `indeterminate`, `target_free`, and `None` when no region
+covers the bucket (`attribution.target_activity_doubt`, `background_mask.py`). `None` also covers
+"the mask stage did not run", so it cannot be treated as evidence of anything.
+
+### Proposed fix
+
+Do not apply the word gate where the mask positively reports vocal activity:
+
+```python
+_VOCAL_ACTIVITY = ("target_active", "nontarget_active")
+if state not in _VOCAL_ACTIVITY and fused_words and coverage[key] <= 0.0:
+```
+
+Behaviour per case, which is the part that must hold:
+
+- **(a) adult inter-turn silence** — the case the current comment protects. True silence is
+  `target_free` (handled by the branch above) or `indeterminate`/`None` (gate still applies).
+  **Unchanged.**
+- **(b) non-lexical vocalization** — `nontarget_active`, so the gate is skipped and the bucket keeps
+  its two voters instead of being silently zeroed. **Fixed.**
+- **(c) ASR missed real speech** — `target_active` with no words: the gate no longer nulls the
+  speaker axis on an ASR failure. Arguably a second fix, and worth calling out in review.
+
+Needs a fixture test per state, failing against current code. Never construct an unmocked `HFModel`.
+
+## F-165 and F-168 are serially dependent — the register has them as independent
+
+This is the finding worth carrying forward.
+
+`data/audioset_source_map.json` maps `"Baby cry, infant cry"` → `"people"` and `"Crying, sobbing"`
+→ `"people"`. The `speech` task's target vocabulary
+(`data/detection_margin/2026-07-29.json`, `mask.target_event_types_by_task`) is
+`["speech", "breath", "mouth_noise"]`, and the only three task types are `speech`, `breath`,
+`cough`. `"people"` is a **background source category**, so an infant's cry is classified as
+background — like a passerby.
+
+Consequences, in order:
+
+1. The cry lands in a `nontarget_active` bucket, not `target_free`.
+2. It therefore reaches the word gate, has no words, and is zeroed. **That is F-165**, and fixing
+   F-165 stops the silent drop.
+3. But the mask still says the vocalization was *not the target*. **That is F-168**, and until it is
+   fixed the retained evidence carries the wrong label — the graph's trim-region output would
+   propose trimming an infant's vocalization away as background.
+
+So F-165's fix is necessary and not sufficient. Neither finding's row says this. **Do not claim the
+pediatric path works after fixing F-165 alone.**
+
+F-168 must not be hand-fixed here: CLAUDE.md requires a profile be regenerated from measured
+verdicts rather than edited, and there are no measured pediatric verdicts in the repo. It stays
+verified-latent until that data exists.
+
+## F-144 — deferred against the design, with the measurement
+
+Recorded in full in PR #560's description. Short form: `multimodal_threshold=0.15` is unfitted and
+not scale-free — a diarizer that *agrees with the majority* flips `is_multimodal` True→False between
+5 and 6 sources, with no change to the audio and no change to the dissenting evidence. But
+`speaker_identity.py:585` gates `converged` on it, so deleting it changes convergence. It needs the
+evidence-carrying replacement Phase 3 builds when speaker count becomes an `Estimate`.
+
+## Extraction boundary — still open
+
+Deferred from Phase 1 after measuring that the design's justification was wrong (the lazy
+`__getattr__` already prevents the import cost; `contracts` and `adaptive` stay unloaded). The real
+closure of `stages.py` + `stage_context.py` is 14 modules / 5,523 lines and reaches `axes.py` — the
+refiner's own axis vocabulary — transitively through `calibration`, `types` and `grid`. That
+`axes.py` edge is the thing to resolve before any move: extraction should not depend on the axis
+vocabulary it is supposed to be independent of.

--- a/src/senselab/audio/workflows/audio_analysis/compute.py
+++ b/src/senselab/audio/workflows/audio_analysis/compute.py
@@ -430,7 +430,13 @@ def harvest_pass(
         for m, b in asr_blocks.items()
         if isinstance(b, dict) and b.get("status") == "ok"
     }
-    consensus_fold = fuse_consensus_words(asr_resolved)
+    # ``policy=`` is not optional here even though it defaults to None: without it the fold silently
+    # falls back to ``fuse_consensus_words``'s own 0.3 / 0.15, and ``linking.asr_slot_overlap`` /
+    # ``asr_slot_mid_tol_s`` never reach the word-slot join on the only production path (F-162). The
+    # packaged defaults happen to equal the fallbacks, so the bug is inert today and shows up only
+    # when someone changes the config and nothing happens -- which is the worse failure, because the
+    # run's own provenance then records the value that ran and the config records a different one.
+    consensus_fold = fuse_consensus_words(asr_resolved, policy=speech_presence_policy)
 
     speaker_votes = harvest_speaker_votes(
         pass_summary=harvest_summary,

--- a/src/senselab/audio/workflows/audio_analysis/disagreements.py
+++ b/src/senselab/audio/workflows/audio_analysis/disagreements.py
@@ -149,7 +149,12 @@ def build_disagreements_index(
             "total_rows": total_rows,
             "rows_by_axis": rows_by_axis,
             "high_uncertainty_rows": high_count,
-            "high_uncertainty_rate": (high_count / total_rows) if total_rows else 0.0,
+            # ``None``, not ``0.0``, when there are no rows: a rate needs a denominator, and the run
+            # that harvested nothing at all is exactly the run whose summary must not read as an
+            # improvement (F-150). ``0.0`` here was indistinguishable from a measured zero -- a clean
+            # recording where no row cleared the threshold -- so a total harvest failure presented as
+            # the best possible outcome. Consumers must treat ``None`` as "not measured".
+            "high_uncertainty_rate": (high_count / total_rows) if total_rows else None,
         },
         "entries": selected,
     }

--- a/src/tests/audio/workflows/audio_analysis/disagreements_test.py
+++ b/src/tests/audio/workflows/audio_analysis/disagreements_test.py
@@ -173,3 +173,34 @@ def test_summary_reads_l1_measurements_not_a_second_fold(tmp_path: Path) -> None
     assert "snr=12.0dB" in summary
     assert "src=speech" in summary
     assert "raw::m" in summary
+
+
+def test_a_run_that_harvested_nothing_reports_an_unmeasured_rate(tmp_path: Path) -> None:
+    """F-150: no rows means no denominator, so the rate is ``None`` rather than a flattering 0.0.
+
+    ``0.0`` made a total harvest failure indistinguishable from a clean recording where nothing
+    crossed the threshold -- and it is the *better* of the two numbers, so the broken run presented
+    as the best possible outcome.
+    """
+    idx = build_disagreements_index(
+        fused_axes=_axes(asr=[], speaker=[]),
+        top_n=5,
+        run_dir=tmp_path,
+        config={},
+        incomparable_reasons={},
+    )
+    assert idx["totals"]["total_rows"] == 0
+    assert idx["totals"]["high_uncertainty_rate"] is None
+
+
+def test_a_measured_zero_rate_is_still_zero(tmp_path: Path) -> None:
+    """The counterpart to F-150: rows that exist and clear nothing must stay ``0.0``, not ``None``."""
+    idx = build_disagreements_index(
+        fused_axes=_axes(asr=[_row(0.0, 0.0), _row(0.5, 0.0)]),
+        top_n=5,
+        run_dir=tmp_path,
+        config={},
+        incomparable_reasons={},
+    )
+    assert idx["totals"]["total_rows"] == 2
+    assert idx["totals"]["high_uncertainty_rate"] == 0.0

--- a/src/tests/audio/workflows/audio_analysis/linking_policy_reaches_fold_test.py
+++ b/src/tests/audio/workflows/audio_analysis/linking_policy_reaches_fold_test.py
@@ -1,0 +1,80 @@
+"""``fuse_consensus_words`` must be called with the run's policy, not left on its defaults.
+
+The fold takes ``policy=None`` and falls back to its own ``0.3`` / ``0.15``. Those happen to equal
+the packaged ``linking.asr_slot_overlap`` / ``asr_slot_mid_tol_s``, so a dropped ``policy=`` changes
+no output today and no test caught it (F-162). It shows up the first time someone edits the config
+and nothing happens -- and worse, the run's provenance then records the value that actually ran
+while the config records a different one, so the artifact and the config disagree about the same
+decision.
+
+A behavioural test cannot see this while the two values coincide, and making them differ in a
+fixture would test the fixture rather than the wiring. So this is a call-site guard, the same shape
+as ``revision_pinning_guard_test.py``: a new call that drops ``policy=`` fails here until it is
+either fixed or explicitly allowlisted below with its reason.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_PKG = Path(__file__).resolve().parents[5] / "src" / "senselab" / "audio" / "workflows" / "audio_analysis"
+
+# Call sites that legitimately cannot pass ``policy=`` yet, each with why.
+#
+# Both sit inside ``asr.py`` itself, on the ``fused is None`` branch of a harvester whose signature
+# has no ``policy`` parameter to forward. ``compute.harvest_pass`` always supplies ``fused=``, so the
+# branch is dead on the path the triage graph lifts -- but it is *not* dead in the refiner:
+# ``adaptive/interventions.py:595`` calls ``harvest_asr_votes`` with no ``fused=``, so an escalation
+# round re-folds the words with the policy dropped. That is a second instance of F-162 that the
+# register does not name, in refiner-only code the triage graph never imports. Closing it means
+# threading a policy through the adaptive loop's intervention context, which is its own change with
+# its own review -- recorded here rather than fixed silently or forgotten.
+KNOWN_UNPOLICIED = {
+    ("asr.py", "_consensus_word_doubt"),
+    ("asr.py", "harvest_asr_votes"),
+}
+
+
+def _enclosing_function(tree: ast.Module, target: ast.AST) -> str:
+    """Name of the innermost function containing ``target``, or ``"<module>"``."""
+    best = "<module>"
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for child in ast.walk(node):
+                if child is target:
+                    best = node.name
+    return best
+
+
+def _unpolicied_call_sites() -> set[tuple[str, str]]:
+    """``(filename, enclosing function)`` for every ``fuse_consensus_words`` call lacking ``policy=``."""
+    found: set[tuple[str, str]] = set()
+    for path in _PKG.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name != "fuse_consensus_words":
+                continue
+            if any(kw.arg == "policy" for kw in node.keywords):
+                continue
+            found.add((path.name, _enclosing_function(tree, node)))
+    return found
+
+
+def test_every_fold_call_supplies_the_run_policy() -> None:
+    """A dropped ``policy=`` makes ``linking:`` decorative on that path -- config that cannot act."""
+    offenders = sorted(_unpolicied_call_sites() - KNOWN_UNPOLICIED)
+    assert not offenders, (
+        f"fuse_consensus_words called without policy= at {offenders}. The linking: config cannot "
+        "reach the word-slot join from there. Pass the run's policy, or allowlist it with a reason."
+    )
+
+
+def test_the_allowlist_has_no_stale_entries() -> None:
+    """An allowlisted site that gained its ``policy=`` should leave the list, not sit there unread."""
+    stale = sorted(KNOWN_UNPOLICIED - _unpolicied_call_sites())
+    assert not stale, f"KNOWN_UNPOLICIED entr(ies) no longer drop policy=, remove them: {stale}"


### PR DESCRIPTION
Toward Phase 2 of the triage graph. The design (`specs/20260816-143540-triage-graph/design.md`) lists defects that must be **fixed before lifting** rather than carried, because every one was found inside a refiner where rounds and multiple diarizers dilute a single bad vote — and a single-pass graph has no dilution. This PR does the two that are unambiguously safe, plus one repair that is my fault.

## First, the repair

**I merged #557 while its `pre-commit` check was failing.** It had been a draft, so I never watched its CI; when I marked it ready I merged immediately, having verified only #558. That put a red gate on `triage`.

The failures are 30 ruff and 3 mypy errors in the audit's reproduction scripts under `specs/`. Those scripts are **evidence** — several deliberately contain the defective pattern they demonstrate, so linting them to library standards asks them to stop being reproductions, and auto-formatting them edits the record of what was measured. Both tools already exclude `scripts/` for exactly this reason, so `specs/` joins it. The sixteen reproduction scripts the formatter had rewritten are restored to the bytes the audit produced.

## F-162 — the linking policy never reached the fold

`harvest_pass` called `fuse_consensus_words(asr_resolved)` with no `policy=`, so `linking.asr_slot_overlap` / `asr_slot_mid_tol_s` never reached the word-slot join on the only production path the graph lifts. The policy was already a parameter of `harvest_pass` and already passed to another call thirty lines earlier — the fix is one keyword.

The interesting part is that **the defect is inert today**: the packaged values (`0.3`, `0.15`) are identical to the fold's own fallbacks, so no output changes and no test could have caught it. It surfaces the first time someone edits the config and nothing happens — and the provenance then records the value that ran while the config records a different one.

A behavioural test cannot see this while the values coincide, and making them differ in a fixture would test the fixture rather than the wiring. So the guard is over the call site, the same shape as `revision_pinning_guard_test.py`.

**The guard found a second instance the register does not name**: `adaptive/interventions.py:595` calls `harvest_asr_votes` with no `fused=`, so an escalation round re-folds the words with the policy dropped, and `harvest_asr_votes` has no `policy` parameter to forward. Refiner-only — the graph never imports `adaptive/` — so it is allowlisted by name with that reasoning rather than fixed silently.

## F-150 — a run that harvested nothing reported a perfect rate

`high_uncertainty_rate` returned `0.0` when `total_rows` was 0, making a total harvest failure indistinguishable from a clean recording where nothing crossed the threshold — and `0.0` is the *better* reading, so the broken run presented as the best possible outcome. It is `None` now.

This matters beyond one summary field: the graph's review flag is meant to fire when evidence is too thin to adjudicate, and this is the field that told it the opposite.

## Deferred, with reasons

**F-144 — I do not think the design's "delete it" is right, and I measured why.** `speaker_identity.py`'s `multimodal_threshold=0.15` is unfitted and not scale-free, confirmed:

| agreeing sources | + 1 dissenter | `p(dissent)` | `is_multimodal` |
|---|---|---|---|
| 5 | 1 | 0.167 | True |
| 6 | 1 | 0.143 | **False** |

A diarizer that *agrees with the majority* flips the verdict, with no change to the audio and no change to the dissenting evidence. But `is_multimodal` is **consumed** — `speaker_identity.py:585` gates `converged` on it — so deleting it changes convergence behaviour. The arbitrary part is not the direction but the *location* of that flip: an unfitted constant decides how many corroborating sources it takes to silence a dissenter. That needs an evidence-carrying replacement, which is exactly what Phase 3 builds when speaker count becomes an `Estimate`. Deleting a consumed decision with no replacement is a bigger call than the design allowed for.

**F-165 — real, and the mechanism is more specific than the register states.** `speaker.py:527` clears the **entire** votes dict when a bucket has no words, including `target_activity`, which is mask-derived and does not depend on words at all. So non-lexical vocalization loses the one voter that could have registered it. The code comment defends this with adult inter-turn silence — the adult-speech assumption, in situ. Fixing it changes axis semantics and deserves its own PR.

## Verification

- `src/tests/audio/workflows/audio_analysis/` — 1420 passed, 3 skipped
- `pre-commit run --all-files` — 17 hooks green, verified directly, no files rewritten
- Both new tests confirmed to **fail against the pre-fix code** and pass after

🤖 Generated with [Claude Code](https://claude.com/claude-code)