### PR TITLE
SpeechBrain: a separation checkpoint was returned as interleaved samples

### DIFF
--- a/specs/20260819-speechbrain-separation-guard/design.md
+++ b/specs/20260819-speechbrain-separation-guard/design.md
@@ -1,0 +1,70 @@
+# SpeechBrain: a separation checkpoint returned interleaved samples as audio
+
+## The defect
+
+`speech_enhancement/speechbrain.py` reshaped `SepformerSeparation.separate_batch`'s output with
+`reshape(1, -1)`. That output is `(batch, samples, sources)`. For an enhancement checkpoint there is
+one source and the reshape is correct. For a separation checkpoint it **interleaves the sources
+sample-by-sample**, and senselab returned the result as audio with no warning.
+
+Measured through `enhance_audios` on a 14.03 s recording, every reachable SepFormer separation
+checkpoint: `sepformer-wsj02mix`, `-wsj03mix`, `-libri2mix`, `-whamr16k`, `-wham`, `-whamr`,
+`resepformer-wsj02mix`.
+
+| symptom | value |
+| --- | --- |
+| output length against input | exactly **2.000×** (3.000× for `wsj03mix`) |
+| cross-correlation peak with input | **\|r\| ≤ 0.08**, at a lag of 50k-154k samples |
+| ASR transcript | **empty**, for every one of the seven |
+
+De-interleaving post hoc recovered streams matching direct-call `src0`/`src1` measurements exactly, so
+nothing was lost — the output was purely mis-shaped.
+
+## The fix
+
+`_single_source` derives the source count from the **output shape**, not from the model name. A name
+rule would misclassify any checkpoint whose id does not advertise itself; the shape is authoritative.
+More than one source raises, naming the model, the count, and pointing the caller at
+`source_separation`. One source has its source axis dropped; a 2-D output passes through, since
+`enhance_batch` returns `(batch, samples)` with no source axis.
+
+Raising is the correct outcome rather than a workaround: `enhance_audios` returns one `Audio` per
+input, so it structurally cannot represent an N-source separation. Exposing SpeechBrain separation
+under `source_separation/`, where the return type fits, is the useful follow-up and is left for the
+pass that is concurrently adding ClearerVoice separation there.
+
+## Prior work included by cherry-pick
+
+PR #525 by Jordan Wilke is included as its two original commits, authorship preserved, rebased onto
+`triage`. It replaces the previous try-one-class-then-fall-back loader selection with `_loader_for`,
+mapping `"sepformer"` in the id to `SepformerSeparation` and everything else to
+`SpectralMaskEnhancement`, plus a fallback for off-convention names.
+
+**That PR identified this defect and scoped it out deliberately**, writing in `_loader_for`'s docstring
+that "true multi-speaker separation checkpoints … are out of scope here, because
+`enhance_audios_with_speechbrain` reshapes the model output to a single waveform and would garble
+multiple separated sources." This branch adds the part they left, and does not correct them.
+
+Two conflicts arose because `speechbrain.py` moved under three merges since June, and both were
+resolved in favour of the newer code: the load now uses `source=str(snapshot_path)` — SpeechBrain's
+`from_hparams` takes no `revision`, so the immutable snapshot path is how a revision is pinned — and
+`run_opts={"device": device_run_opt(device)}` rather than `device.value`.
+
+## Tests
+
+Six, in `TestSpeechBrainSourceGuard`. Five exercise `_single_source` directly. The sixth is the one
+that matters: it drives the **public** `enhance_audios_with_speechbrain` path with a stub separator
+returning `(1, T, 2)`, and pre-fix it reaches a length assertion that fails with
+`interleaved: 32000 samples from 16000 in (2.000x)` — pinning the defect rather than the presence of a
+helper. The other five fail pre-fix on `AttributeError`, which is weaker evidence and is recorded as
+such.
+
+## Not fixed here
+
+`mtl-mimic-voicebank` still fails, at inference rather than load: `SpectralMaskEnhancement` rejects it
+(`Need hparams['compute_stft']`), the `SepformerSeparation` fallback constructs and then dies in
+`separate_batch` with `AttributeError: 'ModuleDict' object has no attribute 'encoder'`. It is a
+`WaveformEnhancement` checkpoint, and `speechbrain` 1.1.0 also ships `SGMSEEnhancement`; senselab tries
+neither. Routing it needs a third and fourth loader class and a decision about how they are selected —
+`_loader_for`'s name mapping would need extending, and a name rule is exactly what this branch avoided
+for the source count. Left as a separate change rather than half-done alongside a guard.

