### PR TITLE
DriftSE: send the device the caller chose, and size the timeout to the work

### DIFF
--- a/specs/20260818-235500-driftse-device-timeout/design.md
+++ b/specs/20260818-235500-driftse-device-timeout/design.md
@@ -1,0 +1,223 @@
+# DriftSE: the device that never left the host, and a ceiling that was a round number
+
+Two defects in `src/senselab/audio/tasks/speech_enhancement/driftse.py`, the same pair fixed for
+the unasdiff separation backend in `specs/20260818-071500-unasdiff-device-timeout-pcm16/design.md`.
+That document is the reference for the approach; this one records where DriftSE agrees with it,
+where it does not, and what was measured here rather than carried over.
+
+Written 2026-08-18. The PCM_16 defect (D-3 there, which also names `driftse.py`) is fixed on the
+unasdiff branch and is deliberately untouched here, so the two changes do not collide.
+
+## D-1. A caller could not select a device
+
+### What was wrong
+
+`enhance_audios_with_driftse` accepted `device`, handed it to `_select_device_and_dtype` for
+validation, and discarded the return value. Nothing about the caller's choice reached the worker
+payload; the worker picked for itself with
+
+```python
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+```
+
+The docstring said so outright — "Accepted for signature parity with the other enhancers. The
+worker selects CUDA when available and CPU otherwise" — so this was a known limitation rather than
+a silent bug. It still made the parameter a decoration on the one enhancer where the choice is a
+real decision (DriftSE is 1 NFE, so CPU is genuinely usable and a caller may want to keep the GPU
+for something else), and the bare `"cuda"` took whatever index torch defaulted to.
+
+### The upstream `CUDA_VISIBLE_DEVICES` pin does **not** reproduce here
+
+unasdiff needed a save/restore around its upstream imports because `models/atten_unet.py:6`
+assigns `os.environ["CUDA_VISIBLE_DEVICES"] = "0"` at module scope, before its own `import torch`.
+This was checked for DriftSE rather than assumed, against the pinned clone at
+`0a489dadfa2778e86e4b4b0af03f6255d2de8c69`:
+
+- A `grep -rn "CUDA_VISIBLE_DEVICES"` over the whole upstream tree returns **three hits, all in
+  shell scripts** — `train.sh:14,15` and `test.sh:10`, each `export CUDA_VISIBLE_DEVICES=$GPU_ID`
+  in a launcher the worker never runs. No Python module assigns it.
+- The worker's import chain is `backbones.ncsnpp_v2`, `backbones.ncsnpp_v2_drift` and `util.other`
+  (plus `backbones/__init__.py`, which imports all six backbones). None of them touches the
+  variable.
+
+So no save/restore was added: there is nothing to work around. The only ordering fact worth
+recording is that `util.other.set_torch_cuda_arch_list()` — called immediately before device
+selection — is the worker's first CUDA API call (`torch.cuda.is_available()`, then
+`get_device_capability` per card), and it *reads* the launcher's mask rather than writing one.
+
+### What was done
+
+The host sends the caller's device in the payload, exactly as unasdiff now does:
+
+- `device=None` sends `None`, and the worker takes `cuda:<current index>` when CUDA is available
+  and CPU otherwise. `None` is **not** resolved on the host: the host interpreter and the venv have
+  separate torch builds, and only the venv's `torch.cuda.is_available()` governs where the worker
+  can actually run. Resolving here would let a CPU-only host build silently pin a CUDA-capable
+  worker to CPU.
+- An explicit `DeviceType` goes through `_select_device_and_dtype` (validation, unchanged — MPS is
+  still rejected) and then `device_run_opt`, which returns `f"cuda:{torch.cuda.current_device()}"`
+  rather than a hardcoded `0`, so under a Slurm-style mask it names the allocated card.
+
+The worker never builds a bare `torch.device("cuda")`; an index is always chosen. A CUDA request
+the venv cannot honour raises inside the worker, naming the requested device and the mask, and
+`parse_subprocess_result` propagates it as-is.
+
+`api.enhance_audios` already forwarded `device` to this function, so nothing changed there.
+
+## D-2. A hardcoded 1800 s ceiling
+
+### What was wrong
+
+`subprocess.run(..., timeout=1800)`, hardcoded, with no `except`. On `TimeoutExpired` the exception
+propagated out of the `TemporaryDirectory` context manager, which deleted every output the worker
+had already written, and the traceback said only that a subprocess had run too long.
+
+### What one window costs, measured on this host
+
+Measured on this machine (Apple silicon, CPU — DriftSE's realistic worst case, and the reason the
+backend exists), default variant `distillhubert_three_layers_with_z`, σ 0.01, seed 0, `chunk_s=20`,
+`overlap_s=2`, warm venv and warm checkpoint cache. Inputs were tiles of
+`tutorial_audio_files/english_conversation_higgs_audio_v2.wav` at 16 kHz mono:
+
+| input | windows | wall time |
+|---|---|---|
+| 20.0 s | 1 | 24.76 s, then 23.47 s on a repeat |
+| 58.0 s | 4 | 87.92 s |
+
+Differencing removes the per-call fixed cost (interpreter start, torch import, checkpoint load):
+
+```
+(87.92 - 23.47) / 3 windows = 21.48 s per 20 s window  ->  1.074 s per window-second
+(87.92 - 24.76) / 3 windows = 21.05 s per 20 s window  ->  1.053 s per window-second
+```
+
+The fixed cost falls out as roughly 2 s on a warm cache. `_SECONDS_PER_WINDOW_SECOND = 1.1` rounds
+the larger figure up.
+
+This is a **measurement, not an estimate**, with three caveats: it is one host, one CPU, one
+checkpoint, and another agent may have been running on the machine at the time — contention makes
+it pessimistic, which is the safe direction for a ceiling. No GPU figure was taken; a GPU is
+faster, so the CPU number is the conservative basis for a ceiling that must cover both.
+
+**The old ceiling in those terms.** At 1.07 s per window-second, 1800 s of worker time covers about
+84 windows, i.e. roughly 25 minutes of audio, on this host. Any longer recording lost everything.
+
+### The formula, and why it is not unasdiff's
+
+unasdiff's cost is dominated by 200 reverse-diffusion steps per window, so its constant is seconds
+per (window x diffusion step). DriftSE is **one network evaluation per window** — that contrast is
+in its own module docstring — so there is no step count to multiply by, and copying unasdiff's
+formula would multiply this backend's cost by a number that does not exist here. The work term is
+instead the audio the worker actually pushes through the network:
+
+```
+max(_TIMEOUT_FLOOR_S, _TIMEOUT_HEADROOM x _SECONDS_PER_WINDOW_SECOND x n_windows x chunk_s)
+```
+
+| constant | value | where it comes from |
+| --- | --- | --- |
+| `_SECONDS_PER_WINDOW_SECOND` | 1.1 | the CPU measurement above, 21.48 s / 20 s window |
+| `_TIMEOUT_HEADROOM` | 4.0 | see below |
+| `_TIMEOUT_FLOOR_S` | 1800.0 | see below |
+
+`n_windows` is counted host-side by `_window_count`, which mirrors the worker's own chunking —
+fixed-length windows on a `chunk_s - overlap_s` hop, plus a final window anchored at the end of the
+signal when the regular ones do not reach it — summed over every input. Windows, not audio
+seconds, because overlap makes the worker evaluate more audio than the caller supplied: 58 s of
+input at 20/2 is four windows, i.e. 80 window-seconds.
+
+**Why the work term is per window-second rather than per window.** `chunk_s` is a caller parameter,
+and a 40 s window costs more than a 20 s one. Scaling by `chunk_s` keeps the ceiling proportionate
+when a caller changes it. The scaling is linear while the true cost is slightly superlinear — the
+NCSN++ backbone carries attention layers, which is the reason chunking exists at all — so for
+`chunk_s` well above 20 the work term underestimates. The headroom factor is what absorbs that, and
+`chunk_s` is not a knob any senselab caller currently changes.
+
+**Why a headroom factor rather than the measured number alone.** One host, one clip, warm caches,
+and a *ceiling* rather than a budget: setting it too high means a genuinely hung worker takes
+longer to fail, setting it too low means losing a multi-hour run. That asymmetry picks 4x. It is
+not a fitted threshold and nothing downstream reads it as one — it gates no verdict, only how long
+a subprocess may live — which is why it is a module constant and not a `data/` profile.
+
+**Why a floor, and why 1800.** A short input is not a short run on first use: the worker clones
+upstream at the pinned commit into its venv, `ensure_venv` may be building that venv (torch,
+torchaudio, librosa), and a 1.14 GB checkpoint is loaded before the first window is evaluated. None
+of that scales with window count. 1800 s is the value the backend already shipped, so the floor is
+also a compatibility statement: **this change never gives any call a smaller ceiling than it had.**
+The work term overtakes the floor at about 21 windows of 20 s, i.e. about 6.4 minutes of audio.
+
+**The failure is now actionable.** `TimeoutExpired` is caught and re-raised as `RuntimeError`
+naming the ceiling that fired, how many of the N outputs had been written, how many inputs and how
+many seconds of audio were being enhanced, the window count and window length, the variant, the
+device, and the `timeout_s` parameter that raises the ceiling.
+
+### Partial output: counted, not returned — for a different reason than unasdiff's
+
+The unasdiff branch declined to salvage partial output because its per-window files overlap-add
+into a signal that is silent past the last completed window, so returning it would be a silently
+truncated result presented as complete. **That argument does not transfer.** DriftSE's worker
+writes one file per *input*, with a single `sf.write` after every window of that input has been
+overlap-added, so a file that exists is complete and correct — apart, at most, from the one file
+being written at the instant the ceiling fired. There is no truncated-signal hazard: a DriftSE
+output is either whole or absent.
+
+Salvage is still refused, on two other grounds:
+
+1. **The contract is positional.** `List[Audio]`, one per input, in order. Returning the two that
+   finished out of three would silently re-associate the caller's inputs with the wrong outputs.
+   Anything safer — padding with `None`, returning a sparse mapping — is a return-type change to
+   serve a failure path, and the caller who wants per-input isolation can call per input.
+2. **Preserving the files only helps if a rerun can consume them**, which means a content-addressed
+   per-input cache keyed on (upstream commit, checkpoint revision, variant, sigma, seed, chunking)
+   plus resume logic. That is the `cached_inference` machinery with its own invalidation story, not
+   something to graft onto a timeout handler.
+
+So the completed outputs are counted and reported — that count is the useful diagnostic, since it
+says whether the ceiling was slightly or wildly too low — and discarded with the temporary
+directory. The count is `Path(p).is_file()` per expected output, which is a progress indicator and
+not a salvage manifest: it can include a file the worker was midway through writing. That costs
+nothing, because nothing is returned. The docstring says outright that every output is discarded.
+
+### `timeout_s` is not plumbed into `api.enhance_audios`
+
+unasdiff's `api.separate_audios` is a single-backend entry point, so `timeout_s` belongs on it.
+`speech_enhancement.api.enhance_audios` dispatches to SpeechBrain as well, which runs in-process and
+has no subprocess to bound; a `timeout_s` there would be a parameter that silently does nothing for
+the default backend. A caller who needs the knob calls `enhance_audios_with_driftse` directly, which
+is already the documented route for `sigma`, `variant` and the chunking. The derived default is what
+serves callers going through `enhance_audios`, and it is the reason the default has to be derived
+rather than a constant.
+
+## Tests
+
+`src/tests/audio/tasks/speech_enhancement_test.py`, nine added. All but the last fail against the
+pre-fix module:
+
+| test | defect | fails pre-fix | pre-fix failure |
+| --- | --- | --- | --- |
+| `test_the_callers_device_reaches_the_driftse_worker_payload` | D-1 | yes | `KeyError: 'device'` |
+| `test_no_device_leaves_the_choice_to_the_driftse_worker` | D-1 | yes | `KeyError: 'device'` |
+| `test_the_driftse_worker_never_requests_a_bare_cuda_device` | D-1 | yes | `assert 'torch.device("cuda" if torch.cuda.is_available() else "cpu")' not in <worker script>` |
+| `test_the_driftse_default_timeout_scales_with_windows_and_window_length` | D-2 | yes | `AttributeError: module ... has no attribute '_default_timeout_s'` |
+| `test_the_window_count_mirrors_the_workers_own_chunking` | D-2 | yes | `AttributeError: module ... has no attribute '_window_count'` |
+| `test_the_derived_driftse_ceiling_reaches_subprocess_run` | D-2 | yes | `AttributeError: ... has no attribute '_TIMEOUT_FLOOR_S'` |
+| `test_an_explicit_driftse_timeout_overrides_the_derived_one` | D-2 | yes | `TypeError: enhance_audios_with_driftse() got an unexpected keyword argument 'timeout_s'` |
+| `test_a_non_positive_driftse_timeout_raises` | D-2 | yes | same `TypeError` |
+| `test_a_driftse_timeout_names_the_ceiling_the_input_and_the_progress` | D-2 | yes | same `TypeError` |
+| `test_an_incompatible_device_is_rejected_before_the_venv` | D-1 | **no** | held before; kept as a guard on the validation the plumbing reuses |
+
+None needs a GPU, the venv or the real checkpoint: the venv, `venv_python` and `subprocess.run` are
+stubbed, and `SENSELAB_DRIFTSE_CHECKPOINT` is pointed at an empty `tmp_path` so the Hub is never
+reached. The two device-payload tests therefore assert what the host *sends*, not what a worker does
+with it; the worker's own `resolve_device` is exercised by the skip-gated end-to-end tests, and its
+CUDA branch is unreachable on any host in this repository's CI.
+
+`test_the_derived_driftse_ceiling_reaches_subprocess_run` monkeypatches `_TIMEOUT_FLOOR_S` down to
+1 s. Without that, proving the ceiling is derived rather than constant would need enough audio to
+push the work term past 1800 s — about six and a half minutes of synthetic input — for a property
+that is about arithmetic.
+
+`test_the_window_count_mirrors_the_workers_own_chunking` additionally asserts that the worker
+script still contains the two chunking lines `_window_count` mirrors. It is a string check, and it
+catches the realistic regression: someone changes the worker's windowing and the host's ceiling
+silently starts sizing a different amount of work.

