### PR TITLE
unasdiff: honour the caller's device, size the timeout to the work, stop writing PCM_16

### DIFF
--- a/specs/20260818-071500-unasdiff-device-timeout-pcm16/design.md
+++ b/specs/20260818-071500-unasdiff-device-timeout-pcm16/design.md
@@ -1,0 +1,227 @@
+# unasdiff: the GPU nobody could select, the ceiling that discarded the run, and PCM_16 again
+
+Three defects in `src/senselab/audio/tasks/source_separation/unasdiff.py`, one of which reaches
+`speech_enhancement/driftse.py` as well. Each was verified against the code and against upstream at
+the pinned commit `5a5d70cdc94fe9d034892a1c5bc68ad1a67d2daa` before being fixed.
+
+## D-1. A caller could not select a GPU, for two compounding reasons
+
+### What was wrong
+
+**Ours.** `separate_with_unasdiff` accepted `device`, handed it to `_select_device_and_dtype` for
+validation and threw the return value away. Nothing about the caller's choice reached the worker
+payload; the worker picked for itself with
+
+```python
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+```
+
+The docstring documented this ("Accepted for signature parity ... The worker selects CUDA when
+available and CPU otherwise"), so it was a known limitation rather than a silent bug — but it made
+the parameter a decoration, and the bare `"cuda"` took whatever index torch defaulted to.
+
+**Upstream's.** `models/atten_unet.py` line 6 executes
+
+```python
+os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+```
+
+at module scope, *before* its own `import torch` on line 7. `models/__init__.py` is
+`from .atten_unet import *`, so a bare `import models` fires it. In our worker the sequence was:
+
+1. `import torch` — CUDA is not initialised by an import,
+2. `import models` — the pin overwrites whatever the launcher set,
+3. `torch.cuda.is_available()` — the first CUDA API call, which initialises CUDA and enumerates
+   against the *overwritten* value.
+
+CUDA initialises lazily, which is exactly why the pin worked: nothing had read the variable before
+step 2. Verified on a four-GPU node — four workers launched with distinct `CUDA_VISIBLE_DEVICES`
+all ran on physical GPU 0, confirmed through `/proc/<pid>/environ`.
+
+`diffusion/gaussian_diffusion.py` line 34 assigns the same variable, but inside `load_spk_model`
+under `if device is None:` — a default-gathering branch of a function this worker never calls. It
+was checked and deliberately left alone.
+
+### What was done
+
+The worker saves `CUDA_VISIBLE_DEVICES` immediately before `import models`, and restores it
+(`os.environ.pop` when it was unset, plain assignment otherwise) immediately after `import
+diffusion` — still ahead of any CUDA API call. The launcher's mask is therefore what CUDA
+enumerates against, and the upstream pin has no observable effect.
+
+The host now sends the caller's device in the payload:
+
+- `device=None` sends `None`, and the worker takes `cuda:<current index>` when CUDA is available
+  and CPU otherwise. `None` is *not* resolved on the host, because the host interpreter and the
+  venv have separate torch builds and only the venv's `torch.cuda.is_available()` governs where the
+  worker can actually run. Resolving here would let a CPU-only host build silently pin a
+  CUDA-capable worker to CPU.
+- An explicit `DeviceType` goes through `_select_device_and_dtype` (validation, unchanged) and then
+  `device_run_opt`, which is the existing helper for exactly this: it returns
+  `f"cuda:{torch.cuda.current_device()}"` rather than a hardcoded `0`, so under a Slurm-style
+  `CUDA_VISIBLE_DEVICES` mask it names the allocated card.
+
+The worker never builds a bare `torch.device("cuda")`; an index is always chosen. A CUDA request
+that the venv cannot honour raises inside the worker naming the requested device and the mask, and
+that error is propagated as-is by `parse_subprocess_result`.
+
+### Rejected
+
+*Resolving `device=None` on the host as well*, for a uniform payload. Rejected for the split-torch
+reason above: it converts a worker-local fact (does this venv see a GPU) into a host-local guess.
+
+*Passing an index through `DeviceType`.* The enum has no index and adding one is a repo-wide
+change; the mask is the existing mechanism for choosing a card, and it now works.
+
+## D-2. A timeout discarded the entire run
+
+### What was wrong
+
+`subprocess.run(..., timeout=3600)`, hardcoded, with no `except`. On `TimeoutExpired` the exception
+propagated out of the `TemporaryDirectory` context manager, which deleted every per-window file the
+worker had already written. This killed a 200-step run outright.
+
+3600 s is not merely arbitrary — it is too small for realistic input. Measured on an exclusive A100
+node: 560.71 s for 14.027 s of audio at 200 steps. That is RTF ≈ 40×, against the module docstring's
+claim of 22-26× on an H100. 14.027 s at 16 kHz is 224 432 samples, which `_window_starts` covers
+with 7 windows (six on the regular 2 s hop, plus one flush against the end), so
+
+```
+560.71 s / (7 windows × 200 steps) = 0.400 s per window-step
+```
+
+At that rate the shipped 3600 s ceiling covers about 45 windows, i.e. roughly 92 s of audio, on an
+A100 — and far less on CPU, where the figure is unmeasured and the fallback softmax attention
+materialises a `[b, h, t, t]` matrix per layer.
+
+### What was done
+
+`timeout_s: Optional[float] = None` on `separate_with_unasdiff` and on `api.separate_audios`.
+`None` derives the ceiling from the work:
+
+```
+max(_TIMEOUT_FLOOR_S, _TIMEOUT_HEADROOM × _SECONDS_PER_WINDOW_STEP × n_windows × diffusion_steps)
+```
+
+| constant | value | where it comes from |
+| --- | --- | --- |
+| `_SECONDS_PER_WINDOW_STEP` | 0.4 | the A100 measurement above, 560.71 s / (7 × 200) |
+| `_TIMEOUT_HEADROOM` | 4.0 | see below |
+| `_TIMEOUT_FLOOR_S` | 1800.0 | see below |
+
+**Why a headroom factor rather than the measured number alone.** The measurement is one card, one
+clip, an exclusive node and no flash-attn. A shared card, an older card, or a CPU host are all
+slower by an amount this repository has not measured, and this is a *ceiling*, not a budget: the
+cost of setting it too high is that a genuinely hung worker takes longer to fail, while the cost of
+setting it too low is losing every window of a multi-hour run. The asymmetry is what picks 4×. It
+is not a fitted threshold and nothing downstream reads it as one — it gates no verdict, only how
+long a subprocess is allowed to live — which is why it is a module constant rather than a `data/`
+profile.
+
+**Why a floor at all.** A short input is not a short run on first use: the worker clones upstream
+at the pinned commit, and both priors are loaded from checkpoint before the first window is
+sampled. Those costs do not scale with the number of windows, so a work-proportional term alone
+would put a one-window call under a ceiling smaller than its own startup.
+
+**The failure is now actionable.** `TimeoutExpired` is caught and re-raised as `RuntimeError`
+naming the ceiling that fired, how many of the N windows had been written when it fired, how many
+inputs and how many seconds of audio were being separated, the mode, the diffusion step count, the
+device, and the `timeout_s` parameter that raises the ceiling.
+
+### Salvage: counted, not returned
+
+The per-window files that *had* been written are counted (each window's full source set must be
+present to count) and reported. They are not returned and not preserved. Two reasons:
+
+1. **A partial result cannot be returned.** The contract is `List[List[Audio]]`, one full-length
+   `Audio` per source per input. Windows 0..k of an N-window recording overlap-add into a signal
+   that is silent past window k. Returning that is a silently truncated separation — the failure
+   mode this repository has repeatedly paid for, and worse than raising.
+2. **Preserving them only helps if a rerun can consume them**, which means a content-addressed
+   per-window cache keyed on (upstream commit, checkpoint revision, mode, labels, diffusion steps,
+   seed, window samples) plus resume logic in the worker. That is the `cached_inference` machinery,
+   a design of its own with its own invalidation story — not something to graft onto a timeout
+   handler. The worker also loads both priors once for the whole batch, so a resume would repay the
+   model load on every attempt; the saving is real but it is not the trivial one it looks like.
+
+Filed as follow-up rather than done here, and the docstring says outright that exceeding the
+ceiling discards every window.
+
+## D-3. PCM_16 intermediates, for the fourth time
+
+### What was wrong
+
+Both subprocess backends round-trip audio through WAV files, and every write took soundfile's
+default WAV subtype, which is `PCM_16`:
+
+- `unasdiff.py` worker — `sf.write(out_path, ...)`, the separated sources;
+- `unasdiff.py` host — `Audio.save_to_file(in_path)`, which writes PCM_16 for a `.wav` (measured);
+- `driftse.py` worker — `sf.write(out_path, ...)`, the enhanced signal;
+- `driftse.py` host — `Audio.save_to_file(in_path)`.
+
+Anything beyond ±1 is clipped. On the probe recording nothing clipped (largest sample 0.9949 across
+126 files) because unasdiff's worker peak-normalises each window before sampling and inverts the
+normalisation on the way out — but that is a property of one code path, not of the format, and the
+host's *input* windows are not normalised at all: a recording peaking above full scale was clipped
+before the worker ever saw it.
+
+This default has silently corrupted a measurement three separate times in this project — two
+harnesses and one GPU re-run, in the last of which three SepFormer streams lost up to 8.9% of their
+samples and disagreed with the CPU run by 9.5 dB.
+
+### What was done
+
+All four sites write `subtype="FLOAT"`. The two host sites stop using `Audio.save_to_file` for the
+hand-off and call `soundfile.write` directly, because `save_to_file` has no subtype parameter.
+Each module carries a `_WAV_SUBTYPE = "FLOAT"` constant and the workers receive it in their payload
+rather than inlining a literal, so there is one place per backend to change.
+
+A grep of `source_separation/` and `speech_enhancement/` found no other `sf.write` /
+`soundfile.write` call. Repository-wide, the remaining default-subtype writes are outside both
+packages and outside this change: `features_extraction/sparc.py` (two), `text_to_speech/qwen_tts.py`
+(one), and `video/tasks/input_output.py` (one, which passes an explicit `format`). The
+`voice_cloning` and `text_to_speech` Coqui paths write FLAC and are unaffected.
+`classification/yamnet.py` already had this fixed, as `LOSSLESS_WAV_SUBTYPE`; three modules now
+carry the same literal under two names, and giving them one shared home is a follow-up rather than
+part of this fix (it would cross task package boundaries).
+
+## Tests
+
+`src/tests/audio/tasks/source_separation_test.py`, fourteen added:
+
+| test | defect | fails pre-fix |
+| --- | --- | --- |
+| `test_the_worker_restores_cuda_visible_devices_before_it_touches_cuda` | D-1 | yes |
+| `test_the_worker_never_requests_a_bare_cuda_device` | D-1 | yes |
+| `test_the_callers_device_reaches_the_worker_payload` | D-1 | yes |
+| `test_no_device_leaves_the_choice_to_the_worker` | D-1 | yes |
+| `test_an_incompatible_device_is_rejected_before_the_venv` | D-1 | no — held before, kept as a guard |
+| `test_the_default_timeout_scales_with_windows_and_steps` | D-2 | yes |
+| `test_the_derived_ceiling_reaches_subprocess_run` | D-2 | yes |
+| `test_an_explicit_timeout_overrides_the_derived_one` | D-2 | yes |
+| `test_a_non_positive_timeout_raises` | D-2 | yes |
+| `test_a_timeout_names_the_ceiling_the_input_and_the_windows_written` | D-2 | yes |
+| `test_separate_audios_forwards_timeout_s` | D-2 | yes |
+| `test_separate_audios_forwards_device` | D-1 | yes |
+| `test_input_windows_are_written_as_float_not_pcm16` | D-3 | yes |
+| `test_every_worker_wav_write_names_an_explicit_subtype` | D-3 | yes |
+
+`src/tests/audio/tasks/speech_enhancement_test.py`, two added:
+`test_every_driftse_worker_wav_write_names_an_explicit_subtype` and
+`test_driftse_input_wavs_are_written_as_float_not_pcm16`, both failing pre-fix.
+
+**The D-1 ordering test is static, and that is a limitation worth naming.** The pin's effect is
+only observable on a multi-GPU host, and this repository's CI has none. The test parses the worker
+script with `ast` and asserts four line-number relations: the save precedes the pinning import, the
+restore follows every upstream import, and the restore precedes the first `torch.cuda` reference.
+That is the property the fix rests on, and it catches the realistic regressions (someone deletes
+the restore, or moves a `torch.cuda` call above it). It cannot catch an upstream commit that starts
+pinning from a module we do not import — nothing short of a GPU node can.
+
+The `in_peak` assertion in `test_input_windows_are_written_as_float_not_pcm16` checks `> 1.5`
+rather than an exact value, because `resample_audios` runs its filter even when the rate is
+unchanged: a 1.75 impulse comes back as 1.7276. The property under test is only that the sample
+survived a format whose ceiling is 1.0.
+
+The existing end-to-end test stays gated on the venv being present *and* CUDA being available.
+Nothing added here needs either.

--- a/src/senselab/audio/tasks/source_separation/api.py
+++ b/src/senselab/audio/tasks/source_separation/api.py
@@ -76,7 +76,9 @@ def separate_audios(
             ``"speech_sound"``, ``n_sources`` for ``"sound_sound"``, unused for
             ``"speech_speech"``). Resolved to conditioning indices via
             :func:`resolve_source_classes`.
-        device: Accepted for signature parity with other separation/enhancement entry points.
+        device: Device the worker runs on -- CUDA or CPU. ``None`` leaves the choice to the
+            worker. Forwarded unchanged to
+            :func:`senselab.audio.tasks.source_separation.unasdiff.separate_with_unasdiff`.
         seed: RNG seed, recorded in the worker's log line.
         diffusion_steps: Number of reverse-diffusion steps the sampler runs per window --
             forwarded unchanged to :func:`senselab.audio.tasks.source_separation.unasdiff.separate_with_unasdiff`.

--- a/src/senselab/audio/tasks/source_separation/api.py
+++ b/src/senselab/audio/tasks/source_separation/api.py
@@ -40,6 +40,7 @@ def separate_audios(
     device: Optional[DeviceType] = None,
     seed: int = 17,
     diffusion_steps: int = _DIFFUSION_STEPS,
+    timeout_s: Optional[float] = None,
 ) -> List[List[Audio]]:
     """Separate each audio into ``n_sources`` sources with unasdiff.
 
@@ -86,6 +87,9 @@ def separate_audios(
             published basis; lower values trade quality for speed roughly proportionally but are
             entirely unmeasured in this repository, so there is no recommended lower setting --
             see that function's docstring for the full derivation.
+        timeout_s: Ceiling on the worker subprocess, in seconds; ``None`` derives one from the
+            number of windows and ``diffusion_steps``. Forwarded unchanged to
+            :func:`senselab.audio.tasks.source_separation.unasdiff.separate_with_unasdiff`.
 
     Returns:
         One list of ``n_sources`` ``Audio`` objects per input, in order.
@@ -94,7 +98,8 @@ def separate_audios(
         ValueError: If ``model`` is given and does not name the unasdiff mirror; if ``mode`` is
             not one of the three supported modes; if a mode using the sound prior is missing
             ``source_classes``; if ``source_classes`` does not have exactly the number of
-            entries that mode's sound slots require; or if ``diffusion_steps`` is not positive.
+            entries that mode's sound slots require; or if ``diffusion_steps`` or ``timeout_s``
+            is not positive.
     """
     if model is not None and not (
         isinstance(model, HFModel) and str(model.path_or_uri).startswith(_UNASDIFF_MODEL_PREFIX)
@@ -133,6 +138,7 @@ def separate_audios(
         device=device,
         seed=seed,
         diffusion_steps=diffusion_steps,
+        timeout_s=timeout_s,
     )
 
 

--- a/src/senselab/audio/tasks/source_separation/unasdiff.py
+++ b/src/senselab/audio/tasks/source_separation/unasdiff.py
@@ -101,6 +101,7 @@ from importlib import resources
 from pathlib import Path
 from typing import Any, List, Optional, Tuple, Union
 
+import soundfile as sf
 import torch
 
 from senselab.audio.data_structures import Audio
@@ -231,6 +232,10 @@ _OVERLAP_S = 2.0  # 50% overlap between adjacent windows -- see Task 5 / doc.md
 # why no lower value is recommended here.
 _DIFFUSION_STEPS = 200
 
+# Every WAV this backend hands to or takes back from the worker. soundfile's WAV default is
+# PCM_16, which clips beyond +-1 -- see specs/20260818-071500-unasdiff-device-timeout-pcm16.
+_WAV_SUBTYPE = "FLOAT"
+
 _FSD_CLASS_MAP_RESOURCE = "fsd41_classes.json"
 
 
@@ -284,6 +289,7 @@ try:
     labels = args["labels"]
     in_paths, out_paths = args["in_paths"], args["out_paths"]
     seed = int(args["seed"])
+    wav_subtype = args["wav_subtype"]
 
     import fcntl, os, shutil, tempfile as _tempfile
 
@@ -433,7 +439,9 @@ try:
 
         for src_wave, out_path in zip(sources, out_path_list):
             src_wave = src_wave / 0.95 * peak
-            sf.write(out_path, src_wave.detach().cpu().numpy(), sr)
+            # Explicit subtype: soundfile's WAV default is PCM_16, which clips every sample
+            # beyond +-1 on the way back to the host.
+            sf.write(out_path, src_wave.detach().cpu().numpy(), sr, subtype=wav_subtype)
         results.append(out_path_list)
 
     print(json.dumps({"output_paths": results, "seed": seed}))
@@ -697,9 +705,10 @@ def separate_with_unasdiff(
             waveform = audio.waveform.squeeze(0)
             for w, start in enumerate(starts):
                 segment = waveform[start : start + window_samples]
-                segment_audio = Audio(waveform=segment.unsqueeze(0), sampling_rate=_TARGET_SR)
                 in_path = str(tmp / f"in_{i}_{w}.wav")
-                segment_audio.save_to_file(in_path)
+                # Not Audio.save_to_file: that writes PCM_16 for a .wav, which clips the input
+                # window before the worker ever reads it.
+                sf.write(in_path, segment.detach().cpu().numpy(), _TARGET_SR, subtype=_WAV_SUBTYPE)
                 in_paths.append(in_path)
                 out_paths.append([str(tmp / f"out_{i}_{w}_{s}.wav") for s in range(n_sources)])
             window_ranges.append((flat_start, len(in_paths)))
@@ -720,6 +729,7 @@ def separate_with_unasdiff(
                 "out_paths": out_paths,
                 "seed": seed,
                 "diffusion_steps": diffusion_steps,
+                "wav_subtype": _WAV_SUBTYPE,
             }
         )
 

--- a/src/senselab/audio/tasks/source_separation/unasdiff.py
+++ b/src/senselab/audio/tasks/source_separation/unasdiff.py
@@ -236,7 +236,27 @@ _DIFFUSION_STEPS = 200
 # PCM_16, which clips beyond +-1 -- see specs/20260818-071500-unasdiff-device-timeout-pcm16.
 _WAV_SUBTYPE = "FLOAT"
 
+# Terms of the default worker ceiling, in seconds per (window x diffusion step) and as a floor.
+# Derivation and the measurement behind both numbers:
+# specs/20260818-071500-unasdiff-device-timeout-pcm16.
+_SECONDS_PER_WINDOW_STEP = 0.4
+_TIMEOUT_HEADROOM = 4.0
+_TIMEOUT_FLOOR_S = 1800.0
+
 _FSD_CLASS_MAP_RESOURCE = "fsd41_classes.json"
+
+
+def _default_timeout_s(n_windows: int, diffusion_steps: int) -> float:
+    """Return the default worker ceiling for ``n_windows`` windows at ``diffusion_steps`` steps.
+
+    Args:
+        n_windows: Total number of 4 s windows the worker will separate, across every input.
+        diffusion_steps: Reverse-diffusion steps per window.
+
+    Returns:
+        Seconds, never below ``_TIMEOUT_FLOOR_S``.
+    """
+    return max(_TIMEOUT_FLOOR_S, _TIMEOUT_HEADROOM * _SECONDS_PER_WINDOW_STEP * n_windows * diffusion_steps)
 
 
 @functools.lru_cache(maxsize=1)
@@ -617,6 +637,7 @@ def separate_with_unasdiff(
     device: Optional[DeviceType] = None,
     seed: int = 17,
     diffusion_steps: int = _DIFFUSION_STEPS,
+    timeout_s: Optional[float] = None,
 ) -> List[List[Audio]]:
     """Separate each audio into ``n_sources`` sources with unasdiff.
 
@@ -661,6 +682,11 @@ def separate_with_unasdiff(
             is no fitted threshold or "recommended" lower setting to fall back on (see this
             module's ``CLAUDE.md``-derived convention against unfitted thresholds), so any value
             below 200 is the caller's own unmeasured quality/speed trade.
+        timeout_s: Ceiling on the worker subprocess, in seconds. ``None`` derives one from the
+            work -- total windows across every input, times ``diffusion_steps``, times a
+            per-window-step factor, with a floor covering the first-use clone and the checkpoint
+            load (:func:`_default_timeout_s`). Exceeding it raises ``RuntimeError`` and discards
+            every window, completed or not.
 
     Returns:
         One list of ``n_sources`` ``Audio`` objects per input, in order. For a multi-window
@@ -672,9 +698,11 @@ def separate_with_unasdiff(
 
     Raises:
         ValueError: if ``len(source_class_indices) != n_sources``, if ``diffusion_steps`` is
-            not positive, or if ``device`` is neither CUDA nor CPU (or names a device this host
-            does not have).
-        RuntimeError: if the worker fails; the upstream traceback is included.
+            not positive, if ``timeout_s`` is not positive, or if ``device`` is neither CUDA
+            nor CPU (or names a device this host does not have).
+        RuntimeError: if the worker fails; the upstream traceback is included. Also if the
+            worker exceeds ``timeout_s`` -- that message names the ceiling, the inputs, and how
+            many windows had been written when it fired.
     """
     if not audios:
         return []
@@ -684,6 +712,8 @@ def separate_with_unasdiff(
         )
     if diffusion_steps <= 0:
         raise ValueError(f"diffusion_steps must be a positive integer, got {diffusion_steps}")
+    if timeout_s is not None and timeout_s <= 0:
+        raise ValueError(f"timeout_s must be a positive number of seconds, got {timeout_s}")
 
     from senselab.audio.tasks.preprocessing import downmix_audios_to_mono, resample_audios
     from senselab.utils.data_structures.device import _select_device_and_dtype, device_run_opt
@@ -708,6 +738,9 @@ def separate_with_unasdiff(
         _window_starts(int(audio.waveform.shape[-1]), window_samples, hop_samples) for audio in mono_16k
     ]
 
+    total_windows = sum(len(w) for w in windows_per_audio)
+    effective_timeout_s = _default_timeout_s(total_windows, diffusion_steps) if timeout_s is None else timeout_s
+
     speech_ckpt_path, speech_config_path, sound_ckpt_path, sound_config_path = _resolve_checkpoint_paths(checkpoint_dir)
 
     venv_dir = ensure_venv(
@@ -723,14 +756,15 @@ def separate_with_unasdiff(
 
     logger.info(
         "unasdiff: separating %d audio(s) (%d window(s) total), mode=%s, n_sources=%d, seed=%d, "
-        "diffusion_steps=%d, device=%s",
+        "diffusion_steps=%d, device=%s, timeout=%.0fs",
         len(mono_16k),
-        sum(len(w) for w in windows_per_audio),
+        total_windows,
         mode,
         n_sources,
         seed,
         diffusion_steps,
         worker_device or "worker's choice",
+        effective_timeout_s,
     )
 
     with tempfile.TemporaryDirectory(prefix="senselab-unasdiff-") as tmpdir:
@@ -775,14 +809,26 @@ def separate_with_unasdiff(
             }
         )
 
-        result = subprocess.run(
-            [python, "-c", _WORKER_SCRIPT],
-            input=input_json,
-            capture_output=True,
-            text=True,
-            timeout=3600,
-            env=_clean_subprocess_env(),
-        )
+        try:
+            result = subprocess.run(
+                [python, "-c", _WORKER_SCRIPT],
+                input=input_json,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout_s,
+                env=_clean_subprocess_env(),
+            )
+        except subprocess.TimeoutExpired as exc:
+            completed = sum(1 for paths in out_paths if all(Path(p).is_file() for p in paths))
+            total_input_s = sum(int(a.waveform.shape[-1]) for a in mono_16k) / _TARGET_SR
+            raise RuntimeError(
+                f"unasdiff worker exceeded its {effective_timeout_s:.0f}s ceiling with "
+                f"{completed}/{len(out_paths)} window(s) written, separating {len(mono_16k)} input(s) "
+                f"({total_input_s:.1f}s of audio at {_TARGET_SR} Hz) with mode={mode!r}, "
+                f"n_sources={n_sources}, diffusion_steps={diffusion_steps}, "
+                f"device={worker_device or 'worker-selected'}. The written windows are discarded "
+                f"with the worker's temporary directory; pass timeout_s to raise the ceiling."
+            ) from exc
         output = parse_subprocess_result(result, venv_label="unasdiff")
         all_output_paths: List[List[str]] = output["output_paths"]
 

--- a/src/senselab/audio/tasks/source_separation/unasdiff.py
+++ b/src/senselab/audio/tasks/source_separation/unasdiff.py
@@ -289,6 +289,7 @@ try:
     labels = args["labels"]
     in_paths, out_paths = args["in_paths"], args["out_paths"]
     seed = int(args["seed"])
+    requested_device = args.get("device")
     wav_subtype = args["wav_subtype"]
 
     import fcntl, os, shutil, tempfile as _tempfile
@@ -328,10 +329,35 @@ try:
 
     # Library modules only. The three test_*.py scripts call torch.cuda.set_device(0) at
     # import and abort on a CPU host.
+    #
+    # models/atten_unet.py assigns CUDA_VISIBLE_DEVICES="0" at module scope, before its own
+    # `import torch`. The launcher's value is saved here and put back immediately after, ahead of
+    # the first CUDA API call below -- see specs/20260818-071500-unasdiff-device-timeout-pcm16.
+    saved_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
     import models
     import diffusion
+    if saved_visible_devices is None:
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+    else:
+        os.environ["CUDA_VISIBLE_DEVICES"] = saved_visible_devices
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    def resolve_device(requested):
+        # Bare "cuda" would take whatever index torch defaults to; an index is always chosen.
+        if requested is None:
+            return torch.device("cuda:%d" % torch.cuda.current_device() if torch.cuda.is_available() else "cpu")
+        if not str(requested).startswith("cuda"):
+            return torch.device(requested)
+        if not torch.cuda.is_available():
+            raise RuntimeError(
+                "unasdiff worker: device %r was requested but torch.cuda.is_available() is False "
+                "inside the unasdiff venv (CUDA_VISIBLE_DEVICES=%r)"
+                % (requested, os.environ.get("CUDA_VISIBLE_DEVICES"))
+            )
+        if ":" in str(requested):
+            return torch.device(requested)
+        return torch.device("cuda:%d" % torch.cuda.current_device())
+
+    device = resolve_device(requested_device)
     torch.manual_seed(seed)
 
     def load_prior(config_path, ckpt_path):
@@ -618,8 +644,12 @@ def separate_with_unasdiff(
         mode: One of ``"speech_sound"``, ``"sound_sound"``, ``"speech_speech"``.
         checkpoint_dir: Directory containing the four mirror files. If ``None``, resolved from
             ``SENSELAB_UNASDIFF_CHECKPOINTS`` or the pinned HF mirror.
-        device: Accepted for signature parity with other separation/enhancement entry points.
-            The worker selects CUDA when available and CPU otherwise.
+        device: Device the worker runs on. ``DeviceType.CUDA`` is resolved to an explicit
+            ``"cuda:<index>"`` (the index ``torch.cuda.current_device()`` reports in this
+            process, so under a ``CUDA_VISIBLE_DEVICES`` mask it is the allocated card) and sent
+            to the worker; ``DeviceType.CPU`` is sent as ``"cpu"``. ``None`` leaves the choice to
+            the worker, which takes ``cuda:<current index>`` when CUDA is available and CPU
+            otherwise. Only CUDA and CPU are accepted.
         seed: RNG seed, recorded in the log line.
         diffusion_steps: Number of reverse-diffusion steps the sampler runs per window. Each
             step is a network evaluation, so this is the backend's dominant cost -- 200 steps
@@ -641,8 +671,9 @@ def separate_with_unasdiff(
         threshold).
 
     Raises:
-        ValueError: if ``len(source_class_indices) != n_sources``, or if ``diffusion_steps`` is
-            not positive.
+        ValueError: if ``len(source_class_indices) != n_sources``, if ``diffusion_steps`` is
+            not positive, or if ``device`` is neither CUDA nor CPU (or names a device this host
+            does not have).
         RuntimeError: if the worker fails; the upstream traceback is included.
     """
     if not audios:
@@ -655,9 +686,17 @@ def separate_with_unasdiff(
         raise ValueError(f"diffusion_steps must be a positive integer, got {diffusion_steps}")
 
     from senselab.audio.tasks.preprocessing import downmix_audios_to_mono, resample_audios
-    from senselab.utils.data_structures.device import _select_device_and_dtype
+    from senselab.utils.data_structures.device import _select_device_and_dtype, device_run_opt
 
-    _select_device_and_dtype(user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU])
+    # None is forwarded as None rather than resolved here: the host interpreter and the venv's
+    # own torch are separate builds, and only the venv's answer to torch.cuda.is_available()
+    # governs where the worker can actually run.
+    worker_device: Optional[str] = None
+    if device is not None:
+        selected_device, _ = _select_device_and_dtype(
+            user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]
+        )
+        worker_device = device_run_opt(selected_device)
 
     mono_16k = downmix_audios_to_mono(resample_audios(audios, resample_rate=_TARGET_SR))
 
@@ -683,13 +722,15 @@ def separate_with_unasdiff(
     repo_dir = Path(venv_dir) / "unasdiff-src"
 
     logger.info(
-        "unasdiff: separating %d audio(s) (%d window(s) total), mode=%s, n_sources=%d, seed=%d, diffusion_steps=%d",
+        "unasdiff: separating %d audio(s) (%d window(s) total), mode=%s, n_sources=%d, seed=%d, "
+        "diffusion_steps=%d, device=%s",
         len(mono_16k),
         sum(len(w) for w in windows_per_audio),
         mode,
         n_sources,
         seed,
         diffusion_steps,
+        worker_device or "worker's choice",
     )
 
     with tempfile.TemporaryDirectory(prefix="senselab-unasdiff-") as tmpdir:
@@ -729,6 +770,7 @@ def separate_with_unasdiff(
                 "out_paths": out_paths,
                 "seed": seed,
                 "diffusion_steps": diffusion_steps,
+                "device": worker_device,
                 "wav_subtype": _WAV_SUBTYPE,
             }
         )

--- a/src/senselab/audio/tasks/speech_enhancement/driftse.py
+++ b/src/senselab/audio/tasks/speech_enhancement/driftse.py
@@ -29,6 +29,8 @@ import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+import soundfile as sf
+
 from senselab.audio.data_structures import Audio
 from senselab.utils.data_structures import DeviceType, HFModel
 from senselab.utils.data_structures.logging import logger
@@ -41,6 +43,10 @@ from senselab.utils.subprocess_venv import (
 
 _DRIFTSE_VENV = "driftse"
 _DRIFTSE_PYTHON = "3.11"
+
+# Every WAV this backend hands to or takes back from the worker. soundfile's WAV default is
+# PCM_16, which clips beyond +-1 -- see specs/20260818-071500-unasdiff-device-timeout-pcm16.
+_WAV_SUBTYPE = "FLOAT"
 
 # Upstream's requirements.txt is a *training* set; only what the inference import chain touches is
 # installed. pesq/pystoi are on that chain (util/other.py imports both at module scope) even though
@@ -106,6 +112,7 @@ try:
     seed = int(args["seed"])
     sigma = float(args["sigma"])
     chunk_s, overlap_s = float(args["chunk_s"]), float(args["overlap_s"])
+    wav_subtype = args["wav_subtype"]
 
     import fcntl, os, shutil, tempfile as _tempfile
 
@@ -244,7 +251,9 @@ try:
                 wsum[start : start + chunk] += taper
             x_hat = acc / wsum.clamp(min=1e-8)
 
-        sf.write(out_path, x_hat.detach().cpu().numpy(), sr)
+        # Explicit subtype: soundfile's WAV default is PCM_16, which clips every sample
+        # beyond +-1 on the way back to the host.
+        sf.write(out_path, x_hat.detach().cpu().numpy(), sr, subtype=wav_subtype)
         results.append(out_path)
 
     print(json.dumps({"output_paths": results, "seed": seed, "sigma": sigma}))
@@ -350,7 +359,14 @@ def enhance_audios_with_driftse(
         for i, audio in enumerate(mono_16k):
             in_path = str(tmp / f"in_{i}.wav")
             out_path = str(tmp / f"out_{i}.wav")
-            audio.save_to_file(in_path)
+            # Not Audio.save_to_file: that writes PCM_16 for a .wav, which clips the input
+            # before the worker ever reads it.
+            sf.write(
+                in_path,
+                audio.waveform.squeeze(0).detach().cpu().numpy(),
+                audio.sampling_rate,
+                subtype=_WAV_SUBTYPE,
+            )
             in_paths.append(in_path)
             out_paths.append(out_path)
 
@@ -368,6 +384,7 @@ def enhance_audios_with_driftse(
                 "sigma": sigma,
                 "chunk_s": chunk_s,
                 "overlap_s": overlap_s,
+                "wav_subtype": _WAV_SUBTYPE,
             }
         )
 

--- a/src/tests/audio/tasks/source_separation_test.py
+++ b/src/tests/audio/tasks/source_separation_test.py
@@ -2,6 +2,7 @@
 
 import ast
 import json
+import subprocess
 import types
 from pathlib import Path
 
@@ -681,6 +682,133 @@ def test_an_incompatible_device_is_rejected_before_the_venv() -> None:
             mode="speech_speech",
             device=DeviceType.MPS,
         )
+
+
+# ── Worker timeout ────────────────────────────────────────────────────
+
+
+def test_the_default_timeout_scales_with_windows_and_steps() -> None:
+    """The ceiling is derived from the work, not a constant.
+
+    A fixed 3600 s ceiling failed every input past roughly 90 s on an A100 — the run that
+    exceeded it lost every window.
+    """
+    floor = unasdiff._default_timeout_s(1, 1)
+    assert floor == unasdiff._TIMEOUT_FLOOR_S
+
+    big = unasdiff._default_timeout_s(200, unasdiff._DIFFUSION_STEPS)
+    bigger_input = unasdiff._default_timeout_s(400, unasdiff._DIFFUSION_STEPS)
+    more_steps = unasdiff._default_timeout_s(200, 2 * unasdiff._DIFFUSION_STEPS)
+    assert big > floor
+    assert bigger_input == pytest.approx(2 * big)
+    assert more_steps == pytest.approx(2 * big)
+
+
+def test_the_derived_ceiling_reaches_subprocess_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The timeout ``subprocess.run`` receives is the derived one, not a hardcoded constant."""
+    captured: dict = {}
+    u = _stub_worker(monkeypatch, captured)
+
+    n_samples = int(6.0 * u._TARGET_SR)  # two windows
+    audio = Audio(waveform=torch.randn(1, n_samples), sampling_rate=u._TARGET_SR)
+    u.separate_with_unasdiff(
+        [audio],
+        n_sources=2,
+        source_class_indices=[0, 0],
+        mode="speech_speech",
+        checkpoint_dir="/tmp/fake-unasdiff-checkpoints",
+        diffusion_steps=9000,
+    )
+    expected = u._default_timeout_s(2, 9000)
+    assert captured["timeout"] == expected
+    assert captured["timeout"] != 3600
+
+
+def test_an_explicit_timeout_overrides_the_derived_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``timeout_s`` is honoured verbatim."""
+    captured: dict = {}
+    u = _stub_worker(monkeypatch, captured)
+
+    audio = Audio(waveform=torch.randn(1, int(u._WINDOW_S * u._TARGET_SR)), sampling_rate=u._TARGET_SR)
+    u.separate_with_unasdiff(
+        [audio],
+        n_sources=2,
+        source_class_indices=[0, 0],
+        mode="speech_speech",
+        checkpoint_dir="/tmp/fake-unasdiff-checkpoints",
+        timeout_s=42.0,
+    )
+    assert captured["timeout"] == 42.0
+
+
+def test_a_non_positive_timeout_raises() -> None:
+    """A zero or negative ceiling would abort the worker instantly; reject it up front."""
+    audio = Audio(waveform=torch.randn(1, 16000), sampling_rate=16000)
+    for bad in (0, -1.0):
+        with pytest.raises(ValueError, match="timeout_s"):
+            unasdiff.separate_with_unasdiff(
+                [audio],
+                n_sources=2,
+                source_class_indices=[0, 0],
+                mode="speech_speech",
+                timeout_s=bad,
+            )
+
+
+def test_a_timeout_names_the_ceiling_the_input_and_the_windows_written(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``TimeoutExpired`` becomes an actionable ``RuntimeError``, not a bare stack trace.
+
+    The unhandled exception said only that a subprocess ran too long: not which ceiling it hit,
+    how much audio it was given, or how far it had got.
+    """
+    import types
+
+    from senselab.audio.tasks.source_separation import unasdiff as u
+
+    monkeypatch.setattr(u, "ensure_venv", lambda *a, **k: Path("/tmp/fake-unasdiff-venv"))
+    monkeypatch.setattr(u, "venv_python", lambda venv_dir: "python3")
+
+    def fake_run(cmd: list, *, input: str, capture_output: bool, text: bool, timeout: float, env: dict) -> None:
+        payload = json.loads(input)
+        # One window completes before the ceiling fires, so the error can report progress.
+        for p in payload["out_paths"][0]:
+            segment = torch.randn(int(u._WINDOW_S * u._TARGET_SR))
+            soundfile.write(p, segment.numpy(), u._TARGET_SR, subtype="FLOAT")
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    monkeypatch.setattr(u.subprocess, "run", fake_run)
+
+    n_samples = int(6.0 * u._TARGET_SR)  # two windows
+    audio = Audio(waveform=torch.randn(1, n_samples), sampling_rate=u._TARGET_SR)
+    with pytest.raises(RuntimeError) as exc:
+        u.separate_with_unasdiff(
+            [audio],
+            n_sources=2,
+            source_class_indices=[0, 0],
+            mode="speech_speech",
+            checkpoint_dir="/tmp/fake-unasdiff-checkpoints",
+            timeout_s=123.0,
+        )
+
+    message = str(exc.value)
+    assert "123s" in message, "the ceiling that fired must be named"
+    assert "1/2 window(s) written" in message, "progress at the point of failure must be reported"
+    assert "6.0s of audio" in message, "the input being processed must be named"
+    assert "speech_speech" in message and "diffusion_steps=200" in message
+    assert "timeout_s" in message, "the message must name the knob that raises the ceiling"
+
+
+def test_separate_audios_forwards_timeout_s(mono_audio_sample: Audio, monkeypatch: pytest.MonkeyPatch) -> None:
+    """api.separate_audios threads timeout_s through to separate_with_unasdiff unchanged."""
+    captured = {}
+
+    def fake(audios: list, n_sources: int, source_class_indices: list, **kwargs: object) -> list:
+        captured["timeout_s"] = kwargs["timeout_s"]
+        return [[audios[0]] * n_sources]
+
+    monkeypatch.setattr("senselab.audio.tasks.source_separation.api.separate_with_unasdiff", fake)
+    separate_audios([mono_audio_sample], mode="speech_speech", n_sources=2, timeout_s=99.0)
+    assert captured["timeout_s"] == 99.0
 
 
 def test_separate_audios_forwards_device(mono_audio_sample: Audio, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/tests/audio/tasks/source_separation_test.py
+++ b/src/tests/audio/tasks/source_separation_test.py
@@ -13,7 +13,7 @@ from senselab.audio.data_structures import Audio
 from senselab.audio.tasks.source_separation import separate_audios, unasdiff
 from senselab.audio.tasks.source_separation.api import resolve_source_classes
 from senselab.audio.tasks.source_separation.unasdiff import align_permutations
-from senselab.utils.data_structures import HFModel
+from senselab.utils.data_structures import DeviceType, HFModel
 from senselab.utils.subprocess_venv import _cache_dir_path
 
 
@@ -537,6 +537,163 @@ def test_unasdiff_separates_a_mixture_into_n_sources(mono_audio_sample: Audio) -
 
     a, b = result[0][0].waveform, result[0][1].waveform
     assert (a - b).abs().mean() > 1e-4, "both slots returned the same signal"
+
+
+# ── Worker device selection ───────────────────────────────────────────
+
+_CUDA_VISIBLE_DEVICES = "CUDA_VISIBLE_DEVICES"
+
+
+def _reads_os_environ(node: ast.AST) -> bool:
+    """True if ``node`` is the expression ``os.environ``."""
+    return isinstance(node, ast.Attribute) and node.attr == "environ" and isinstance(node.value, ast.Name)
+
+
+def _cuda_visible_devices_landmarks(script: str) -> dict:
+    """Line numbers of the four events the worker's device handling must order correctly.
+
+    Args:
+        script: The worker script source.
+
+    Returns:
+        ``{"saves": [...], "restores": [...], "upstream_imports": [...], "cuda_api": [...]}``,
+        each a list of line numbers in the order ``ast.walk`` yields them.
+    """
+    tree = ast.parse(script)
+    landmarks: dict = {"saves": [], "restores": [], "upstream_imports": [], "cuda_api": []}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and _reads_os_environ(node.func.value):
+            named = node.args and isinstance(node.args[0], ast.Constant) and node.args[0].value == _CUDA_VISIBLE_DEVICES
+            if named and node.func.attr == "get":
+                landmarks["saves"].append(node.lineno)
+            elif named and node.func.attr == "pop":
+                landmarks["restores"].append(node.lineno)
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Subscript)
+                    and _reads_os_environ(target.value)
+                    and isinstance(target.slice, ast.Constant)
+                    and target.slice.value == _CUDA_VISIBLE_DEVICES
+                ):
+                    landmarks["restores"].append(node.lineno)
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in ("models", "diffusion"):
+                    landmarks["upstream_imports"].append(node.lineno)
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == "cuda"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "torch"
+        ):
+            landmarks["cuda_api"].append(node.lineno)
+    return landmarks
+
+
+def test_the_worker_restores_cuda_visible_devices_before_it_touches_cuda() -> None:
+    """The upstream module-scope GPU pin is saved before the import and put back before any CUDA call.
+
+    ``models/atten_unet.py`` assigns ``CUDA_VISIBLE_DEVICES = "0"`` at module scope, ahead of its
+    own ``import torch``. CUDA initialises lazily, so restoring the launcher's value after the
+    import but before the first CUDA API call is what makes the pin have no effect. This is a
+    static ordering check because the pin's effect is only observable on a multi-GPU host.
+    """
+    marks = _cuda_visible_devices_landmarks(unasdiff._WORKER_SCRIPT)
+    assert marks["saves"], "the worker never reads CUDA_VISIBLE_DEVICES before the upstream import"
+    assert marks["restores"], "the worker never restores CUDA_VISIBLE_DEVICES after the upstream import"
+    assert marks["upstream_imports"], "test premise: the worker imports the upstream modules"
+    assert marks["cuda_api"], "test premise: the worker calls into torch.cuda"
+
+    assert min(marks["saves"]) < min(marks["upstream_imports"]), "the save must precede the pinning import"
+    assert max(marks["restores"]) > max(marks["upstream_imports"]), "the restore must follow every upstream import"
+    assert max(marks["restores"]) < min(marks["cuda_api"]), "the restore must precede the first CUDA API call"
+
+
+def test_the_worker_never_requests_a_bare_cuda_device() -> None:
+    """Every ``torch.device`` the worker builds for CUDA carries an explicit index.
+
+    A bare ``"cuda"`` takes whatever index torch defaults to, which is the outcome the upstream
+    pin produced on a four-GPU node.
+    """
+    tree = ast.parse(unasdiff._WORKER_SCRIPT)
+    bare = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "device"):
+            continue
+        # Every string constant reachable from the argument, so a ternary picking between
+        # "cuda" and "cpu" is caught as readily as a plain literal.
+        for inner in ast.walk(node.args[0]) if node.args else []:
+            if isinstance(inner, ast.Constant) and inner.value == "cuda":
+                bare.append(node.lineno)
+    assert not bare, f"bare torch.device('cuda') at worker line(s) {sorted(set(bare))}"
+
+
+def test_the_callers_device_reaches_the_worker_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A caller-selected device is sent to the worker instead of being validated and dropped.
+
+    ``device`` used to be handed to ``_select_device_and_dtype`` purely for validation and its
+    result discarded, so the worker chose for itself and no caller could select a card.
+    """
+    captured: dict = {}
+    u = _stub_worker(monkeypatch, captured)
+
+    audio = Audio(waveform=torch.randn(1, int(u._WINDOW_S * u._TARGET_SR)), sampling_rate=u._TARGET_SR)
+    u.separate_with_unasdiff(
+        [audio],
+        n_sources=2,
+        source_class_indices=[0, 0],
+        mode="speech_speech",
+        checkpoint_dir="/tmp/fake-unasdiff-checkpoints",
+        device=DeviceType.CPU,
+    )
+    assert captured["payload"]["device"] == "cpu"
+
+
+def test_no_device_leaves_the_choice_to_the_worker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``device=None`` sends ``None``, not a device the host's own torch build happened to see.
+
+    The host interpreter and the venv have separate torch builds; only the venv's answer to
+    ``torch.cuda.is_available()`` governs where the worker can run.
+    """
+    captured: dict = {}
+    u = _stub_worker(monkeypatch, captured)
+
+    audio = Audio(waveform=torch.randn(1, int(u._WINDOW_S * u._TARGET_SR)), sampling_rate=u._TARGET_SR)
+    u.separate_with_unasdiff(
+        [audio],
+        n_sources=2,
+        source_class_indices=[0, 0],
+        mode="speech_speech",
+        checkpoint_dir="/tmp/fake-unasdiff-checkpoints",
+    )
+    assert captured["payload"]["device"] is None
+
+
+def test_an_incompatible_device_is_rejected_before_the_venv() -> None:
+    """MPS is not one of this backend's compatible devices and must raise rather than fall back."""
+    audio = Audio(waveform=torch.randn(1, 16000), sampling_rate=16000)
+    with pytest.raises(ValueError):
+        unasdiff.separate_with_unasdiff(
+            [audio],
+            n_sources=2,
+            source_class_indices=[0, 0],
+            mode="speech_speech",
+            device=DeviceType.MPS,
+        )
+
+
+def test_separate_audios_forwards_device(mono_audio_sample: Audio, monkeypatch: pytest.MonkeyPatch) -> None:
+    """api.separate_audios threads device through to separate_with_unasdiff unchanged."""
+    captured = {}
+
+    def fake(audios: list, n_sources: int, source_class_indices: list, **kwargs: object) -> list:
+        captured["device"] = kwargs["device"]
+        return [[audios[0]] * n_sources]
+
+    monkeypatch.setattr("senselab.audio.tasks.source_separation.api.separate_with_unasdiff", fake)
+    separate_audios([mono_audio_sample], mode="speech_speech", n_sources=2, device=DeviceType.CPU)
+    assert captured["device"] is DeviceType.CPU
 
 
 # ── WAV intermediates ─────────────────────────────────────────────────

--- a/src/tests/audio/tasks/source_separation_test.py
+++ b/src/tests/audio/tasks/source_separation_test.py
@@ -1,6 +1,12 @@
 """unasdiff source separation — API contract and class-space handling."""
 
+import ast
+import json
+import types
+from pathlib import Path
+
 import pytest
+import soundfile
 import torch
 
 from senselab.audio.data_structures import Audio
@@ -18,6 +24,40 @@ def _cuda_available() -> bool:
         return torch.cuda.is_available()
     except Exception:
         return False
+
+
+def _stub_worker(monkeypatch: pytest.MonkeyPatch, captured: dict) -> types.ModuleType:
+    """Replace the venv and the worker subprocess with a fake that records what the host sent.
+
+    Args:
+        monkeypatch: The test's monkeypatch fixture.
+        captured: Filled in with ``payload``, ``timeout``, ``in_subtypes`` and ``in_peak``.
+
+    Returns:
+        The ``unasdiff`` module, with ``ensure_venv``, ``venv_python`` and ``subprocess.run``
+        stubbed for the duration of the test.
+    """
+    from senselab.audio.tasks.source_separation import unasdiff as u
+
+    monkeypatch.setattr(u, "ensure_venv", lambda *a, **k: Path("/tmp/fake-unasdiff-venv"))
+    monkeypatch.setattr(u, "venv_python", lambda venv_dir: "python3")
+
+    def fake_run(
+        cmd: list, *, input: str, capture_output: bool, text: bool, timeout: float, env: dict
+    ) -> types.SimpleNamespace:
+        payload = json.loads(input)
+        captured["payload"] = payload
+        captured["timeout"] = timeout
+        captured["in_subtypes"] = [soundfile.info(p).subtype for p in payload["in_paths"]]
+        captured["in_peak"] = max(abs(soundfile.read(p, dtype="float32")[0]).max() for p in payload["in_paths"])
+        for paths in payload["out_paths"]:
+            for p in paths:
+                segment = torch.randn(int(u._WINDOW_S * u._TARGET_SR))
+                soundfile.write(p, segment.numpy(), u._TARGET_SR, subtype="FLOAT")
+        return types.SimpleNamespace(returncode=0, stdout=json.dumps({"output_paths": payload["out_paths"]}), stderr="")
+
+    monkeypatch.setattr(u.subprocess, "run", fake_run)
+    return u
 
 
 def test_class_map_has_41_classes_in_50_slots() -> None:
@@ -497,3 +537,48 @@ def test_unasdiff_separates_a_mixture_into_n_sources(mono_audio_sample: Audio) -
 
     a, b = result[0][0].waveform, result[0][1].waveform
     assert (a - b).abs().mean() > 1e-4, "both slots returned the same signal"
+
+
+# ── WAV intermediates ─────────────────────────────────────────────────
+
+
+def test_input_windows_are_written_as_float_not_pcm16(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The window files the host hands the worker are FLOAT, and samples past +-1 survive.
+
+    soundfile's WAV default is PCM_16, which clips every such sample before the worker reads it.
+    """
+    captured: dict = {}
+    u = _stub_worker(monkeypatch, captured)
+
+    window_samples = int(u._WINDOW_S * u._TARGET_SR)
+    waveform = torch.zeros(1, window_samples)
+    waveform[0, 100] = 1.75
+    u.separate_with_unasdiff(
+        [Audio(waveform=waveform, sampling_rate=u._TARGET_SR)],
+        n_sources=2,
+        source_class_indices=[0, 0],
+        mode="speech_speech",
+        checkpoint_dir="/tmp/fake-unasdiff-checkpoints",
+    )
+
+    assert captured["in_subtypes"] == ["FLOAT"]
+    # PCM_16 caps at 1.0; the exact peak is not asserted because resample_audios filters even at
+    # an unchanged rate, which rounds the impulse off.
+    assert captured["in_peak"] > 1.5, "an out-of-range sample was clipped on write"
+
+
+def test_every_worker_wav_write_names_an_explicit_subtype() -> None:
+    """No ``sf.write`` in the worker relies on soundfile's PCM_16 default.
+
+    That default has silently corrupted a measurement three times in this repository.
+    """
+    tree = ast.parse(unasdiff._WORKER_SCRIPT)
+    writes = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "write"
+    ]
+    assert writes, "test premise: the worker writes WAV files"
+    for node in writes:
+        keywords = {kw.arg for kw in node.keywords}
+        assert "subtype" in keywords, f"sf.write at worker line {node.lineno} relies on the PCM_16 default"

--- a/src/tests/audio/tasks/speech_enhancement_test.py
+++ b/src/tests/audio/tasks/speech_enhancement_test.py
@@ -1,10 +1,15 @@
 """Tests for the speech enhancement task."""
 
+import ast
+import json
+import types
 from pathlib import Path
 from typing import List
 from unittest.mock import patch
 
 import pytest
+import soundfile
+import torch
 from speechbrain.inference.separation import SepformerSeparation as separator
 
 from senselab.audio.data_structures import Audio
@@ -302,6 +307,65 @@ def test_checkpoint_override_skips_the_hub_entirely(
     model: HFModel = HFModel(path_or_uri=driftse._DRIFTSE_HF_REPO, revision=driftse._DRIFTSE_HF_REVISION)
     with pytest.raises(RuntimeError, match="stop-before-venv"):
         driftse.enhance_audios_with_driftse([mono_audio_sample], model=model)
+
+
+def test_every_driftse_worker_wav_write_names_an_explicit_subtype() -> None:
+    """No ``sf.write`` in the DriftSE worker relies on soundfile's PCM_16 default.
+
+    That default clips every sample past +-1, and it has silently corrupted a measurement three
+    times in this repository -- once costing three SepFormer streams up to 8.9% of their samples
+    and 9.5 dB of agreement with the CPU run.
+    """
+    tree = ast.parse(driftse._WORKER_SCRIPT)
+    writes = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "write"
+    ]
+    assert writes, "test premise: the worker writes WAV files"
+    for node in writes:
+        assert "subtype" in {kw.arg for kw in node.keywords}, (
+            f"sf.write at worker line {node.lineno} relies on the PCM_16 default"
+        )
+
+
+def test_driftse_input_wavs_are_written_as_float_not_pcm16(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _offline_hfmodel_construction: None
+) -> None:
+    """The WAV the host hands the DriftSE worker is FLOAT, and samples past +-1 survive it.
+
+    ``Audio.save_to_file`` writes PCM_16 for a ``.wav``, so an input peaking above full scale
+    was clipped before the enhancer ever saw it.
+    """
+    monkeypatch.setenv(driftse._DRIFTSE_CHECKPOINT_ENV, str(tmp_path))
+    monkeypatch.setattr(driftse, "ensure_venv", lambda *a, **k: Path("/tmp/fake-driftse-venv"))
+    monkeypatch.setattr(driftse, "venv_python", lambda venv_dir: "python3")
+
+    captured: dict = {}
+
+    def fake_run(
+        cmd: list, *, input: str, capture_output: bool, text: bool, timeout: float, env: dict
+    ) -> types.SimpleNamespace:
+        payload = json.loads(input)
+        captured["subtypes"] = [soundfile.info(p).subtype for p in payload["in_paths"]]
+        captured["peak"] = max(abs(soundfile.read(p, dtype="float32")[0]).max() for p in payload["in_paths"])
+        for in_path, out_path in zip(payload["in_paths"], payload["out_paths"]):
+            data, sr = soundfile.read(in_path, dtype="float32")
+            soundfile.write(out_path, data, sr, subtype="FLOAT")
+        return types.SimpleNamespace(returncode=0, stdout=json.dumps({"output_paths": payload["out_paths"]}), stderr="")
+
+    monkeypatch.setattr(driftse.subprocess, "run", fake_run)
+
+    waveform = torch.zeros(1, 16000)
+    waveform[0, 100:200] = 1.75
+    model: HFModel = HFModel(path_or_uri=driftse._DRIFTSE_HF_REPO, revision=driftse._DRIFTSE_HF_REVISION)
+    driftse.enhance_audios_with_driftse(
+        [Audio(waveform=waveform, sampling_rate=16000)],
+        model=model,
+    )
+
+    assert captured["subtypes"] == ["FLOAT"]
+    assert captured["peak"] > 1.5, "an out-of-range sample was clipped on write"
 
 
 @pytest.fixture


### PR DESCRIPTION
Three defects in the unasdiff backend, all found while measuring it on real audio, all verified before fixing.

## 1. A caller cannot select a GPU — two compounding causes

**Ours**: `separate_with_unasdiff` accepted `device`, passed it to `_select_device_and_dtype` for its side effect, and **discarded the result**. It never reached the worker payload, which built a bare `torch.device("cuda")` with no index.

**Upstream's**: `models/atten_unet.py:6` assigns `CUDA_VISIBLE_DEVICES = "0"` *before its own `import torch`*, and `models/__init__.py` is `from .atten_unet import *`, so a bare `import models` fires it. In our worker the order was `import torch` (CUDA not yet initialised) → `import models` (pin fires) → `torch.cuda.is_available()` (first CUDA call, reads the overwritten value). Verified on a 4-GPU node: four workers with distinct assignments all ran on physical GPU 0, confirmed via `/proc/<pid>/environ`.

`diffusion/gaussian_diffusion.py:34` sets the same variable but sits inside `load_spk_model` under `if device is None:` — a default-gathering branch we never reach. Left alone.

The worker now saves the mask immediately before the pinning import and restores it after, ahead of any CUDA API call. The host resolves an explicit `DeviceType` and puts it in the payload; `device=None` is forwarded as `None` rather than resolved host-side, because the host interpreter and the isolated venv have separate torch builds and only the venv's `torch.cuda.is_available()` decides where the worker can run.

Verified end to end **on a CPU host**, by running the real worker script against a fake repo reproducing the pin verbatim: with the launcher at `CUDA_VISIBLE_DEVICES=3` the worker reports `3`; without the save/restore the same fake `models` turns it into `0`.

## 2. A timeout discarded the entire run

`subprocess.run(..., timeout=3600)` was hardcoded with no `except`, so `TimeoutExpired` propagated out of the `TemporaryDirectory` and deleted every window already written. This killed a 200-step run outright.

3600 s is not merely arbitrary — it is too small for real input. Measured on an exclusive A100 node, 200 steps runs at RTF ≈ 40× (560.71 s for 14.027 s of audio), so anything past roughly 90 seconds of audio exceeded the ceiling on that hardware, and far less on CPU.

`timeout_s` is now a parameter on both `separate_with_unasdiff` and `api.separate_audios`, defaulting to `max(1800, 4.0 × 0.4 × n_windows × diffusion_steps)`. The 0.4 s per window-step is that A100 figure reduced: 560.71 s ÷ (7 windows × 200 steps). The 4× headroom and the 1800 s floor are argued in the spec — the cost of a ceiling is asymmetric, and first-use clone plus checkpoint load do not scale with windows. On timeout a `RuntimeError` names the ceiling, `completed/total` windows, input count and seconds of audio, mode, steps, device, and the knob to raise.

**Partial output is counted, not returned.** Windows 0..k overlap-add into a signal that is silent past k, so returning it would be a silently truncated separation presented as a complete one. Real resumption needs a content-addressed per-window cache keyed on commit, revision, mode, labels, steps and seed — `cached_inference`-shaped work, not a timeout handler. Filed as follow-up; the docstring now states plainly that a timeout discards everything.

## 3. PCM_16 intermediates — four sites, not two

Both workers wrote per-window files at soundfile's default WAV subtype, and **both hosts wrote their input WAVs** through `Audio.save_to_file`, also PCM_16. The input side is the worse exposure, because unasdiff's worker peak-normalises only *after* reading — anything beyond ±1 is already clipped by then.

This default has silently corrupted a measurement three separate times in this project: two analysis harnesses, and a GPU re-run in which three SepFormer streams lost up to 8.9% of samples and disagreed with the CPU pass by 9.5 dB. All four sites now write `subtype="FLOAT"` via a module constant carried in the worker payload.

Remaining default-subtype writes outside these two packages, noted in the spec and not touched here: `features_extraction/sparc.py` (×2), `text_to_speech/qwen_tts.py`, `video/tasks/input_output.py`. `yamnet.py` already had `LOSSLESS_WAV_SUBTYPE = "FLOAT"`, so three modules now carry the same literal under two names — a shared home would cross task-package boundaries and is left as follow-up.

## Verification

**16 tests added; 15 fail against the pre-fix code**, confirmed by stashing the source and rerunning. Representative pre-fix failures: `never reads CUDA_VISIBLE_DEVICES before the upstream import`; `bare torch.device('cuda') at worker line(s) [62]`; `KeyError: 'device'`; `unexpected keyword argument 'timeout_s'`; `assert ['PCM_16'] == ['FLOAT']`; `line 170 relies on the PCM_16 default`.

The sixteenth (`test_an_incompatible_device_is_rejected_before_the_venv`) passed before as well — that validation already worked. It is kept as a guard and the spec's table marks it as such rather than claiming it as a catch.

The device-ordering test is deliberately static — an AST check that the save precedes the pinning import and the restore follows every upstream import and precedes the first `torch.cuda` reference — because the pin's effect is only observable on a multi-GPU host. That limitation is stated in the spec. Nothing added needs a GPU or the real checkpoints.

- `source_separation_test.py` + `speech_enhancement_test.py`: **70 passed, 1 skipped** (the skip is the venv+CUDA end-to-end test)
- `src/tests/utils`: **325 passed, 5 skipped**
- `pre-commit run --all-files`: green over all files

## Not done, deliberately

DriftSE carries its own hardcoded `timeout=1800` and the identical device-parity docstring — same defect shape, out of scope for this branch, worth its own pass. The timeout constants are code literals rather than a `data/` profile: CLAUDE.md's rule concerns fitted thresholds that gate verdicts, and this one gates only how long a subprocess may live. That reading is argued in the spec rather than assumed.

Spec: `specs/20260818-071500-unasdiff-device-timeout-pcm16/design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