--- a/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
+++ b/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
@@ -128,6 +128,36 @@ class SpeechBrainEnhancer:
 
         return cls._models[key], device, dtype
 
+
+    @staticmethod
+    def _single_source(waveform: "torch.Tensor", model: SpeechBrainModel) -> "torch.Tensor":
+        """Return the one enhanced source, refusing a multi-source separation output.
+
+        ``SepformerSeparation.separate_batch`` returns ``(batch, samples, sources)``. An
+        enhancement checkpoint yields one source; a separation checkpoint yields two or three.
+
+        Args:
+            waveform: The tensor returned by ``separate_batch``.
+            model: The model that produced it, named in the error.
+
+        Returns:
+            The waveform with the source axis dropped.
+
+        Raises:
+            ValueError: If more than one source is present.
+        """
+        if waveform.ndim < 3:
+            return waveform
+        n_sources = waveform.shape[-1]
+        if n_sources > 1:
+            raise ValueError(
+                f"{model.path_or_uri} returned {n_sources} separated sources. "
+                "enhance_audios yields one Audio per input and cannot represent a multi-source "
+                "separation; flattening them here would interleave the sources sample-by-sample. "
+                "Use senselab.audio.tasks.source_separation for separation checkpoints."
+            )
+        return waveform[..., 0]
+
     @classmethod
     def enhance_audios_with_speechbrain(
         cls, audios: List[Audio], model: Optional[SpeechBrainModel] = None, device: Optional[DeviceType] = None
@@ -195,6 +225,7 @@ class SpeechBrainEnhancer:
                         enhanced_waveform = enhancer.enhance_batch(segment.waveform, lengths=torch.tensor([1.0]))
                     else:
                         enhanced_waveform = enhancer.separate_batch(segment.waveform)
+                        enhanced_waveform = cls._single_source(enhanced_waveform, model)
 
                     enhanced_segments.append(
                         Audio(waveform=enhanced_waveform.reshape(1, -1), sampling_rate=segment.sampling_rate)

--- a/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
+++ b/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
@@ -1,7 +1,7 @@
 """This module provides the Speechbrain interface for speech enhancement."""
 
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -33,7 +33,7 @@ class SpeechBrainEnhancer:
     _models: Dict[str, Union["separator", "enhance_model"]] = {}
 
     @staticmethod
-    def _loader_for(model_uri: str) -> Any:  # noqa: ANN401  # the speechbrain class (untyped third-party)
+    def _loader_for(model_uri: str) -> Union[type["separator"], type["enhance_model"]]:
         """Return the speechbrain inference class for an *enhancement* ``model_uri``.
 
         Both supported model families are enhancers (denoisers); they differ only in
@@ -56,8 +56,8 @@ class SpeechBrainEnhancer:
             model_uri (str): The model path or URI.
 
         Returns:
-            type: ``SepformerSeparation`` for SepFormer enhancement checkpoints,
-                else ``SpectralMaskEnhancement``.
+            The ``SepformerSeparation`` class for SepFormer enhancement checkpoints,
+            else the ``SpectralMaskEnhancement`` class.
         """
         return separator if "sepformer" in model_uri.lower() else enhance_model
 
@@ -99,12 +99,32 @@ class SpeechBrainEnhancer:
             loader = cls._loader_for(str(model.path_or_uri))
             logger.debug("Loading %s as %s", model.path_or_uri, loader.__name__)
             with speechbrain_loading_cwd(savedir):
-                cls._models[key] = retry_on_transient_error(
-                    loader.from_hparams,
-                    source=str(snapshot_path),
-                    savedir=str(savedir),
-                    run_opts={"device": device_run_opt(device)},
-                )
+                try:
+                    cls._models[key] = retry_on_transient_error(
+                        loader.from_hparams,
+                        source=str(snapshot_path),
+                        savedir=str(savedir),
+                        run_opts={"device": device_run_opt(device)},
+                    )
+                except Exception as e:
+                    # _loader_for routes by name; it is wrong only for off-convention
+                    # models -- e.g. a custom SepFormer checkpoint whose path lacks
+                    # "sepformer", which routes to SpectralMaskEnhancement. Fall back to
+                    # SepformerSeparation for that catch-all branch; a sepformer-named
+                    # model that fails to load is a genuine error, so re-raise.
+                    if loader is not enhance_model:
+                        raise
+                    logger.info(
+                        "SpectralMaskEnhancement failed for %s; trying SepformerSeparation: %s",
+                        model.path_or_uri,
+                        e,
+                    )
+                    cls._models[key] = retry_on_transient_error(
+                        separator.from_hparams,
+                        source=str(snapshot_path),
+                        savedir=str(savedir),
+                        run_opts={"device": device_run_opt(device)},
+                    )
 
         return cls._models[key], device, dtype
 

--- a/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
+++ b/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
@@ -1,7 +1,7 @@
 """This module provides the Speechbrain interface for speech enhancement."""
 
 import time
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -31,6 +31,35 @@ class SpeechBrainEnhancer:
     MAX_DURATION_SECONDS = 60  # Maximum duration per segment in seconds
     MIN_LENGTH = 16  # kernel size for speechbrain/sepformer-wham16k-enhancement
     _models: Dict[str, Union["separator", "enhance_model"]] = {}
+
+    @staticmethod
+    def _loader_for(model_uri: str) -> Any:  # noqa: ANN401  # the speechbrain class (untyped third-party)
+        """Return the speechbrain inference class for an *enhancement* ``model_uri``.
+
+        Both supported model families are enhancers (denoisers); they differ only in
+        architecture, which dictates the speechbrain inference wrapper:
+
+        - SepFormer-architecture enhancement checkpoints (e.g. ``sepformer-wham16k-enhancement``,
+          ``sepformer-dns4-16k-enhancement``) load via ``SepformerSeparation`` — that is just
+          SepFormer's inference class; for an enhancement checkpoint it emits a single cleaned source.
+        - Spectral-mask checkpoints (e.g. ``metricgan-plus-voicebank``, ``mtl-mimic-voicebank``)
+          load via ``SpectralMaskEnhancement``.
+
+        The architecture is an unambiguous discriminator in the name, so we map it directly
+        rather than loading one class and falling back on the ``compute_stft``/hparams error the
+        wrong class would raise. NOTE: this is keyed on ``sepformer`` (the architecture), not on
+        "separation" — true multi-speaker separation checkpoints (e.g. ``sepformer-wsj02mix``)
+        are out of scope here, because :meth:`enhance_audios_with_speechbrain` reshapes the model
+        output to a single waveform and would garble multiple separated sources.
+
+        Args:
+            model_uri (str): The model path or URI.
+
+        Returns:
+            type: ``SepformerSeparation`` for SepFormer enhancement checkpoints,
+                else ``SpectralMaskEnhancement``.
+        """
+        return separator if "sepformer" in model_uri.lower() else enhance_model
 
     @classmethod
     def _get_speechbrain_model(
@@ -67,22 +96,15 @@ class SpeechBrainEnhancer:
             # ``revision`` arg, so we pin via the immutable snapshot path.
             _, snapshot_path = resolve_model(str(model.path_or_uri), model.revision or "main")
             savedir = speechbrain_savedir(str(model.path_or_uri), model.revision)
+            loader = cls._loader_for(str(model.path_or_uri))
+            logger.debug("Loading %s as %s", model.path_or_uri, loader.__name__)
             with speechbrain_loading_cwd(savedir):
-                try:
-                    cls._models[key] = retry_on_transient_error(
-                        enhance_model.from_hparams,
-                        source=str(snapshot_path),
-                        savedir=str(savedir),
-                        run_opts={"device": device_run_opt(device)},
-                    )
-                except Exception as e:
-                    logger.info("Trying SepformerSeparation model after SpectralMaskEnhancement failed: %s", e)
-                    cls._models[key] = retry_on_transient_error(
-                        separator.from_hparams,
-                        source=str(snapshot_path),
-                        savedir=str(savedir),
-                        run_opts={"device": device_run_opt(device)},
-                    )
+                cls._models[key] = retry_on_transient_error(
+                    loader.from_hparams,
+                    source=str(snapshot_path),
+                    savedir=str(savedir),
+                    run_opts={"device": device_run_opt(device)},
+                )
 
         return cls._models[key], device, dtype
 

--- a/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
+++ b/src/senselab/audio/tasks/speech_enhancement/speechbrain.py
@@ -128,7 +128,6 @@ class SpeechBrainEnhancer:
 
         return cls._models[key], device, dtype
 
-
     @staticmethod
     def _single_source(waveform: "torch.Tensor", model: SpeechBrainModel) -> "torch.Tensor":
         """Return the one enhanced source, refusing a multi-source separation output.

--- a/src/tests/audio/tasks/speech_enhancement_test.py
+++ b/src/tests/audio/tasks/speech_enhancement_test.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 import soundfile
 import torch
+from speechbrain.inference.enhancement import SpectralMaskEnhancement as enhance_model
 from speechbrain.inference.separation import SepformerSeparation as separator
 
 from senselab.audio.data_structures import Audio
@@ -366,6 +367,20 @@ def test_driftse_input_wavs_are_written_as_float_not_pcm16(
 
     assert captured["subtypes"] == ["FLOAT"]
     assert captured["peak"] > 1.5, "an out-of-range sample was clipped on write"
+
+
+@pytest.mark.parametrize(
+    ("model_uri", "expected"),
+    [
+        ("speechbrain/sepformer-wham16k-enhancement", separator),
+        ("speechbrain/sepformer-wsj02mix", separator),
+        ("speechbrain/metricgan-plus-voicebank", enhance_model),
+        ("speechbrain/mtl-mimic-voicebank", enhance_model),
+    ],
+)
+def test_loader_for_selects_class_by_name(model_uri: str, expected: type) -> None:
+    """The interface class is chosen directly from the model name, no load needed."""
+    assert SpeechBrainEnhancer._loader_for(model_uri) is expected
 
 
 @pytest.fixture

--- a/src/tests/audio/tasks/speech_enhancement_test.py
+++ b/src/tests/audio/tasks/speech_enhancement_test.py
@@ -818,3 +818,80 @@ def test_a_driftse_timeout_names_the_ceiling_the_input_and_the_progress(
     assert driftse._DRIFTSE_DEFAULT_VARIANT in message
     assert "device=cpu" in message
     assert "timeout_s" in message, "the message must name the knob that raises the ceiling"
+
+
+class TestSpeechBrainSourceGuard:
+    """A separation checkpoint must be refused, not flattened into interleaved samples.
+
+    Measured through ``enhance_audios`` before this guard: seven reachable SepFormer separation
+    checkpoints returned output of exactly 2.000x the input length (3.000x for ``wsj03mix``), with
+    cross-correlation peak |r| <= 0.08 against the input and an empty ASR transcript. The sources
+    were all present, merely interleaved sample-by-sample by ``reshape(1, -1)`` over
+    ``(batch, samples, sources)``. See specs/20260819-speechbrain-separation-guard/design.md.
+    """
+
+    @staticmethod
+    def _model() -> SpeechBrainModel:
+        return SpeechBrainModel(path_or_uri="speechbrain/sepformer-wsj02mix", revision="main")
+
+    def test_two_sources_are_refused_rather_than_interleaved(self) -> None:
+        """The defect: (1, T, 2) must raise, not become a 2T-long waveform."""
+        two_sources = torch.stack([torch.zeros(16000), torch.ones(16000)], dim=-1).unsqueeze(0)
+        assert two_sources.shape == (1, 16000, 2)
+        with pytest.raises(ValueError, match="2 separated sources"):
+            SpeechBrainEnhancer._single_source(two_sources, self._model())
+
+    def test_three_sources_are_refused(self) -> None:
+        """``wsj03mix`` returned 3.000x the input length."""
+        three = torch.zeros(1, 16000, 3)
+        with pytest.raises(ValueError, match="3 separated sources"):
+            SpeechBrainEnhancer._single_source(three, self._model())
+
+    def test_the_error_points_at_source_separation(self) -> None:
+        """A caller must be told where the capability actually lives."""
+        with pytest.raises(ValueError, match="source_separation"):
+            SpeechBrainEnhancer._single_source(torch.zeros(1, 100, 2), self._model())
+
+    def test_one_source_drops_the_source_axis(self) -> None:
+        """An enhancement checkpoint yields (1, T, 1); the samples must survive unchanged."""
+        ramp = torch.linspace(-1.0, 1.0, 16000)
+        one_source = ramp.reshape(1, 16000, 1)
+        out = SpeechBrainEnhancer._single_source(one_source, self._model())
+        assert out.shape == (1, 16000)
+        assert torch.equal(out.reshape(-1), ramp)
+
+    def test_a_two_dimensional_output_is_passed_through(self) -> None:
+        """``enhance_batch`` returns (batch, samples) with no source axis to drop."""
+        already_flat = torch.zeros(1, 16000)
+        out = SpeechBrainEnhancer._single_source(already_flat, self._model())
+        assert out.shape == (1, 16000)
+
+    def test_the_public_path_refuses_instead_of_doubling_the_length(self) -> None:
+        """The behavioural test: pre-fix this produced audio of exactly 2x the input length.
+
+        Fails before the guard with a length assertion rather than an AttributeError, so it pins
+        the defect and not merely the presence of a helper.
+        """
+        samples = 16000
+        audio = Audio(waveform=torch.zeros(1, samples), sampling_rate=8000)
+
+        class _TwoSourceSeparator:
+            hparams = types.SimpleNamespace(sample_rate=8000)
+
+            def separate_batch(self, waveform: torch.Tensor) -> torch.Tensor:
+                n = waveform.shape[-1]
+                return torch.stack([torch.zeros(n), torch.ones(n)], dim=-1).unsqueeze(0)
+
+        with patch.object(
+            SpeechBrainEnhancer,
+            "_get_speechbrain_model",
+            return_value=(_TwoSourceSeparator(), DeviceType.CPU, torch.float32),
+        ):
+            with pytest.raises(ValueError, match="2 separated sources"):
+                out = SpeechBrainEnhancer.enhance_audios_with_speechbrain(audios=[audio], model=self._model())
+                # Unreachable once the guard exists. Pre-fix, execution arrives here and the
+                # assertion below is what fails, naming the actual defect.
+                assert out[0].waveform.shape[-1] == samples, (
+                    f"interleaved: {out[0].waveform.shape[-1]} samples from {samples} in "
+                    f"({out[0].waveform.shape[-1] / samples:.3f}x)"
+                )


### PR DESCRIPTION
`senselab` returned **non-audio** for seven model ids, silently. Includes @wilke0818's #525 by cherry-pick with authorship preserved, and adds the case that PR deliberately scoped out.

## The defect

`speechbrain.py` reshaped `SepformerSeparation.separate_batch`'s output with `reshape(1, -1)`. That output is `(batch, samples, sources)`. One source — an enhancement checkpoint — reshapes correctly. Two or three sources — a separation checkpoint — get **interleaved sample-by-sample**, and the result was returned as audio with no warning.

Measured through `enhance_audios` on a 14.03 s recording, for every reachable SepFormer separation checkpoint (`sepformer-wsj02mix`, `-wsj03mix`, `-libri2mix`, `-whamr16k`, `-wham`, `-whamr`, `resepformer-wsj02mix`):

| symptom | value |
|---|---|
| output length vs input | exactly **2.000×** (3.000× for `wsj03mix`) |
| cross-correlation peak with input | **\|r\| ≤ 0.08**, at a lag of 50k–154k samples |
| ASR transcript | **empty**, all seven |

De-interleaving post hoc recovers streams that match direct-call `src0`/`src1` measurements exactly — nothing was lost, the output was purely mis-shaped.

## The fix

`_single_source` derives the source count from the **output shape**, not the model name. A name rule would misclassify any checkpoint whose id doesn't advertise itself; the shape is authoritative. More than one source raises, naming the model and count and pointing at `source_separation`. One source has its source axis dropped. A 2-D output passes through, since `enhance_batch` returns `(batch, samples)` with no source axis.

Raising is correct rather than a workaround: `enhance_audios` returns one `Audio` per input, so it structurally cannot represent an N-source separation. Exposing SpeechBrain separation under `source_separation/`, where the return type fits, is the useful follow-up — left to the pass concurrently adding ClearerVoice separation there, so the two share conventions.

## Prior work, by cherry-pick

@wilke0818's two commits from #525 are included unchanged in substance, authorship preserved, rebased onto `triage`. They replace try-one-class-then-fall-back loader selection with `_loader_for` — `"sepformer"` in the id → `SepformerSeparation`, else `SpectralMaskEnhancement` — plus a fallback for off-convention names.

**That PR found this defect and scoped it out on purpose**, writing in `_loader_for`'s docstring that "true multi-speaker separation checkpoints … are out of scope here, because `enhance_audios_with_speechbrain` reshapes the model output to a single waveform and would garble multiple separated sources." This branch adds what they left; it does not correct them. #525 is commented with the measurements and its author can close it or land it on its original base as they prefer.

Two conflicts arose because `speechbrain.py` moved under three merges since June, both resolved toward the newer code: `source=str(snapshot_path)` — SpeechBrain's `from_hparams` takes no `revision`, so the immutable snapshot path *is* the pin — and `run_opts={"device": device_run_opt(device)}` rather than `device.value`.

## Tests

Six in `TestSpeechBrainSourceGuard`. Five exercise `_single_source` directly and fail pre-fix on `AttributeError`, which is weak evidence and is labelled as such in the spec.

The sixth is the one that matters: it drives the **public** `enhance_audios_with_speechbrain` path with a stub separator returning `(1, T, 2)`. Pre-fix it reaches a length assertion and fails with `interleaved: 32000 samples from 16000 in (2.000x)` — pinning the defect rather than the presence of a helper.

`speech_enhancement_test.py`: **44 passed**. `pre-commit run --all-files` green.

## Not fixed here, deliberately

`mtl-mimic-voicebank` still fails, at inference rather than load: `SpectralMaskEnhancement` rejects it (`Need hparams['compute_stft']`), the `SepformerSeparation` fallback constructs and then dies in `separate_batch` with `AttributeError: 'ModuleDict' object has no attribute 'encoder'`. It is a `WaveformEnhancement` checkpoint, and `speechbrain` 1.1.0 also ships `SGMSEEnhancement`; senselab tries neither. Routing it needs a third and fourth loader class plus a decision on how they're selected — and extending a *name* map is exactly what this branch avoided for the source count. A separate change rather than half-done alongside a guard.

Spec: `specs/20260819-speechbrain-separation-guard/design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