--- a/src/senselab/audio/tasks/speech_enhancement/driftse.py
+++ b/src/senselab/audio/tasks/speech_enhancement/driftse.py
@@ -17,7 +17,8 @@ checkpoint file from the Hub. ``SENSELAB_DRIFTSE_CHECKPOINT`` points it at a loc
 ``last.ckpt`` + ``config.json`` instead, and then no Hub access happens at all.
 
 Design, upstream history, the pins and the measurements behind every choice here:
-``specs/20260818-083214-driftse-upstream-mit/design.md``.
+``specs/20260818-083214-driftse-upstream-mit/design.md``. The device hand-off and the derivation of
+the worker's default timeout: ``specs/20260818-235500-driftse-device-timeout/design.md``.
 """
 
 from __future__ import annotations
@@ -93,6 +94,49 @@ _DRIFTSE_DEFAULT_VARIANT = "distillhubert_three_layers_with_z"
 # Upstream enhancement.py's own constant for the Gaussian it adds to the model input.
 _DRIFTSE_DEFAULT_SIGMA = 0.01
 
+# Terms of the default worker ceiling: seconds of wall time per second of audio inside one window,
+# a headroom multiplier, and a floor. Measurement and derivation:
+# specs/20260818-235500-driftse-device-timeout/design.md.
+_SECONDS_PER_WINDOW_SECOND = 1.1
+_TIMEOUT_HEADROOM = 4.0
+_TIMEOUT_FLOOR_S = 1800.0
+
+
+def _window_count(n_samples: int, chunk_samples: int, hop_samples: int) -> int:
+    """Return how many windows the worker will evaluate for one input.
+
+    Mirrors the worker's own chunking: fixed-length windows on a regular hop, plus a final window
+    anchored at the end of the signal when the regular ones do not reach it.
+
+    Args:
+        n_samples: Length of the (resampled) input in samples.
+        chunk_samples: Window length in samples.
+        hop_samples: Distance between the starts of adjacent windows, in samples.
+
+    Returns:
+        The number of windows, at least one.
+    """
+    if n_samples <= chunk_samples:
+        return 1
+    starts = list(range(0, n_samples - chunk_samples + 1, hop_samples))
+    if starts[-1] + chunk_samples < n_samples:
+        starts.append(n_samples - chunk_samples)
+    return len(starts)
+
+
+def _default_timeout_s(n_windows: int, chunk_s: float) -> float:
+    """Return the default worker ceiling for ``n_windows`` windows of ``chunk_s`` seconds each.
+
+    Args:
+        n_windows: Total number of windows the worker will enhance, across every input.
+        chunk_s: Window length in seconds.
+
+    Returns:
+        Seconds, never below ``_TIMEOUT_FLOOR_S``.
+    """
+    return max(_TIMEOUT_FLOOR_S, _TIMEOUT_HEADROOM * _SECONDS_PER_WINDOW_SECOND * n_windows * chunk_s)
+
+
 # Worker script — runs inside the isolated venv. Clones the (non-packaged) upstream repo at a pinned
 # commit on first use and adds it to sys.path, then reuses upstream's own backbone construction and
 # spectral transforms rather than reimplementing them here.
@@ -113,6 +157,7 @@ try:
     sigma = float(args["sigma"])
     chunk_s, overlap_s = float(args["chunk_s"]), float(args["overlap_s"])
     wav_subtype = args["wav_subtype"]
+    requested_device = args.get("device")
 
     import fcntl, os, shutil, tempfile as _tempfile
 
@@ -152,7 +197,25 @@ try:
     from util.other import pad_spec, set_torch_cuda_arch_list
 
     set_torch_cuda_arch_list()  # prints and returns when CUDA is absent
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    def resolve_device(requested):
+        # The host sends its caller's choice; None means "you decide". A bare "cuda" would take
+        # whatever index torch defaults to, so an index is always chosen.
+        if requested is None:
+            return torch.device("cuda:%d" % torch.cuda.current_device() if torch.cuda.is_available() else "cpu")
+        if not str(requested).startswith("cuda"):
+            return torch.device(requested)
+        if not torch.cuda.is_available():
+            raise RuntimeError(
+                "DriftSE worker: device %r was requested but torch.cuda.is_available() is False "
+                "inside the driftse venv (CUDA_VISIBLE_DEVICES=%r)"
+                % (requested, os.environ.get("CUDA_VISIBLE_DEVICES"))
+            )
+        if ":" in str(requested):
+            return torch.device(requested)
+        return torch.device("cuda:%d" % torch.cuda.current_device())
+
+    device = resolve_device(requested_device)
     torch.manual_seed(seed)
 
     # A local override supplies its own config.json; otherwise the architecture config comes from
@@ -278,6 +341,7 @@ def enhance_audios_with_driftse(
     variant: str = _DRIFTSE_DEFAULT_VARIANT,
     chunk_s: float = 20.0,
     overlap_s: float = 2.0,
+    timeout_s: Optional[float] = None,
 ) -> List[Audio]:
     """Enhance each audio with DriftSE, one network evaluation per window.
 
@@ -288,8 +352,12 @@ def enhance_audios_with_driftse(
     Args:
         audios: Inputs. Resampled and downmixed to 16 kHz mono if needed.
         model: ``HFModel`` naming the weights repo and revision (``LIANGXU123/DriftSE``).
-        device: Accepted for signature parity with the other enhancers. The worker selects CUDA
-            when available and CPU otherwise; at 1 NFE, CPU is practical here.
+        device: Device the worker runs on. ``DeviceType.CUDA`` is resolved to an explicit
+            ``"cuda:<index>"`` (the index ``torch.cuda.current_device()`` reports in this process,
+            so under a ``CUDA_VISIBLE_DEVICES`` mask it is the allocated card) and sent to the
+            worker; ``DeviceType.CPU`` is sent as ``"cpu"``. ``None`` leaves the choice to the
+            worker, which takes ``cuda:<current index>`` when CUDA is available and CPU otherwise
+            -- at 1 NFE, CPU is practical here. Only CUDA and CPU are accepted.
         seed: RNG seed for the Gaussian perturbation, which the released checkpoints make part of
             the forward pass. Output is stochastic without it, so it is recorded in the log line.
         sigma: Scale of that Gaussian. Upstream's own default is 0.01; 0 is equivalent within
@@ -300,24 +368,42 @@ def enhance_audios_with_driftse(
         chunk_s: Window length for long inputs. Each window is peak-normalised in and peak-matched
             out on its own, exactly as upstream treats a whole file.
         overlap_s: Overlap between windows, Hann-tapered and overlap-added.
+        timeout_s: Ceiling on the worker subprocess, in seconds. ``None`` derives one from the
+            work -- total windows across every input, times ``chunk_s``, times a per-window-second
+            factor, with a floor covering the first-use venv build, clone and checkpoint load
+            (:func:`_default_timeout_s`). Exceeding it raises ``RuntimeError`` and discards every
+            output, finished or not.
 
     Returns:
         One enhanced ``Audio`` per input, in order.
 
     Raises:
-        ValueError: if ``variant`` is not a known checkpoint.
-        RuntimeError: if the worker fails; the upstream traceback is included.
+        ValueError: if ``variant`` is not a known checkpoint, if ``timeout_s`` is not positive,
+            or if ``device`` is neither CUDA nor CPU.
+        RuntimeError: if the worker fails; the upstream traceback is included. Also if the worker
+            exceeds ``timeout_s`` -- that message names the ceiling, the input, how far the worker
+            had got, and the knob that raises it.
     """
     if variant not in _DRIFTSE_VARIANTS:
         raise ValueError(f"unknown DriftSE variant {variant!r}; known: {sorted(_DRIFTSE_VARIANTS)}")
+    if timeout_s is not None and timeout_s <= 0:
+        raise ValueError(f"timeout_s must be a positive number of seconds, got {timeout_s}")
 
     if not audios:
         return []
 
     from senselab.audio.tasks.preprocessing import downmix_audios_to_mono, resample_audios
-    from senselab.utils.data_structures import _select_device_and_dtype
+    from senselab.utils.data_structures import _select_device_and_dtype, device_run_opt
 
-    _select_device_and_dtype(user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU])
+    # None is forwarded as None rather than resolved here: the host interpreter and the venv have
+    # separate torch builds, and only the venv's torch.cuda.is_available() governs where the worker
+    # can actually run.
+    worker_device: Optional[str] = None
+    if device is not None:
+        selected_device, _ = _select_device_and_dtype(
+            user_preference=device, compatible_devices=[DeviceType.CUDA, DeviceType.CPU]
+        )
+        worker_device = device_run_opt(selected_device)
 
     checkpoint_file, config_rel = _DRIFTSE_VARIANTS[variant]
 
@@ -348,9 +434,15 @@ def enhance_audios_with_driftse(
 
     mono_16k = downmix_audios_to_mono(resample_audios(audios, resample_rate=16000))
 
+    chunk_samples = int(chunk_s * 16000)
+    hop_samples = int((chunk_s - overlap_s) * 16000)
+    total_windows = sum(_window_count(int(a.waveform.shape[-1]), chunk_samples, hop_samples) for a in mono_16k)
+    effective_timeout_s = _default_timeout_s(total_windows, chunk_s) if timeout_s is None else timeout_s
+
     logger.info(
-        f"DriftSE: enhancing {len(mono_16k)} audio(s), variant={variant}, seed={seed}, "
-        f"sigma={sigma}, chunk_s={chunk_s}, overlap_s={overlap_s}"
+        f"DriftSE: enhancing {len(mono_16k)} audio(s) ({total_windows} window(s) total), "
+        f"variant={variant}, seed={seed}, sigma={sigma}, chunk_s={chunk_s}, overlap_s={overlap_s}, "
+        f"device={worker_device or 'worker-selected'}, timeout={effective_timeout_s:.10g}s"
     )
 
     with tempfile.TemporaryDirectory(prefix="senselab-driftse-") as tmpdir:
@@ -385,17 +477,30 @@ def enhance_audios_with_driftse(
                 "chunk_s": chunk_s,
                 "overlap_s": overlap_s,
                 "wav_subtype": _WAV_SUBTYPE,
+                "device": worker_device,
             }
         )
 
-        result = subprocess.run(
-            [python, "-c", _WORKER_SCRIPT],
-            input=input_json,
-            capture_output=True,
-            text=True,
-            timeout=1800,
-            env=_clean_subprocess_env(),
-        )
+        try:
+            result = subprocess.run(
+                [python, "-c", _WORKER_SCRIPT],
+                input=input_json,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout_s,
+                env=_clean_subprocess_env(),
+            )
+        except subprocess.TimeoutExpired as exc:
+            completed = sum(1 for path in out_paths if Path(path).is_file())
+            total_input_s = sum(int(a.waveform.shape[-1]) for a in mono_16k) / 16000
+            raise RuntimeError(
+                f"DriftSE worker exceeded its {effective_timeout_s:.10g}s ceiling with "
+                f"{completed}/{len(out_paths)} output(s) written, enhancing {len(mono_16k)} input(s) "
+                f"({total_input_s:.1f}s of audio at 16000 Hz, {total_windows} window(s) of "
+                f"{chunk_s:g}s) with variant={variant!r}, "
+                f"device={worker_device or 'worker-selected'}. The written outputs are discarded "
+                f"with the worker's temporary directory; pass timeout_s to raise the ceiling."
+            ) from exc
         output = parse_subprocess_result(result, venv_label="DriftSE")
 
         # Read outputs back while the temp dir is still alive: Audio(filepath=...) lazy-loads on

--- a/src/tests/audio/tasks/speech_enhancement_test.py
+++ b/src/tests/audio/tasks/speech_enhancement_test.py
@@ -582,3 +582,224 @@ def test_driftse_output_keeps_the_input_level_for_both_variants(mono_audio_sampl
     )
     clipped = float((out.waveform.abs() >= 0.999).double().mean())
     assert clipped < 0.01, f"{variant}: {clipped:.1%} of samples at full scale"
+
+
+# ── DriftSE worker device selection ───────────────────────────────────
+
+
+def _stub_driftse_worker(monkeypatch: pytest.MonkeyPatch, captured: dict, tmp_path: Path) -> None:
+    """Replace the checkpoint, the venv and the worker subprocess with fakes that record the payload.
+
+    Args:
+        monkeypatch: The test's monkeypatch fixture.
+        captured: Filled in with ``payload`` and ``timeout``.
+        tmp_path: Directory used as the local checkpoint override, so the Hub is never reached.
+    """
+    import json
+    import types
+
+    import soundfile
+
+    monkeypatch.setenv(driftse._DRIFTSE_CHECKPOINT_ENV, str(tmp_path))
+    monkeypatch.setattr(driftse, "ensure_venv", lambda *a, **k: Path("/tmp/fake-driftse-venv"))
+    monkeypatch.setattr(driftse, "venv_python", lambda venv_dir: "python3")
+
+    def fake_run(
+        cmd: list, *, input: str, capture_output: bool, text: bool, timeout: float, env: dict
+    ) -> types.SimpleNamespace:
+        payload = json.loads(input)
+        captured["payload"] = payload
+        captured["timeout"] = timeout
+        for in_path, out_path in zip(payload["in_paths"], payload["out_paths"]):
+            samples, sr = soundfile.read(in_path, dtype="float32", always_2d=True)
+            soundfile.write(out_path, samples[:, 0], sr, subtype="FLOAT")
+        return types.SimpleNamespace(returncode=0, stdout=json.dumps({"output_paths": payload["out_paths"]}), stderr="")
+
+    monkeypatch.setattr(driftse.subprocess, "run", fake_run)
+
+
+def _synthetic_audio(seconds: float) -> Audio:
+    """Return ``seconds`` of 16 kHz mono noise, well inside full scale.
+
+    Args:
+        seconds: Duration to generate.
+
+    Returns:
+        An ``Audio`` at 16 kHz.
+    """
+    import torch
+
+    return Audio(waveform=0.1 * torch.randn(1, int(seconds * 16000)), sampling_rate=16000)
+
+
+def test_the_callers_device_reaches_the_driftse_worker_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _offline_hfmodel_construction: None
+) -> None:
+    """A caller-selected device is sent to the worker instead of being validated and dropped.
+
+    ``device`` was handed to ``_select_device_and_dtype`` purely for validation and its result
+    thrown away, so the worker chose for itself and no caller could select a card.
+    """
+    captured: dict = {}
+    _stub_driftse_worker(monkeypatch, captured, tmp_path)
+
+    model: HFModel = HFModel(path_or_uri=driftse._DRIFTSE_HF_REPO)
+    enhance_audios_with_driftse([_synthetic_audio(1.0)], model=model, device=DeviceType.CPU)
+
+    assert captured["payload"]["device"] == "cpu"
+
+
+def test_no_device_leaves_the_choice_to_the_driftse_worker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _offline_hfmodel_construction: None
+) -> None:
+    """``device=None`` sends ``None``, not a device the host's own torch build happened to see.
+
+    The host interpreter and the venv have separate torch builds; only the venv's answer to
+    ``torch.cuda.is_available()`` governs where the worker can run.
+    """
+    captured: dict = {}
+    _stub_driftse_worker(monkeypatch, captured, tmp_path)
+
+    model: HFModel = HFModel(path_or_uri=driftse._DRIFTSE_HF_REPO)
+    enhance_audios_with_driftse([_synthetic_audio(1.0)], model=model)
+
+    assert captured["payload"]["device"] is None
+
+
+def test_the_driftse_worker_never_requests_a_bare_cuda_device() -> None:
+    """A bare ``torch.device("cuda")`` takes whatever index torch defaults to.
+
+    On a multi-GPU host that is card 0 regardless of the caller's choice or of a
+    ``CUDA_VISIBLE_DEVICES`` mask, so the worker always names an index.
+    """
+    script = driftse._WORKER_SCRIPT
+    assert 'torch.device("cuda" if torch.cuda.is_available() else "cpu")' not in script
+    assert "cuda:%d" in script, "the worker must name an explicit CUDA index"
+    assert 'args.get("device")' in script, "the worker must read the device the host sent"
+
+
+def test_an_incompatible_device_is_rejected_before_the_venv(_offline_hfmodel_construction: None) -> None:
+    """MPS is not one of this backend's compatible devices and must raise rather than fall back.
+
+    Held before this change too; kept as a guard on the validation the device plumbing reuses.
+    """
+    model: HFModel = HFModel(path_or_uri=driftse._DRIFTSE_HF_REPO)
+    with pytest.raises(ValueError):
+        enhance_audios_with_driftse([_synthetic_audio(1.0)], model=model, device=DeviceType.MPS)
+
+
+# ── DriftSE worker timeout ────────────────────────────────────────────
+
+
+def test_the_driftse_default_timeout_scales_with_windows_and_window_length() -> None:
+    """The ceiling is derived from the work, not a constant.
+
+    A fixed 1800 s ceiling covers about 25 minutes of audio at the per-window cost measured on
+    this host, and the run that exceeded it lost everything the worker had written.
+    """
+    assert driftse._default_timeout_s(1, 20.0) == driftse._TIMEOUT_FLOOR_S
+
+    big = driftse._default_timeout_s(200, 20.0)
+    more_windows = driftse._default_timeout_s(400, 20.0)
+    longer_windows = driftse._default_timeout_s(200, 40.0)
+    assert big > driftse._TIMEOUT_FLOOR_S
+    assert more_windows == pytest.approx(2 * big)
+    assert longer_windows == pytest.approx(2 * big)
+
+
+def test_the_window_count_mirrors_the_workers_own_chunking() -> None:
+    """The host counts the windows the worker will actually run, including the flush-to-end one.
+
+    The count only feeds the ceiling, but a count that drifts from the worker's chunking would
+    set the ceiling for a different amount of work than the worker performs.
+    """
+    chunk, hop = 20 * 16000, 18 * 16000
+    assert driftse._window_count(16000, chunk, hop) == 1, "shorter than one window"
+    assert driftse._window_count(chunk, chunk, hop) == 1, "exactly one window"
+    assert driftse._window_count(chunk + 1, chunk, hop) == 2, "one sample over -- a flush-to-end window"
+    assert driftse._window_count(38 * 16000, chunk, hop) == 2, "two regular windows, nothing left over"
+    assert driftse._window_count(58 * 16000, chunk, hop) == 4, "three regular windows plus a flush-to-end one"
+
+    # If the worker's own windowing moves, this count has to move with it.
+    assert "starts = list(range(0, total - chunk + 1, hop_samples))" in driftse._WORKER_SCRIPT
+    assert "starts.append(total - chunk)" in driftse._WORKER_SCRIPT
+
+
+def test_the_derived_driftse_ceiling_reaches_subprocess_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _offline_hfmodel_construction: None
+) -> None:
+    """The timeout ``subprocess.run`` receives is the derived one, not a hardcoded 1800."""
+    captured: dict = {}
+    _stub_driftse_worker(monkeypatch, captured, tmp_path)
+    # The floor covers the first-use venv build and would otherwise swallow the work term for any
+    # input short enough to keep this test cheap.
+    monkeypatch.setattr(driftse, "_TIMEOUT_FLOOR_S", 1.0)
+
+    model: HFModel = HFModel(path_or_uri=driftse._DRIFTSE_HF_REPO)
+    enhance_audios_with_driftse([_synthetic_audio(58.0)], model=model)
+
+    assert captured["timeout"] == driftse._default_timeout_s(4, 20.0)
+    assert captured["timeout"] != 1800
+
+
+def test_an_explicit_driftse_timeout_overrides_the_derived_one(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _offline_hfmodel_construction: None
+) -> None:
+    """``timeout_s`` is honoured verbatim."""
+    captured: dict = {}
+    _stub_driftse_worker(monkeypatch, captured, tmp_path)
+
+    model: HFModel = HFModel(path_or_uri=driftse._DRIFTSE_HF_REPO)
+    enhance_audios_with_driftse([_synthetic_audio(1.0)], model=model, timeout_s=42.0)
+
+    assert captured["timeout"] == 42.0
+
+
+def test_a_non_positive_driftse_timeout_raises(_offline_hfmodel_construction: None) -> None:
+    """A zero or negative ceiling would abort the worker instantly; reject it up front."""
+    model: HFModel = HFModel(path_or_uri=driftse._DRIFTSE_HF_REPO)
+    for bad in (0, -1.0):
+        with pytest.raises(ValueError, match="timeout_s"):
+            enhance_audios_with_driftse([_synthetic_audio(1.0)], model=model, timeout_s=bad)
+
+
+def test_a_driftse_timeout_names_the_ceiling_the_input_and_the_progress(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, _offline_hfmodel_construction: None
+) -> None:
+    """A ``TimeoutExpired`` becomes an actionable ``RuntimeError``, not a bare stack trace.
+
+    The unhandled exception said only that a subprocess had run too long: not which ceiling it
+    hit, how much audio it was given, how far it had got, or which knob raises the ceiling.
+    """
+    import json
+    import subprocess
+
+    import soundfile
+
+    monkeypatch.setenv(driftse._DRIFTSE_CHECKPOINT_ENV, str(tmp_path))
+    monkeypatch.setattr(driftse, "ensure_venv", lambda *a, **k: Path("/tmp/fake-driftse-venv"))
+    monkeypatch.setattr(driftse, "venv_python", lambda venv_dir: "python3")
+
+    def fake_run(cmd: list, *, input: str, capture_output: bool, text: bool, timeout: float, env: dict) -> None:
+        payload = json.loads(input)
+        # The first input finishes before the ceiling fires, so the error can report progress.
+        samples, sr = soundfile.read(payload["in_paths"][0], dtype="float32", always_2d=True)
+        soundfile.write(payload["out_paths"][0], samples[:, 0], sr, subtype="FLOAT")
+        raise subprocess.TimeoutExpired(cmd, timeout)
+
+    monkeypatch.setattr(driftse.subprocess, "run", fake_run)
+
+    model: HFModel = HFModel(path_or_uri=driftse._DRIFTSE_HF_REPO)
+    with pytest.raises(RuntimeError) as exc:
+        enhance_audios_with_driftse(
+            [_synthetic_audio(58.0), _synthetic_audio(20.0)], model=model, timeout_s=123.0, device=DeviceType.CPU
+        )
+
+    message = str(exc.value)
+    assert "123s" in message, "the ceiling that fired must be named"
+    assert "1/2 output(s) written" in message, "progress at the point of failure must be reported"
+    assert "78.0s of audio" in message, "the input being processed must be named"
+    assert "5 window(s) of 20s" in message, "the work the ceiling was set for must be named"
+    assert driftse._DRIFTSE_DEFAULT_VARIANT in message
+    assert "device=cpu" in message
+    assert "timeout_s" in message, "the message must name the knob that raises the ceiling"


### PR DESCRIPTION
DriftSE carried the same two defects just fixed for the unasdiff backend in #564. This closes the parity gap.

## The caller's device never reached the worker

`_select_device_and_dtype(...)` was called for its validation side-effect and its **result discarded**, so the `device` argument was documented as accepted "for signature parity" while the worker chose for itself with a bare `torch.device("cuda" if torch.cuda.is_available() else "cpu")` — no index.

Now: the host puts an explicit `"cuda:<index>"` / `"cpu"` in the payload (via `_select_device_and_dtype` then `device_run_opt`, so a Slurm mask yields the allocated card), and the worker's new `resolve_device` always names an index and raises — naming the request and the visible mask — if CUDA was asked for and the venv cannot see it. `device=None` is forwarded as `None` rather than resolved host-side, because the host interpreter and the isolated venv have separate torch builds and only the venv's `torch.cuda.is_available()` can answer. Docstring rewritten; it promised the opposite.

**The `CUDA_VISIBLE_DEVICES` import-time pin does not exist here.** unasdiff needed a save/restore around its upstream imports because `models/atten_unet.py:6` assigns the variable before its own `import torch`. Checked at DriftSE's pinned clone `0a489dad`: three hits repo-wide, all shell (`train.sh:14,15`, `test.sh:10`), in launchers the worker never runs. No Python module on the import chain assigns it — `backbones/__init__.py`, `ncsnpp_v2`, `ncsnpp_v2_drift`, `util.other` are all clean. No workaround added where none was needed.

## A one-hour... actually half-hour ceiling, replaced by one derived from the work

`timeout=1800` was hardcoded with no `except`. Now `timeout_s: Optional[float] = None`, defaulting to `max(_TIMEOUT_FLOOR_S, headroom × per_window_second × n_windows × chunk_s)`, with `_window_count` mirroring the worker's chunking (regular hop plus a flush-to-end window) summed over inputs. `TimeoutExpired` is caught and re-raised as a `RuntimeError` naming the ceiling, outputs written against expected, input count and audio seconds, window count and length, variant, device, and the `timeout_s` knob. A non-positive `timeout_s` raises before any venv work.

**The per-window-second constant rests on a measurement, not a guess.** Taken on this host with a warm venv and warm checkpoint: 20 s input / 1 window → 24.76 s then 23.47 s; 58 s input / 4 windows → 87.92 s. Differencing out the ~2 s fixed cost gives `(87.92 − 23.47)/3 = 21.48 s` per 20 s window = **1.074 s per window-second**, set to 1.1. The machine was under concurrent load, which biases the figure pessimistic — the safe direction for a ceiling, and the reason it is usable as an upper bound rather than as a cost. Headroom 4×; floor kept at 1800 s so no call gets a smaller ceiling than before, and because first use pays venv build, clone and a 1.14 GB checkpoint load.

**unasdiff's formula was deliberately not copied.** There is no diffusion-step count here — DriftSE is 1 NFE — so the work term is windows × window length rather than windows × steps. The per-window-second form keeps the ceiling proportionate if a caller changes `chunk_s`, at the cost of being linear where attention makes the true cost slightly superlinear; the headroom absorbs that. For scale, at the measured rate the old 1800 s ceiling covered roughly 25 minutes of audio on this host.

## Partial output refused, for a different reason than unasdiff's

unasdiff's argument does not transfer. Its worker writes per-window files that overlap-add into a signal silent past the last completed window, so returning it would be a silently truncated separation. DriftSE writes one file per **input**, with a single `sf.write` after all of that input's windows are overlap-added — so an output is whole or absent.

Salvage is still refused, because the contract is a positional `List[Audio]`: returning 2 of 3 would re-associate the caller's inputs with the wrong outputs. Completed outputs are counted and reported as a progress diagnostic only.

## Verification

**Nine tests added; nine fail against the pre-fix file**, verified by stashing `driftse.py` alone. Representative messages: `KeyError: 'device'`; `assert 'torch.device("cuda" if torch.cuda.is_available() else "cpu")' not in <worker script>`; `AttributeError: module has no attribute '_default_timeout_s'` / `'_window_count'` / `'_TIMEOUT_FLOOR_S'`; `TypeError: enhance_audios_with_driftse() got an unexpected keyword argument 'timeout_s'`.

A tenth (`test_an_incompatible_device_is_rejected_before_the_venv`, MPS) passed pre-fix as well — that validation already worked. It is kept as a guard and labelled as such in the spec rather than counted as a catch.

None of the new tests needs a GPU, the venv or the real checkpoint. The worker's `resolve_device` CUDA branch is unreachable in CI here; it was exercised for real on CPU, where explicit `DeviceType.CPU` and `None` both enhance correctly and a 0.5 s ceiling produces the actionable message.

- `speech_enhancement_test.py`: **44 passed** (includes the venv-gated end-to-end DriftSE tests, which ran)
- `pre-commit run --all-files`: green over all files

## Scope

`timeout_s` was deliberately **not** added to `api.enhance_audios` — that entry point also dispatches to in-process SpeechBrain, where the parameter would do nothing.

Spec: `specs/20260818-235500-driftse-device-timeout/design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
