### PR TITLE
One audio write policy, and a guard so silent clipping cannot return

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,8 +70,8 @@ repos:
     # Encoder, a model name. preemptable: Slurm's own spelling (PreemptMode, the
     # mit_preemptable partition) -- codespell wants "preemptible", but that is not the
     # partition's actual name. All four are terms codespell reads as misspellings of other
-    # words.
-    args: [--skip=*.ipynb, --ignore-words-list, 'AER,FPR,PASE,preemptable']
+    # words. caf: Apple's Core Audio Format, a libsndfile format name.
+    args: [--skip=*.ipynb, --ignore-words-list, 'AER,FPR,PASE,preemptable,caf']
     additional_dependencies:
     - tomli
 - repo: local

--- a/specs/20260819-091500-wav-subtype-sweep/design.md
+++ b/specs/20260819-091500-wav-subtype-sweep/design.md
@@ -1,0 +1,278 @@
+# The PCM_16 default, swept repo-wide instead of one backend at a time
+
+`soundfile.write` takes its subtype from the file extension when the caller does not name one, and
+for both WAV and FLAC that default is `PCM_16`. Samples beyond ±1 are hard-clipped; everything else
+is quantized with a floor at −96 dBFS. The call succeeds, the file is readable, and nothing reports
+that the samples are not the ones that were handed over.
+
+That default has now cost this project four measurements:
+
+1. two analysis harnesses;
+2. a GPU re-run in which three SepFormer streams lost up to 8.9% of their samples and disagreed
+   with the CPU pass by 9.5 dB;
+3. DriftSE's plain-checkpoint output, whose input-output correlation fell from 0.995 to 0.204
+   because 98.5% of samples were clipped into a square wave.
+
+Two backends were fixed in PRs #564 and #566 —
+`specs/20260818-071500-unasdiff-device-timeout-pcm16` §D-3 fixed four sites and closed with an
+inventory of the ones it did not touch, plus the note that the constant then existed under two
+names in three modules. This change is that inventory, done: every remaining write, the shared
+constant, and a guard so the next one fails a test instead of a measurement.
+
+## The inventory, re-verified
+
+The starting list came from `grep -rn "sf.write\|soundfile.write" src/senselab --include="*.py"`.
+Re-running it found the same twelve call sites and no multi-line call the grep had missed. Two
+things in the inherited classification were wrong:
+
+- **`features_extraction/sparc.py:126` and `:165` are FLAC sites, not WAV sites.** Both write
+  `Path(output_dir) / "decoded.flac"` and `"converted.flac"`, so libsndfile infers FLAC from the
+  extension. They took `PCM_16` all the same — FLAC's default is also `PCM_16` — but the fix
+  available to them is not the one a WAV site gets, so they belong with the FLAC group. That makes
+  `text_to_speech/qwen_tts.py:212` the only true WAV site left in the repository.
+- **`video/tasks/input_output.py:70` is not a third category so much as the only site where the
+  container is the caller's.** Everything else writes a temp file senselab controls end to end.
+
+## What each site did, and does now
+
+| site | container | before | after |
+| --- | --- | --- | --- |
+| `audio/tasks/features_extraction/sparc.py` decode worker | `.flac` → `.wav` | default `PCM_16` | `subtype=wav_subtype` (`FLOAT`) |
+| `audio/tasks/features_extraction/sparc.py` convert worker | `.flac` → `.wav` | default `PCM_16` | `subtype=wav_subtype` (`FLOAT`) |
+| `audio/tasks/voice_cloning/sparc.py` worker | `.flac` → `.wav` | `format="FLAC"`, default `PCM_16` | `subtype=wav_subtype` (`FLOAT`) |
+| `audio/tasks/voice_cloning/coqui.py` worker | `.flac` → `.wav` | `format="FLAC"`, default `PCM_16` | `subtype=wav_subtype` (`FLOAT`) |
+| `audio/tasks/text_to_speech/coqui.py` worker | `.flac` → `.wav` | `format="FLAC"`, default `PCM_16` | `subtype=wav_subtype` (`FLOAT`) |
+| `audio/tasks/text_to_speech/qwen_tts.py` worker | `.wav` | default `PCM_16` | `subtype=wav_subtype` (`FLOAT`) |
+| `video/tasks/input_output.py` | caller's | default for that format | `widest_subtype(fmt, dtype)` + a clipping warning |
+| `audio/tasks/classification/yamnet.py` | `.wav` | already `FLOAT`, own constant | imports the shared constant |
+| `audio/tasks/source_separation/unasdiff.py` (2 sites) | `.wav` | already `FLOAT`, own constant | imports the shared constant |
+| `audio/tasks/speech_enhancement/driftse.py` (2 sites) | `.wav` | already `FLOAT`, own constant | imports the shared constant |
+
+Every one of the five FLAC sites writes into a `tempfile.TemporaryDirectory` whose paths the parent
+reads back through `Audio(filepath=...)` and then discards, so changing the container changes
+nothing a caller can observe. No parent constructs those paths; the worker returns them in its JSON
+result.
+
+## The FLAC judgement, and the evidence behind it
+
+FLAC is an integer codec: `soundfile.available_subtypes("FLAC")` is `{PCM_S8, PCM_16, PCM_24}`, so
+`subtype="FLOAT"` raises there and "write FLOAT everywhere" is not available as a policy. For each
+FLAC site the question was whether the data is guaranteed in-range (then `PCM_24` costs nothing but
+quantization at −144 dBFS), or whether the container has to change.
+
+**Measured, by calling the models rather than reasoning about them.** Both venvs
+(`~/.cache/senselab/venvs/{sparc,coqui}`) and all four checkpoints were already warm, so each of
+these is a real call on `src/tests/data_for_testing/` audio:
+
+| path | model | peak | fraction over ±1 |
+| --- | --- | --- | --- |
+| SPARC `coder.convert(src, trg)` | `cheoljun95/Speech-Articulatory-Coding`, multi | 0.3216 | 0 |
+| SPARC `coder.decode(...)` | same | 0.4194 | 0 |
+| Coqui VC `tts.voice_conversion(...)` | `knnvc` + `wavlm-hifigan_prematched` | 0.6930 | 0 |
+| Coqui TTS `tts.tts(...)` | `xtts_v2`, one plain English sentence | 0.8846 | 0 |
+
+Nothing clipped, which is why no one has reported these as broken. But the *bound* is what matters,
+and it is not uniform:
+
+- **SPARC is bounded by construction.** `sparc.sparc.SPARC.decode` returns the generator output
+  with no post-processing, and the loaded checkpoint's `generator.output_conv` is
+  `Sequential(LeakyReLU, Conv1d(32→1, k=7), Tanh)` — inspected on the real model, not inferred from
+  `use_tanh`'s default. `convert` is `decode` after a pitch shift, so it inherits the bound. Both
+  SPARC sites are therefore genuinely in-range.
+- **Coqui voice conversion is bounded, but one layer further out.** `KNNVC.voice_conversion`
+  returns *features*; `Synthesizer.voice_conversion` then runs `self.vocoder_model.inference(...)`,
+  and that generator ends in `torch.tanh` (`TTS/vocoder/models/hifigan_generator.py:287`).
+  FreeVC — the other model a caller might pass — ends in `torch.tanh` too
+  (`TTS/vc/models/freevc.py:156`). But the model is a `CoquiTTSModel` the caller supplies, so the
+  bound is a property of today's default rather than of the code path.
+- **Coqui TTS is not bounded.** XTTS-v2 decodes through its own `HifiganGenerator` in
+  `TTS/tts/layers/xtts/hifigan_decoder.py`, which contains zero occurrences of `tanh`; the module
+  returns `self.waveform_decoder(z, g=g)` directly. `TTS.api.TTS.tts()` returns that raw output.
+  Upstream never writes it as-is: `TTS/utils/audio/numpy_transforms.py:save_wav` does
+  `wav * (32767 / max(0.01, np.max(np.abs(wav))))` — an unconditional peak normalization — which
+  senselab bypasses by calling `tts()` rather than `tts_to_file()`. So the one measurement is
+  0.885, i.e. 1.1 dB of headroom, on a model whose own maintainers rescale rather than trust the
+  range.
+
+**Decision: WAV/`FLOAT` for all five, not FLAC/`PCM_24`.**
+
+- One of the five is provably unbounded, and the two Coqui sites take a caller-supplied model, so a
+  per-site "this model is bounded" argument would have to be re-litigated on every checkpoint
+  change — the kind of premise that stops holding without anyone noticing. Uniform policy is worth
+  more here than the smaller per-site optimum.
+- FLAC's compression is buying nothing measurable. These files exist inside a
+  `TemporaryDirectory` for the duration of one subprocess hand-off; halving their size on disk is
+  not a cost anyone has measured, and it is being paid for with a hard ±1 ceiling.
+- It matches what PRs #564 and #566 established for the other four hand-offs, so all nine worker
+  hand-offs now encode identically and the guard can check one rule rather than three.
+
+**Rejected: FLAC with `PCM_24` plus a clamp-and-warn.** It keeps the container and raises the
+quantization floor to −144 dBFS, which is below any measurement senselab makes. But at the XTTS
+site the clamp is the loss: the excursion is signal, and reporting that it was destroyed is worse
+than not destroying it. The clamp also has to be written, tested and kept correct in five worker
+strings that cannot import shared code.
+
+**Rejected: peak-normalizing before the write, with the gain recorded in the payload.** This is
+what upstream Coqui does, and it is lossless in the container. It changes the returned `Audio`'s
+level relative to what the model produced, so every downstream level measurement (loudness, SNR,
+the uncertainty workflow's own gates) would be reading a number senselab invented. Recording the
+gain makes it recoverable, not correct.
+
+## `video/tasks/input_output.py`: the subtype is the caller's format's problem
+
+`extract_audios_from_local_videos(files, audio_format="wav", acodec="pcm_s16le")`. Both knobs are
+free strings, and the write was `sf.write(path, audio_data, sample_rate, format=fmt.upper())`.
+
+Two facts decide the fix:
+
+- **The float path is reachable and was clipping.** `audio_data` is `float32` unless `"s16" in
+  codec`, because PyAV hands back `fltp` for AAC/MP3/Vorbis streams (verified on
+  `src/tests/data_for_testing/video_48khz_stereo_16bits.mp4`: `codec=aac`, `format=fltp`). So any
+  `acodec` without `s16` in it — `pcm_f32le`, `pcm_s24le`, `flac`, `aac`, `""` — wrote float samples
+  into `PCM_16`. Lossy decoders routinely overshoot ±1 on transients, and that overshoot was being
+  clipped with no report.
+- **A lossy container is also reachable, so `FLOAT` cannot be hardcoded.** `audio_format="ogg"`
+  resolves to `format="OGG"`, whose only subtypes are `VORBIS` and `OPUS`; `FLOAT` raises. Same for
+  `mp3`.
+
+So the subtype is resolved from the format and the dtype by `widest_subtype`, and where the
+resolved subtype is fixed-point while the data is float, the fraction of samples that will clip is
+logged. Reported rather than repaired: rescaling would change the extracted track's level relative
+to the video's own audio, which is not this function's decision.
+
+The `acodec="pcm_s16le"` default is behaviourally unchanged — `int16` data resolves to `PCM_16`,
+which is what the default already produced.
+
+## The shared constant: `senselab/utils/audio_write.py`
+
+Before: `LOSSLESS_WAV_SUBTYPE` in `audio/tasks/classification/yamnet.py`, `_WAV_SUBTYPE` in
+`audio/tasks/source_separation/unasdiff.py`, `_WAV_SUBTYPE` in
+`audio/tasks/speech_enhancement/driftse.py` — the same literal under two names in three modules,
+each with its own rationale comment. That is precisely why the sweep was needed: a module that had
+*not* been fixed looked, locally, exactly as deliberate as the three that had.
+
+It lives in `utils/` rather than under `audio/` because the importers span three task packages plus
+`video/tasks/input_output.py`, and the video path must not have to import `senselab.audio` (and its
+torch/transformers chain) to learn how to encode a WAV. It is a top-level leaf module importing
+nothing from senselab, so there is no cycle to reason about — the constraint recorded in
+`dependencies.py`'s own history, that a utility module must not reach into
+`senselab.utils.data_structures`, is satisfied trivially.
+
+Contents:
+
+- `LOSSLESS_WAV_SUBTYPE = "FLOAT"` — the subtype for every WAV senselab writes for itself.
+- `widest_subtype(fmt, dtype)` — for the one site where the container is the caller's. Float data
+  prefers `FLOAT`, then the widest fixed-point subtype the format has (this is how FLAC resolves to
+  `PCM_24`); integer data prefers the subtype that represents it exactly, since widening `int16` to
+  `PCM_24` gains nothing and costs 50% more bytes; a lossy container with no PCM subtype at all
+  falls back to its own codec default, because there is no "widest" there to pick.
+- `out_of_range_fraction(data)` — the number the video site logs.
+
+`FLOAT` over `PCM_24` for the constant, for the same reason as above plus one measurement of the
+low end. Against libsndfile 1.2.2: a −100 dBFS signal written at 16 bits reads back at −93 dBFS, and
+so does a −120 dBFS one. libsndfile truncates toward negative infinity rather than rounding, so at
+−120 dBFS the surviving int16 codes are `{0, −1}` alone — a rectified, DC-offset artifact sitting at
+the 1-LSB floor. Background characterization hands YAMNet exactly this kind of quiet residual audio,
+and a broadband artifact at −93 dBFS is indistinguishable from analog noise, so amplifying it yields
+water-like environmental labels: a fabricated finding rather than a missed one.
+
+**A claim that did not reproduce.** `yamnet.py`'s constant docstring said a −120 dBFS signal "reads
+back as exact zeros" at 16 bits. It does not, under soundfile 0.13.1 / libsndfile 1.2.2 — it reads
+back at −93 dBFS as the `{0, −1}` artifact above, which is worse, because zeros would at least be
+recognisable as absent signal. The replacement wording is what the test now measures.
+
+## The guard: `src/tests/utils/audio_write_guard_test.py`
+
+Modelled on `revision_pinning_guard_test.py`, including its allowlist discipline: a new unguarded
+write fails the test until a human reviews it and either fixes it or records why the default is safe
+there.
+
+Two sweeps, because the writes live in two places. Nine of the twelve call sites are inside
+subprocess-worker `r"""..."""` strings, invisible to a plain AST walk of the parent, so
+`_writes_in_source` recurses into any string constant containing `sf.write(` and parses it as
+Python. A worker string that mentions `sf.write(` and does *not* parse is reported as unguarded
+rather than skipped — the alternative is a write nobody ever checks.
+
+| test | what it enforces |
+| --- | --- |
+| `test_every_sf_write_names_its_subtype` | every write in `src/senselab`, parent-side or worker-side, passes `subtype=` (keyword or 4th positional) or is in `UNGUARDED_SF_WRITE` with a reason |
+| `test_the_allowlist_is_current_and_explained` | allowlist entries name real files, carry a reason, and still have an unguarded write — a stale entry fails |
+| `test_the_detector_actually_rejects_the_default` | the detector's verdicts on synthetic sources, including the pre-fix spellings and the worker-string recursion |
+| `test_worker_payloads_carry_the_shared_constant` | every parent whose worker reads `args["wav_subtype"]` builds `{"wav_subtype": LOSSLESS_WAV_SUBTYPE}` — a literal there would be a second copy of the constant |
+| `test_the_constant_home_check_tells_a_definition_from_a_use` | the definition-vs-use distinction, so a lowercase local is not mistaken for a re-fork |
+| `test_the_subtype_constant_has_one_home` | no constant-cased `*SUBTYPE*` assignment outside `utils/audio_write.py` |
+| `test_widest_subtype_is_what_each_container_can_actually_carry` | the resolved subtype passes `soundfile.check_format` for WAV, FLAC, AIFF, OGG and MP3 |
+
+`UNGUARDED_SF_WRITE` ships empty, because every write now names its subtype. It is kept rather than
+deleted along with its assertions so the next one lands there after review instead of being waved
+through, and its stale-entry test keeps the mechanism from rotting while unused.
+
+**Against the pre-fix tree** the sweep names all seven defective sites and nothing else:
+
+```
+E       AssertionError: Audio write(s) take libsndfile's default subtype, which is PCM_16 for WAV and FLAC -- it clips every sample beyond +-1 and quantizes the rest at -96 dBFS, silently:
+E           audio/tasks/features_extraction/sparc.py:92 (worker script):35
+E           audio/tasks/features_extraction/sparc.py:136 (worker script):30
+E           audio/tasks/text_to_speech/coqui.py:30 (worker script):42
+E           audio/tasks/text_to_speech/qwen_tts.py:161 (worker script):52
+E           audio/tasks/voice_cloning/coqui.py:31 (worker script):61
+E           audio/tasks/voice_cloning/sparc.py:39 (worker script):37
+E           video/tasks/input_output.py:70
+```
+
+The other three pre-fix failures were `test_worker_payloads_carry_the_shared_constant` (five
+backends read no subtype from their payload), `test_the_subtype_constant_has_one_home` (three
+modules defining it), and the five `widest_subtype` cases (no such module).
+
+## Tests
+
+`src/tests/utils/audio_write_test.py` — the policy, checked against libsndfile rather than against
+itself. Every assertion writes a real file and reads it back, because the defect was invisible
+exactly because the code *looked* right.
+
+| test | what it measures |
+| --- | --- |
+| `test_the_wav_default_really_does_clip_and_float_really_does_not` | a 1.6-peak float32 signal: `PCM_16` clips >50% of samples to 1.0; `FLOAT` round-trips bit-exactly |
+| `test_the_16_bit_floor_replaces_quiet_content_rather_than_dropping_it` | −100 and −120 dBFS both read back at −93 dBFS; the surviving codes at −120 dBFS are `{0, −1}` |
+| `test_flac_cannot_take_the_wav_subtype` | `check_format("FLAC", "FLOAT")` is false; FLAC's subtypes are exactly the three PCM ones |
+| `test_widest_subtype_picks_something_the_container_accepts` | ten (format, dtype) pairs, each verified with `check_format` |
+| `test_widest_subtype_writes_are_actually_writable` | WAV/FLAC/OGG round-trip through a real write, `sf.info(...).subtype` matching what was asked |
+| `test_widest_subtype_refuses_what_it_cannot_answer` | an unknown format raises; a format with no default subtype raises rather than returning `None`, which `sf.write` would read as "use the default" |
+| `test_out_of_range_fraction_counts_only_what_a_fixed_point_write_would_lose` | exactly ±1 is representable and must not count; an empty array is 0.0 |
+
+`src/tests/video/tasks/input_output_test.py` — the one changed site whose behaviour is observable
+without a model, tested end to end through the real extractor by intercepting
+`read_files_from_disk` (which is called while the `TemporaryDirectory` is still alive) and copying
+the written files out.
+
+| test | what it measures |
+| --- | --- |
+| `test_the_s16_codec_hint_still_writes_pcm_16` | the default path is unchanged |
+| `test_a_float_codec_hint_writes_float_not_pcm_16` | `acodec="pcm_f32le"` → `sf.info(...).subtype == "FLOAT"` (pre-fix: `PCM_16`) |
+| `test_a_flac_container_gets_the_widest_integer_subtype_it_has` | `audio_format="flac"` → `PCM_24`, not `FLOAT` (which would raise) and not `PCM_16` |
+| `test_a_lossy_container_is_still_writable` | `audio_format="ogg"` → `VORBIS`, i.e. the fix did not break the lossy path |
+| `test_a_video_with_no_audio_track_is_skipped` | pre-existing behaviour, kept while the function was edited |
+
+The five worker sites have no test that runs them: each needs its own venv and a multi-GB
+checkpoint. What covers them is the guard's two AST sweeps — the write names a subtype, and the
+value it names comes from the shared constant — which is the same trade
+`revision_pinning_guard_test.py` makes for the same reason.
+
+## Out of scope, with a measurement so the follow-up is concrete
+
+`Audio.save_to_file` is the *other* way senselab writes audio, and it has the same defect through a
+different API. Measured on a 1.6-peak float32 signal:
+
+| `format=` | resulting subtype | fraction of samples clipped |
+| --- | --- | --- |
+| `"wav"` | `PCM_16` | 0.575 |
+| `"flac"` | `PCM_24` | 0.575 |
+
+It has no subtype parameter at all on the torchcodec path (`AudioEncoder(...).to_file(path)`), which
+is why PRs #564/#566 stopped using it for their hand-offs and called `soundfile.write` directly.
+Three sites still feed workers through it — the input serialization in
+`features_extraction/sparc.py`, `voice_cloning/sparc.py` and `voice_cloning/coqui.py` — so a
+recording peaking above full scale is clipped before the worker sees it. Fixing that means either a
+subtype parameter on `save_to_file` or replacing those three calls, and it needs its own decision
+about the public API; it is not folded in here. The guard does not see it, because the guard
+watches `sf.write`.

--- a/specs/20260819-091500-wav-subtype-sweep/design.md
+++ b/specs/20260819-091500-wav-subtype-sweep/design.md
@@ -276,3 +276,49 @@ recording peaking above full scale is clipped before the worker sees it. Fixing 
 subtype parameter on `save_to_file` or replacing those three calls, and it needs its own decision
 about the public API; it is not folded in here. The guard does not see it, because the guard
 watches `sf.write`.
+
+## The hand-off format: eight workers were reading a clipped signal
+
+The range policy's first act, once merged, was to fail CI on
+`test_extract_sparc_features_resample`:
+
+```
+ValueError: 0.03125% of samples exceed ±1 (peak 1.07517) and FLAC/PCM_24 cannot
+represent them writing /tmp/senselab-sparc-.../audio_0.flac
+```
+
+That is not the policy being too strict. It is the policy reporting a defect that predates it.
+
+**Mechanism.** Eight call sites handed audio to a subprocess worker by writing
+`format="flac"` to a temp file. FLAC has no float subtype at any bit depth — libsndfile
+offers `PCM_16`, `PCM_24`, `PCM_S8`, and nothing else — so the container's ceiling is ±1
+regardless of depth. Resampling overshoots that ceiling routinely: sinc interpolation rings
+around a transient, and a signal already near full scale comes out above it. Every such
+sample arrived at the model hard-clipped, and neither side could tell, because the write
+returned success and the read returned a plausible waveform.
+
+The eight: `classification/speech_emotion_recognition/api.py`, `ssl_embeddings/s3prl.py`,
+`features_extraction/sparc.py`, `features_extraction/ppg.py`, `voice_cloning/sparc.py` (×2),
+`voice_cloning/coqui.py` (×2), `text_to_speech/coqui.py`. Only SPARC's resample test
+happened to feed a waveform that crossed the line, which is why one test failed rather
+than eight.
+
+**Why FLAC was there.** Compression, on a file that exists for the duration of one
+subprocess call. Weighed against silently altering the signal a model then measures, that
+is not a trade worth making.
+
+**Fix.** Omit `format` and let the path extension decide: `.wav` resolves to `FLOAT`, which
+is bit-exact and has no range ceiling. Every read side was already format-agnostic
+(`sf.read(path, dtype="float32")`, the portable shim's `read_audio`, or Coqui's own
+`speaker_wav` loader), so the switch needed no worker changes. Rejected alternatives:
+`out_of_range="normalize"` would have rescaled the signal the model sees, and
+`out_of_range="warn"` would have kept the clipping with a log line nobody reads.
+
+**Guard.** `test_no_internal_handoff_writes_a_format_that_cannot_carry_the_range` fails on
+any `save_to_file` whose literal `format=` is outside the float-capable set. It fails on
+eight sites before the fix and none after; `RANGE_LIMITED_HANDOFF` ships empty, because an
+internal intermediate has no reason to be range-limited. A computed `format=` is out of
+scope — only a literal is a decision made at that site.
+
+The generic marshaller in `utils/subprocess_venv.py` had already been moved to `.wav` in
+the same change; two docstrings still advertised `.flac` and now do not.

--- a/src/senselab/audio/data_structures/audio.py
+++ b/src/senselab/audio/data_structures/audio.py
@@ -11,6 +11,14 @@ from pydantic import BaseModel, Field, PrivateAttr
 
 from senselab.audio.data_structures.audio_hints import AudioHints
 from senselab.utils.constants import SENSELAB_NAMESPACE
+from senselab.utils.portable_audio_io import (
+    RAISE,
+    AudioWriteReport,
+    apply_range_policy,
+    format_for,
+    libsndfile_can_write,
+    write_audio,
+)
 
 try:
     from torchcodec.decoders import AudioDecoder
@@ -32,6 +40,13 @@ try:
     SOUNDFILE_AVAILABLE = True
 except ModuleNotFoundError:
     SOUNDFILE_AVAILABLE = False
+
+
+# What the non-libsndfile backends actually write. torchcodec's AudioEncoder exposes no encoding
+# control, and torchaudio 2.9 forwards save() to it while warning that ``encoding`` and
+# ``bits_per_sample`` are unsupported, so 16-bit fixed point is the conservative assumption the
+# range policy is applied against for those containers.
+_TORCH_BACKEND_SUBTYPE = "PCM_16"
 
 
 class Audio(BaseModel):
@@ -311,64 +326,132 @@ class Audio(BaseModel):
         self,
         file_path: Union[str, os.PathLike],
         format: Optional[str] = None,
-        encoding: Optional[str] = None,
-        bits_per_sample: Optional[int] = None,
-        buffer_size: int = 4096,
-        backend: Optional[str] = None,
-        compression: Optional[Union[float, int]] = None,
-    ) -> None:
-        """Saves the Audio object to a file using torchcodec AudioEncoder.
+        subtype: Optional[str] = None,
+        out_of_range: str = RAISE,
+    ) -> AudioWriteReport:
+        """Write this Audio to a file, preserving the samples exactly where the format allows.
+
+        The subtype is resolved rather than left to the container's default: a plain ``.wav``
+        write gets ``FLOAT`` and round-trips float samples bit-exactly, including values beyond
+        ±1. Where the destination cannot represent the samples -- FLAC has no float subtype at
+        any depth, and an explicitly requested ``PCM_16`` has a ±1 ceiling -- the write refuses
+        rather than clipping, unless the caller asks for another outcome.
 
         Args:
             file_path: Destination file path.
-            format: Audio format (e.g. "wav", "ogg", "flac", "mp3"). Inferred from the file extension if None.
-            encoding: Encoding hint (used by soundfile fallback).
-            bits_per_sample: Bit depth hint (used by soundfile fallback).
-            buffer_size: Buffer size (unused with torchcodec).
-            backend: I/O backend hint (unused with torchcodec).
-            compression: Compression level hint (unused with torchcodec).
+            format: Audio format (e.g. "wav", "ogg", "flac", "mp3"). Inferred from the file
+                extension if None.
+            subtype: libsndfile subtype (e.g. ``"FLOAT"``, ``"PCM_16"``, ``"PCM_24"``). None
+                preserves as much as the format allows. On the non-libsndfile fallback path it is
+                translated to ``torchaudio.save``'s encoding and bit depth.
+            out_of_range: What to do when the resolved subtype cannot represent the samples:
+                ``"raise"`` (default), ``"warn"`` (clip, loudly) or ``"normalize"`` (rescale,
+                with the applied gain in the returned report).
+
+        Returns:
+            An :class:`~senselab.utils.portable_audio_io.AudioWriteReport` naming the format,
+            subtype, peak and any gain applied.
 
         Raises:
-            ModuleNotFoundError: If torchcodec encoder is not available.
-            ValueError: If the waveform dimensions or sampling rate are invalid.
-            RuntimeError: If saving fails.
+            ValueError: If the waveform dimensions or sampling rate are invalid, the subtype does
+                not fit the format, or the samples do not fit the subtype under ``"raise"``.
+            RuntimeError: If the output directory is not writable, no backend can write the
+                requested format, or the write itself fails.
         """
-        if not TORCHCODEC_AVAILABLE and not TORCHAUDIO_AVAILABLE:
-            raise RuntimeError("Neither torchcodec nor torchaudio is available for saving audio.")
-
         if self.waveform.ndim != 2:
             raise ValueError("Waveform must be a 2D tensor with shape (num_channels, num_samples).")
         if self.sampling_rate <= 0:
             raise ValueError("Sampling rate must be a positive integer.")
 
         output_dir = os.path.dirname(file_path)
-        if not os.access(output_dir, os.W_OK):
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+        if output_dir and not os.access(output_dir, os.W_OK):
             raise RuntimeError(f"Output directory '{output_dir}' is not writable.")
 
-        try:
-            if not os.path.exists(output_dir):
-                os.makedirs(output_dir)
-            if TORCHCODEC_AVAILABLE:
-                encoder = AudioEncoder(
-                    samples=self.waveform,
-                    sample_rate=self.sampling_rate,
+        samples = self.waveform.detach().cpu().numpy()
+        fmt = format_for(file_path, format)
+
+        if libsndfile_can_write(fmt):
+            try:
+                return write_audio(
+                    file_path,
+                    samples,
+                    self.sampling_rate,
+                    format=fmt,
+                    subtype=subtype,
+                    out_of_range=out_of_range,
+                    channels_first=True,
                 )
-                encoder.to_file(file_path)
+            except ValueError:
+                raise
+            except Exception as e:
+                raise RuntimeError(f"Error saving audio to file: {e}") from e
+
+        return self._save_via_torch_backend(file_path, fmt, subtype, out_of_range, samples)
+
+    def _save_via_torch_backend(
+        self,
+        file_path: Union[str, os.PathLike],
+        fmt: str,
+        subtype: Optional[str],
+        out_of_range: str,
+        samples: "np.ndarray",
+    ) -> AudioWriteReport:
+        """Write a container libsndfile cannot, under the same range policy.
+
+        Reached only for formats outside ``soundfile.available_formats()`` -- AAC in an ``.m4a``,
+        for instance. None of those carries float samples, so the policy is applied against
+        ``PCM_16`` before either backend is called, and an explicit ``subtype`` is refused because
+        neither backend can honour one (see the spec named in the class docstring).
+
+        Args:
+            file_path: Destination file path.
+            fmt: Resolved format name.
+            subtype: The caller's subtype request, or None.
+            out_of_range: The range policy.
+            samples: Channels-first samples.
+
+        Returns:
+            An :class:`~senselab.utils.portable_audio_io.AudioWriteReport`.
+
+        Raises:
+            RuntimeError: If a subtype was requested, no backend is available, or the write fails.
+        """
+        if subtype is not None:
+            raise RuntimeError(
+                f"subtype={subtype!r} cannot be honoured for a {fmt} file: soundfile cannot write "
+                "this container, and neither torchcodec's AudioEncoder nor torchaudio's "
+                "torchcodec-backed save exposes encoding control."
+            )
+        if not TORCHCODEC_AVAILABLE and not TORCHAUDIO_AVAILABLE:
+            raise RuntimeError(f"No backend available to write a {fmt} file.")
+
+        samples, peak, fraction, gain = apply_range_policy(
+            samples, fmt, _TORCH_BACKEND_SUBTYPE, out_of_range, os.fspath(file_path)
+        )
+        waveform = torch.from_numpy(samples)
+        try:
+            if TORCHCODEC_AVAILABLE:
+                AudioEncoder(samples=waveform, sample_rate=self.sampling_rate).to_file(os.fspath(file_path))
             else:
                 torchaudio.save(
-                    uri=file_path,
-                    src=self.waveform,
+                    uri=os.fspath(file_path),
+                    src=waveform,
                     sample_rate=self.sampling_rate,
                     channels_first=True,
-                    format=format,
-                    encoding=encoding,
-                    bits_per_sample=bits_per_sample,
-                    buffer_size=buffer_size,
-                    backend=backend,
-                    compression=compression,
                 )
         except Exception as e:
             raise RuntimeError(f"Error saving audio to file: {e}") from e
+
+        return AudioWriteReport(
+            path=os.fspath(file_path),
+            format=fmt,
+            subtype=_TORCH_BACKEND_SUBTYPE,
+            peak=peak,
+            out_of_range_fraction=fraction,
+            gain=gain,
+        )
 
     @classmethod
     def from_stream(

--- a/src/senselab/audio/tasks/classification/speech_emotion_recognition/api.py
+++ b/src/senselab/audio/tasks/classification/speech_emotion_recognition/api.py
@@ -607,8 +607,8 @@ def _classify_continuous_ser_venv(
 
         audio_paths = []
         for i, audio in enumerate(audios):
-            path = str(tmp / f"audio_{i}.flac")
-            audio.save_to_file(path, format="flac")
+            path = str(tmp / f"audio_{i}.wav")
+            audio.save_to_file(path)
             audio_paths.append(path)
 
         # Forward the resolved commit SHA to the worker, never the ref -- it has no senselab

--- a/src/senselab/audio/tasks/classification/yamnet.py
+++ b/src/senselab/audio/tasks/classification/yamnet.py
@@ -16,22 +16,6 @@ from senselab.audio.tasks.preprocessing import resample_audios
 from senselab.utils.data_structures.logging import logger
 from senselab.utils.subprocess_venv import _clean_subprocess_env, ensure_venv, parse_subprocess_result, venv_python
 
-LOSSLESS_WAV_SUBTYPE = "FLOAT"
-"""WAV subtype for the worker hand-off.
-
-The temp WAV is the only lossy step between senselab and the TensorFlow subprocess, and
-this classifier has an absolute low-level floor — so a fixed-point write is exactly the
-wrong thing here. Measured with a 16-bit write: a -100 dBFS signal reads back at -93 dBFS,
-because 16-bit quantization noise is louder than the content; at -120 dBFS it reads back as
-exact zeros, which the model reports as silence with full confidence.
-
-Two reasons that matters beyond losing a faint source. First, background characterization
-deliberately presents this classifier quiet residual audio. Second, 16-bit quantization
-noise is statistically indistinguishable from analog broadband noise, so amplifying it
-yields the water-like environmental labels the noise-character guard exists to reject —
-a fabricated finding rather than a missed one.
-"""
-
 
 def write_worker_wav(path: "Path | str", waveform: Any, sampling_rate: int) -> Dict[str, Any]:  # noqa: ANN401
     """Write a lossless mono WAV for the YAMNet worker and report input-path artifacts.
@@ -48,14 +32,16 @@ def write_worker_wav(path: "Path | str", waveform: Any, sampling_rate: int) -> D
         (FR-017d, FR-019b).
     """
     import numpy as np
-    import soundfile as sf
+    import torch
 
     arr = np.asarray(waveform, dtype=np.float32)
     if arr.ndim > 1:
         arr = arr.mean(axis=0) if arr.shape[0] < arr.shape[-1] else arr.mean(axis=-1)
+    # At or beyond full scale on the *input*, which is a different measurement from the write's
+    # own out-of-range fraction: this one reports what arrived, not what the container lost.
     clipped = float(np.count_nonzero(np.abs(arr) >= 0.9999) / arr.size) if arr.size else 0.0
-    sf.write(str(path), arr, sampling_rate, subtype=LOSSLESS_WAV_SUBTYPE)
-    return {"subtype": LOSSLESS_WAV_SUBTYPE, "clipped_fraction": clipped, "requantized": False}
+    report = Audio(waveform=torch.from_numpy(arr).unsqueeze(0), sampling_rate=sampling_rate).save_to_file(str(path))
+    return {"subtype": report.subtype, "clipped_fraction": clipped, "requantized": False}
 
 
 _YAMNET_VENV = "yamnet"

--- a/src/senselab/audio/tasks/features_extraction/ppg.py
+++ b/src/senselab/audio/tasks/features_extraction/ppg.py
@@ -137,7 +137,7 @@ def extract_ppgs_from_audios(audios: List[Audio], device: Optional[DeviceType] =
     """Extracts phonetic posteriorgrams (PPGs) from every audio.
 
     The ppgs model runs in an isolated subprocess venv with its own
-    Python and dependencies. Audio is transferred via FLAC files.
+    Python and dependencies. Audio is transferred via WAV files.
 
     Args:
         audios: The audios to extract PPGs from.
@@ -157,11 +157,11 @@ def extract_ppgs_from_audios(audios: List[Audio], device: Optional[DeviceType] =
     with tempfile.TemporaryDirectory(prefix="senselab-ppgs-") as tmpdir:
         tmp = Path(tmpdir)
 
-        # Serialize audios to FLAC
+        # Serialize audios for the worker
         audio_paths = []
         for i, audio in enumerate(audios):
-            path = str(tmp / f"audio_{i}.flac")
-            audio.save_to_file(path, format="flac")
+            path = str(tmp / f"audio_{i}.wav")
+            audio.save_to_file(path)
             audio_paths.append(path)
 
         # Run worker in isolated venv

--- a/src/senselab/audio/tasks/features_extraction/sparc.py
+++ b/src/senselab/audio/tasks/features_extraction/sparc.py
@@ -3,6 +3,8 @@
 speech-articulatory-coding (SPARC) has dependencies that may conflict
 with the main environment. It runs in an isolated subprocess venv
 managed by uv, shared with ppgs where possible.
+
+Resynthesized and voice-converted audio comes back as WAV/FLOAT: ``specs/20260819-091500-wav-subtype-sweep/design.md``.
 """
 
 import json
@@ -17,7 +19,13 @@ import torch
 from senselab.audio.data_structures import Audio
 from senselab.audio.tasks.preprocessing import resample_audios
 from senselab.utils.data_structures import DeviceType, Language, _select_device_and_dtype, logger
-from senselab.utils.subprocess_venv import _clean_subprocess_env, ensure_venv, parse_subprocess_result, venv_python
+from senselab.utils.subprocess_venv import (
+    _clean_subprocess_env,
+    ensure_venv,
+    parse_subprocess_result,
+    stage_portable_audio_io,
+    venv_python,
+)
 
 # SPARC venv specification
 _SPARC_VENV = "sparc"
@@ -106,6 +114,9 @@ device = args["device"]
 output_dir = args["output_dir"]
 feature_dir = args["feature_dir"]
 
+sys.path.insert(0, args["io_dir"])
+from portable_audio_io import write_audio
+
 coder = load_model(language, device=device)
 
 try:
@@ -117,13 +128,12 @@ try:
 
     waveform = coder.decode(ema, pitch, loudness, spk_emb)
 
-    # Save output as FLAC
-    out_path = str(Path(output_dir) / "decoded.flac")
+    out_path = str(Path(output_dir) / "decoded.wav")
     if isinstance(waveform, torch.Tensor):
         wav_np = waveform.detach().cpu().numpy().squeeze()
     else:
         wav_np = np.asarray(waveform).squeeze()
-    sf.write(out_path, wav_np, coder.output_sr)
+    write_audio(out_path, wav_np, coder.output_sr)
 
     print(json.dumps({"output_path": out_path, "sample_rate": coder.output_sr}))
 except Exception as e:
@@ -151,18 +161,20 @@ output_dir = args["output_dir"]
 source_path = args["source_path"]
 target_path = args["target_path"]
 
+sys.path.insert(0, args["io_dir"])
+from portable_audio_io import write_audio
+
 coder = load_model(language, device=device)
 
 try:
     waveform = coder.convert(src_wav=source_path, trg_wav=target_path)
 
-    # Save output as FLAC
-    out_path = str(Path(output_dir) / "converted.flac")
+    out_path = str(Path(output_dir) / "converted.wav")
     if isinstance(waveform, torch.Tensor):
         wav_np = waveform.detach().cpu().numpy().squeeze()
     else:
         wav_np = np.asarray(waveform).squeeze()
-    sf.write(out_path, wav_np, coder.output_sr)
+    write_audio(out_path, wav_np, coder.output_sr)
 
     print(json.dumps({"output_path": out_path, "sample_rate": coder.output_sr}))
 except Exception as e:
@@ -358,6 +370,7 @@ class SparcFeatureExtractor:
                     "device": device.value,
                     "output_dir": str(tmp),
                     "feature_dir": str(feature_dir),
+                    "io_dir": stage_portable_audio_io(tmp),
                 }
             )
 
@@ -437,6 +450,7 @@ class SparcFeatureExtractor:
                     "output_dir": str(tmp),
                     "source_path": src_path,
                     "target_path": trg_path,
+                    "io_dir": stage_portable_audio_io(tmp),
                 }
             )
 

--- a/src/senselab/audio/tasks/features_extraction/sparc.py
+++ b/src/senselab/audio/tasks/features_extraction/sparc.py
@@ -199,7 +199,7 @@ class SparcFeatureExtractor:
         """Extract SPARC articulatory features from audios.
 
         The SPARC model runs in an isolated subprocess venv with its own
-        Python and dependencies. Audio is transferred via FLAC files.
+        Python and dependencies. Audio is transferred via WAV files.
 
         Args:
             audios: List of audio objects.
@@ -230,13 +230,13 @@ class SparcFeatureExtractor:
         with tempfile.TemporaryDirectory(prefix="senselab-sparc-") as tmpdir:
             tmp = Path(tmpdir)
 
-            # Serialize audios to FLAC
+            # Serialize audios for the worker
             audio_paths = []
             for i, audio in enumerate(audios):
                 if audio.waveform.squeeze().dim() != 1:
                     raise ValueError(f"Only mono audio files are supported. Audio index: {i}")
-                path = str(tmp / f"audio_{i}.flac")
-                audio.save_to_file(path, format="flac")
+                path = str(tmp / f"audio_{i}.wav")
+                audio.save_to_file(path)
                 audio_paths.append(path)
 
             # Run worker in isolated venv

--- a/src/senselab/audio/tasks/health_acoustics/hear.py
+++ b/src/senselab/audio/tasks/health_acoustics/hear.py
@@ -105,6 +105,7 @@ from senselab.utils.data_structures import DeviceType, _select_device_and_dtype
 from senselab.utils.data_structures.logging import logger
 from senselab.utils.data_structures.model import get_huggingface_token
 from senselab.utils.dependencies import resolve_model
+from senselab.utils.portable_audio_io import write_audio
 from senselab.utils.subprocess_venv import (
     _clean_subprocess_env,
     ensure_venv,
@@ -417,7 +418,7 @@ def write_hear_wav(path: "Path | str", audio: Audio) -> None:
     """
     waveform = audio.waveform.detach().cpu().numpy()
     mono = waveform.mean(axis=0) if waveform.ndim > 1 else waveform
-    sf.write(str(path), mono.astype(np.float32), audio.sampling_rate, subtype="FLOAT")
+    write_audio(path, mono.astype(np.float32), audio.sampling_rate, channels_first=False)
 
 
 def build_worker_payload(

--- a/src/senselab/audio/tasks/source_separation/unasdiff.py
+++ b/src/senselab/audio/tasks/source_separation/unasdiff.py
@@ -111,6 +111,7 @@ from senselab.utils.subprocess_venv import (
     _clean_subprocess_env,
     ensure_venv,
     parse_subprocess_result,
+    stage_portable_audio_io,
     venv_python,
 )
 
@@ -232,10 +233,6 @@ _OVERLAP_S = 2.0  # 50% overlap between adjacent windows -- see Task 5 / doc.md
 # why no lower value is recommended here.
 _DIFFUSION_STEPS = 200
 
-# Every WAV this backend hands to or takes back from the worker. soundfile's WAV default is
-# PCM_16, which clips beyond +-1 -- see specs/20260818-071500-unasdiff-device-timeout-pcm16.
-_WAV_SUBTYPE = "FLOAT"
-
 # Terms of the default worker ceiling, in seconds per (window x diffusion step) and as a floor.
 # Derivation and the measurement behind both numbers:
 # specs/20260818-071500-unasdiff-device-timeout-pcm16.
@@ -310,7 +307,8 @@ try:
     in_paths, out_paths = args["in_paths"], args["out_paths"]
     seed = int(args["seed"])
     requested_device = args.get("device")
-    wav_subtype = args["wav_subtype"]
+    sys.path.insert(0, args["io_dir"])
+    from portable_audio_io import read_audio, write_audio
 
     import fcntl, os, shutil, tempfile as _tempfile
 
@@ -473,7 +471,7 @@ try:
 
     results = []
     for in_path, out_path_list in zip(in_paths, out_paths):
-        y_np, sr = sf.read(in_path, dtype="float32", always_2d=True)
+        y_np, sr = read_audio(in_path, always_2d=True, channels_first=False)
         y = torch.as_tensor(y_np[:, 0]).to(device)
         assert sr == 16000, "worker expects 16 kHz; the host resamples"
 
@@ -485,9 +483,7 @@ try:
 
         for src_wave, out_path in zip(sources, out_path_list):
             src_wave = src_wave / 0.95 * peak
-            # Explicit subtype: soundfile's WAV default is PCM_16, which clips every sample
-            # beyond +-1 on the way back to the host.
-            sf.write(out_path, src_wave.detach().cpu().numpy(), sr, subtype=wav_subtype)
+            write_audio(out_path, src_wave.detach().cpu().numpy(), sr)
         results.append(out_path_list)
 
     print(json.dumps({"output_paths": results, "seed": seed}))
@@ -781,9 +777,7 @@ def separate_with_unasdiff(
             for w, start in enumerate(starts):
                 segment = waveform[start : start + window_samples]
                 in_path = str(tmp / f"in_{i}_{w}.wav")
-                # Not Audio.save_to_file: that writes PCM_16 for a .wav, which clips the input
-                # window before the worker ever reads it.
-                sf.write(in_path, segment.detach().cpu().numpy(), _TARGET_SR, subtype=_WAV_SUBTYPE)
+                Audio(waveform=segment.unsqueeze(0), sampling_rate=_TARGET_SR).save_to_file(in_path)
                 in_paths.append(in_path)
                 out_paths.append([str(tmp / f"out_{i}_{w}_{s}.wav") for s in range(n_sources)])
             window_ranges.append((flat_start, len(in_paths)))
@@ -805,7 +799,7 @@ def separate_with_unasdiff(
                 "seed": seed,
                 "diffusion_steps": diffusion_steps,
                 "device": worker_device,
-                "wav_subtype": _WAV_SUBTYPE,
+                "io_dir": stage_portable_audio_io(tmp),
             }
         )
 

--- a/src/senselab/audio/tasks/speech_enhancement/driftse.py
+++ b/src/senselab/audio/tasks/speech_enhancement/driftse.py
@@ -39,15 +39,12 @@ from senselab.utils.subprocess_venv import (
     _clean_subprocess_env,
     ensure_venv,
     parse_subprocess_result,
+    stage_portable_audio_io,
     venv_python,
 )
 
 _DRIFTSE_VENV = "driftse"
 _DRIFTSE_PYTHON = "3.11"
-
-# Every WAV this backend hands to or takes back from the worker. soundfile's WAV default is
-# PCM_16, which clips beyond +-1 -- see specs/20260818-071500-unasdiff-device-timeout-pcm16.
-_WAV_SUBTYPE = "FLOAT"
 
 # Upstream's requirements.txt is a *training* set; only what the inference import chain touches is
 # installed. pesq/pystoi are on that chain (util/other.py imports both at module scope) even though
@@ -156,7 +153,8 @@ try:
     seed = int(args["seed"])
     sigma = float(args["sigma"])
     chunk_s, overlap_s = float(args["chunk_s"]), float(args["overlap_s"])
-    wav_subtype = args["wav_subtype"]
+    sys.path.insert(0, args["io_dir"])
+    from portable_audio_io import read_audio, write_audio
     requested_device = args.get("device")
 
     import fcntl, os, shutil, tempfile as _tempfile
@@ -282,7 +280,7 @@ try:
 
     results = []
     for in_path, out_path in zip(in_paths, out_paths):
-        y_np, sr = sf.read(in_path, dtype="float32", always_2d=True)
+        y_np, sr = read_audio(in_path, always_2d=True, channels_first=False)
         y = torch.as_tensor(y_np[:, 0]).to(device)
         assert sr == 16000, "worker expects 16 kHz; the host resamples"
 
@@ -314,9 +312,7 @@ try:
                 wsum[start : start + chunk] += taper
             x_hat = acc / wsum.clamp(min=1e-8)
 
-        # Explicit subtype: soundfile's WAV default is PCM_16, which clips every sample
-        # beyond +-1 on the way back to the host.
-        sf.write(out_path, x_hat.detach().cpu().numpy(), sr, subtype=wav_subtype)
+        write_audio(out_path, x_hat.detach().cpu().numpy(), sr)
         results.append(out_path)
 
     print(json.dumps({"output_paths": results, "seed": seed, "sigma": sigma}))
@@ -451,14 +447,7 @@ def enhance_audios_with_driftse(
         for i, audio in enumerate(mono_16k):
             in_path = str(tmp / f"in_{i}.wav")
             out_path = str(tmp / f"out_{i}.wav")
-            # Not Audio.save_to_file: that writes PCM_16 for a .wav, which clips the input
-            # before the worker ever reads it.
-            sf.write(
-                in_path,
-                audio.waveform.squeeze(0).detach().cpu().numpy(),
-                audio.sampling_rate,
-                subtype=_WAV_SUBTYPE,
-            )
+            audio.save_to_file(in_path)
             in_paths.append(in_path)
             out_paths.append(out_path)
 
@@ -476,7 +465,7 @@ def enhance_audios_with_driftse(
                 "sigma": sigma,
                 "chunk_s": chunk_s,
                 "overlap_s": overlap_s,
-                "wav_subtype": _WAV_SUBTYPE,
+                "io_dir": stage_portable_audio_io(tmp),
                 "device": worker_device,
             }
         )

--- a/src/senselab/audio/tasks/ssl_embeddings/s3prl.py
+++ b/src/senselab/audio/tasks/ssl_embeddings/s3prl.py
@@ -155,11 +155,11 @@ class S3PRLEmbeddingExtractor:
         with tempfile.TemporaryDirectory(prefix="senselab-s3prl-") as tmpdir:
             tmp = Path(tmpdir)
 
-            # Serialize audios to FLAC
+            # Serialize audios for the worker
             audio_paths = []
             for i, audio in enumerate(audios):
-                path = str(tmp / f"audio_{i}.flac")
-                audio.save_to_file(path, format="flac")
+                path = str(tmp / f"audio_{i}.wav")
+                audio.save_to_file(path)
                 audio_paths.append(path)
 
             # Run worker in isolated venv

--- a/src/senselab/audio/tasks/text_to_speech/coqui.py
+++ b/src/senselab/audio/tasks/text_to_speech/coqui.py
@@ -141,8 +141,8 @@ class CoquiTTS:
             target_paths: List[str] = []
             if targets:
                 for i, audio in enumerate(targets):
-                    path = str(tmp / f"target_{i}.flac")
-                    audio.save_to_file(path, format="flac")
+                    path = str(tmp / f"target_{i}.wav")
+                    audio.save_to_file(path)
                     target_paths.append(path)
 
             input_json = json.dumps(

--- a/src/senselab/audio/tasks/text_to_speech/coqui.py
+++ b/src/senselab/audio/tasks/text_to_speech/coqui.py
@@ -2,6 +2,9 @@
 
 Coqui TTS has conflicting dependencies (pins older transformers, requires
 Python <=3.11). It runs in an isolated subprocess venv managed by uv.
+
+Synthesized audio comes back as WAV/FLOAT; why the output cannot go in a fixed-point
+container: ``specs/20260819-091500-wav-subtype-sweep/design.md``.
 """
 
 import json
@@ -13,7 +16,13 @@ from typing import Any, Dict, List, Optional
 
 from senselab.audio.data_structures import Audio
 from senselab.utils.data_structures import CoquiTTSModel, DeviceType, Language, _select_device_and_dtype
-from senselab.utils.subprocess_venv import _clean_subprocess_env, ensure_venv, parse_subprocess_result, venv_python
+from senselab.utils.subprocess_venv import (
+    _clean_subprocess_env,
+    ensure_venv,
+    parse_subprocess_result,
+    stage_portable_audio_io,
+    venv_python,
+)
 
 # Reuse the same coqui venv as voice_cloning
 _COQUI_VENV = "coqui"
@@ -47,6 +56,9 @@ try:
     target_paths = args.get("target_paths", [])
     output_dir = args["output_dir"]
 
+    sys.path.insert(0, args["io_dir"])
+    from portable_audio_io import write_audio
+
     tts = TTS(model_id).to(device=device)
     output_sr = tts.synthesizer.output_sample_rate
 
@@ -67,8 +79,10 @@ try:
         if wav.dim() == 1:
             wav = wav.unsqueeze(0)
 
-        out_path = str(Path(output_dir) / f"tts_{idx}.flac")
-        sf.write(out_path, wav.squeeze().cpu().numpy(), output_sr, format="FLAC")
+        # write_audio, not sf.write: TTS.api.tts() returns the decoder's raw output, which
+        # nothing bounds to +-1 (measured for XTTS-v2 in the spec named in the module docstring).
+        out_path = str(Path(output_dir) / f"tts_{idx}.wav")
+        write_audio(out_path, wav.squeeze().cpu().numpy(), output_sr)
         output_paths.append(out_path)
 
     print(json.dumps({"output_paths": output_paths, "sample_rate": output_sr}))
@@ -139,6 +153,7 @@ class CoquiTTS:
                     "language": language.alpha_2 if language else None,
                     "target_paths": target_paths,
                     "output_dir": str(tmp),
+                    "io_dir": stage_portable_audio_io(tmp),
                 }
             )
 

--- a/src/senselab/audio/tasks/text_to_speech/qwen_tts.py
+++ b/src/senselab/audio/tasks/text_to_speech/qwen_tts.py
@@ -131,7 +131,13 @@ from senselab.audio.data_structures import Audio
 from senselab.utils.data_structures import DeviceType, HFModel, _select_device_and_dtype
 from senselab.utils.data_structures.logging import logger
 from senselab.utils.dependencies import hf_subprocess_env
-from senselab.utils.subprocess_venv import _clean_subprocess_env, ensure_venv, parse_subprocess_result, venv_python
+from senselab.utils.subprocess_venv import (
+    _clean_subprocess_env,
+    ensure_venv,
+    parse_subprocess_result,
+    stage_portable_audio_io,
+    venv_python,
+)
 
 _QWEN_TTS_VENV = "qwen-tts"
 _QWEN_TTS_PYTHON = "3.12"
@@ -178,6 +184,9 @@ try:
     device = args["device"]
     out_paths = args["out_paths"]
 
+    sys.path.insert(0, args["io_dir"])
+    from portable_audio_io import write_audio
+
     # dtype matches the model card verbatim. device_map is set only for CUDA --
     # from_pretrained's own default (no device_map) places the model on CPU, and
     # invoking accelerate's dispatch machinery for a CPU-only run buys nothing.
@@ -209,7 +218,7 @@ try:
     )
 
     for wav, out_path in zip(wavs, out_paths):
-        sf.write(out_path, np.asarray(wav, dtype="float32"), sr)
+        write_audio(out_path, np.asarray(wav, dtype="float32"), int(sr))
 
     print(json.dumps({"output_paths": out_paths, "sample_rate": int(sr)}))
 except Exception as exc:
@@ -324,6 +333,7 @@ def synthesize_texts_with_qwen(
                 "instruct": instruct,
                 "device": device_type.value,
                 "out_paths": out_paths,
+                "io_dir": stage_portable_audio_io(tmp),
             }
         )
 

--- a/src/senselab/audio/tasks/voice_cloning/coqui.py
+++ b/src/senselab/audio/tasks/voice_cloning/coqui.py
@@ -167,10 +167,10 @@ class CoquiVoiceCloner:
                 if src.waveform.squeeze().dim() != 1 or tgt.waveform.squeeze().dim() != 1:
                     raise ValueError(f"[Pair {i}] Only mono audio is supported.")
 
-                src_path = str(tmp / f"source_{i}.flac")
-                tgt_path = str(tmp / f"target_{i}.flac")
-                src.save_to_file(src_path, format="flac")
-                tgt.save_to_file(tgt_path, format="flac")
+                src_path = str(tmp / f"source_{i}.wav")
+                tgt_path = str(tmp / f"target_{i}.wav")
+                src.save_to_file(src_path)
+                tgt.save_to_file(tgt_path)
                 source_paths.append(src_path)
                 target_paths.append(tgt_path)
 

--- a/src/senselab/audio/tasks/voice_cloning/coqui.py
+++ b/src/senselab/audio/tasks/voice_cloning/coqui.py
@@ -2,7 +2,8 @@
 
 Coqui TTS has conflicting dependencies (pins old torch versions, requires
 Python <=3.11). It runs in an isolated subprocess venv managed by uv.
-Audio data is serialized as FLAC for efficient lossless transfer.
+Inputs are serialized as FLAC; results come back as WAV/FLOAT. Why, and the measured
+range of each supported model's output: ``specs/20260819-091500-wav-subtype-sweep/design.md``.
 """
 
 import json
@@ -13,7 +14,13 @@ from typing import List, Optional
 
 from senselab.audio.data_structures import Audio
 from senselab.utils.data_structures import CoquiTTSModel, DeviceType
-from senselab.utils.subprocess_venv import _clean_subprocess_env, ensure_venv, parse_subprocess_result, venv_python
+from senselab.utils.subprocess_venv import (
+    _clean_subprocess_env,
+    ensure_venv,
+    parse_subprocess_result,
+    stage_portable_audio_io,
+    venv_python,
+)
 
 # Coqui venv specification
 _COQUI_VENV = "coqui"
@@ -45,6 +52,9 @@ try:
     device = args["device"]
     output_dir = args["output_dir"]
 
+    sys.path.insert(0, args["io_dir"])
+    from portable_audio_io import read_audio, write_audio
+
     tts = TTS(model_id).to(device=device)
     audio_config = tts.voice_converter.vc_config.audio
 
@@ -61,8 +71,8 @@ try:
 
     output_paths = []
     for i, (src_path, tgt_path) in enumerate(zip(source_paths, target_paths)):
-        src_data, src_sr = sf.read(src_path, dtype="float32")
-        tgt_data, tgt_sr = sf.read(tgt_path, dtype="float32")
+        src_data, src_sr = read_audio(src_path)
+        tgt_data, tgt_sr = read_audio(tgt_path)
         src_wav = torch.from_numpy(src_data).unsqueeze(0) if src_data.ndim == 1 else torch.from_numpy(src_data.T)
         tgt_wav = torch.from_numpy(tgt_data).unsqueeze(0) if tgt_data.ndim == 1 else torch.from_numpy(tgt_data.T)
 
@@ -87,8 +97,8 @@ try:
             converted = converted.unsqueeze(0)
 
         sr = output_sample_rate or src_sr
-        out_path = str(Path(output_dir) / f"cloned_{i}.flac")
-        sf.write(out_path, converted.squeeze().cpu().numpy(), sr, format="FLAC")
+        out_path = str(Path(output_dir) / f"cloned_{i}.wav")
+        write_audio(out_path, converted.squeeze().cpu().numpy(), sr)
         output_paths.append(out_path)
 
     print(json.dumps({"output_paths": output_paths}))
@@ -129,8 +139,8 @@ class CoquiVoiceCloner:
         """Clone voices from source audios to target audios using Coqui TTS.
 
         The actual Coqui TTS operations run in an isolated subprocess venv
-        with its own Python and torch version. Audio is transferred via
-        lossless FLAC files.
+        with its own Python and torch version. Inputs go over as FLAC, results
+        come back as WAV/FLOAT.
 
         Args:
             source_audios: List of source audio objects.
@@ -172,6 +182,7 @@ class CoquiVoiceCloner:
                     "model_id": str(model.path_or_uri),
                     "device": device.value if device else "cpu",
                     "output_dir": str(tmp),
+                    "io_dir": stage_portable_audio_io(tmp),
                 }
             )
 

--- a/src/senselab/audio/tasks/voice_cloning/sparc.py
+++ b/src/senselab/audio/tasks/voice_cloning/sparc.py
@@ -2,6 +2,9 @@
 
 speech-articulatory-coding (SPARC) has dependencies that may conflict
 with the main environment. It runs in an isolated subprocess venv.
+
+Results come back as WAV/FLOAT; why, and the measured range of this vocoder's output:
+``specs/20260819-091500-wav-subtype-sweep/design.md``.
 """
 
 import json
@@ -16,6 +19,7 @@ from senselab.utils.subprocess_venv import (
     _clean_subprocess_env,
     ensure_venv,
     parse_subprocess_result,
+    stage_portable_audio_io,
     venv_python,
 )
 
@@ -52,12 +56,15 @@ language = args["language"]
 device = args["device"]
 output_dir = args["output_dir"]
 
+sys.path.insert(0, args["io_dir"])
+from portable_audio_io import read_audio, write_audio
+
 coder = load_model(language, device=device)
 
 output_paths = []
 for i, (src_path, tgt_path) in enumerate(zip(source_paths, target_paths)):
-    src_data, src_sr = sf.read(src_path, dtype="float32")
-    tgt_data, tgt_sr = sf.read(tgt_path, dtype="float32")
+    src_data, src_sr = read_audio(src_path)
+    tgt_data, tgt_sr = read_audio(tgt_path)
 
     src_wav = src_data.squeeze().astype(np.float32)
     tgt_wav = tgt_data.squeeze().astype(np.float32)
@@ -71,8 +78,8 @@ for i, (src_path, tgt_path) in enumerate(zip(source_paths, target_paths)):
         converted = converted.squeeze()
 
     sr = coder.sr
-    out_path = str(Path(output_dir) / f"cloned_{i}.flac")
-    sf.write(out_path, converted, sr, format="FLAC")
+    out_path = str(Path(output_dir) / f"cloned_{i}.wav")
+    write_audio(out_path, converted, sr)
     output_paths.append(out_path)
 
 print(json.dumps({"output_paths": output_paths, "expected_sr": coder.sr}))
@@ -93,7 +100,7 @@ class SparcVoiceCloner:
         """Clone voices from source audios to target audios using SPARC.
 
         The SPARC model runs in an isolated subprocess venv with its own
-        Python and dependencies. Audio is transferred via FLAC files.
+        Python and dependencies. Inputs go over as FLAC, results come back as WAV/FLOAT.
 
         Args:
             source_audios: List of source audio objects.
@@ -146,6 +153,7 @@ class SparcVoiceCloner:
                     "language": used_language,
                     "device": device.value,
                     "output_dir": str(tmp),
+                    "io_dir": stage_portable_audio_io(tmp),
                 }
             )
 

--- a/src/senselab/audio/tasks/voice_cloning/sparc.py
+++ b/src/senselab/audio/tasks/voice_cloning/sparc.py
@@ -138,10 +138,10 @@ class SparcVoiceCloner:
                 if src.waveform.squeeze().dim() != 1 or tgt.waveform.squeeze().dim() != 1:
                     raise ValueError(f"[Pair {i}] Only mono audio is supported.")
 
-                src_path = str(tmp / f"source_{i}.flac")
-                tgt_path = str(tmp / f"target_{i}.flac")
-                src.save_to_file(src_path, format="flac")
-                tgt.save_to_file(tgt_path, format="flac")
+                src_path = str(tmp / f"source_{i}.wav")
+                tgt_path = str(tmp / f"target_{i}.wav")
+                src.save_to_file(src_path)
+                tgt.save_to_file(tgt_path)
                 source_paths.append(src_path)
                 target_paths.append(tgt_path)
 

--- a/src/senselab/utils/portable_audio_io.py
+++ b/src/senselab/utils/portable_audio_io.py
@@ -1,0 +1,332 @@
+"""The one definition of how senselab reads and writes audio files.
+
+Two callers implement nothing of their own: :meth:`senselab.audio.data_structures.Audio.save_to_file`
+delegates to :func:`write_audio`, and subprocess-venv workers -- which run in isolated
+environments where senselab is not installed -- get this file staged next to their payload by
+:func:`senselab.utils.subprocess_venv.stage_portable_audio_io` and import it directly.
+
+**This module must import nothing from senselab, and nothing beyond numpy, soundfile and the
+standard library.** ``src/tests/utils/portable_audio_io_test.py`` enforces both by AST sweep; a
+convenient ``from senselab...`` here breaks every worker the next time a venv is rebuilt.
+
+Two decisions live here and nowhere else:
+
+* which subtype a destination gets (:func:`resolve_subtype`), and
+* what happens when the samples cannot be represented in it (:func:`apply_range_policy`).
+
+The measurements behind both, and why the default preserves rather than clips:
+``specs/20260819-091500-wav-subtype-sweep/design.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import NamedTuple, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import soundfile as sf
+
+logger = logging.getLogger("senselab")
+
+LOSSLESS_WAV_SUBTYPE = "FLOAT"
+"""The subtype a WAV gets when the caller does not ask for another one."""
+
+RAISE = "raise"
+WARN = "warn"
+NORMALIZE = "normalize"
+OUT_OF_RANGE_POLICIES = (RAISE, WARN, NORMALIZE)
+
+# Preference order per input dtype; the first subtype the destination supports wins. FLAC has no
+# float subtype at any depth, so float data resolves to PCM_24 there and the range policy applies.
+_PREFERENCE_BY_KIND = {
+    "float": ("FLOAT", "DOUBLE", "PCM_32", "PCM_24", "PCM_16"),
+    "int16": ("PCM_16", "PCM_24", "PCM_32", "FLOAT"),
+    "int32": ("PCM_32", "FLOAT", "PCM_24", "PCM_16"),
+}
+
+_FLOAT_SUBTYPES = ("FLOAT", "DOUBLE")
+
+
+class AudioWriteReport(NamedTuple):
+    """What a write did, so a caller can record it rather than assume it."""
+
+    path: str
+    format: str
+    subtype: str
+    peak: float
+    out_of_range_fraction: float
+    gain: float
+
+
+def is_float_subtype(subtype: str) -> bool:
+    """Whether ``subtype`` stores samples as floats, i.e. carries values beyond ±1 unchanged."""
+    return subtype in _FLOAT_SUBTYPES
+
+
+def format_for(path: Union[str, os.PathLike], format: Optional[str] = None) -> str:
+    """Return the libsndfile format name for a destination.
+
+    Args:
+        path: The destination path; its extension is used when ``format`` is None.
+        format: An explicit format name, case-insensitive.
+
+    Returns:
+        An upper-case format name, e.g. ``"WAV"``. Not necessarily one libsndfile can write --
+        use :func:`libsndfile_can_write` to find out.
+    """
+    if format:
+        return format.upper()
+    return os.fspath(path).rsplit(".", 1)[-1].upper() if "." in os.fspath(path) else ""
+
+
+def libsndfile_can_write(fmt: str) -> bool:
+    """Whether libsndfile can write ``fmt``, and therefore whether a subtype can be chosen."""
+    return fmt.upper() in sf.available_formats()
+
+
+def widest_subtype(fmt: str, dtype: Union[np.dtype, type, str] = np.float32) -> str:
+    """Return the subtype of ``fmt`` that loses the least of a ``dtype`` array.
+
+    Args:
+        fmt: A libsndfile format name, case-insensitive.
+        dtype: The dtype of the array about to be written. Only the dtypes ``soundfile.write``
+            accepts are distinguished (float, ``int32``, ``int16``); anything else is float.
+
+    Returns:
+        A subtype name ``soundfile.check_format(fmt, subtype)`` accepts. For a lossy container
+        with no PCM subtype, the container's own default.
+
+    Raises:
+        ValueError: If ``fmt`` is not a format libsndfile can write, or has no default subtype.
+    """
+    normalized = fmt.upper()
+    try:
+        available = set(sf.available_subtypes(normalized))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{fmt!r} is not a format soundfile can write") from exc
+    if not available:
+        raise ValueError(f"{fmt!r} is not a format soundfile can write")
+
+    resolved = np.dtype(dtype)
+    if np.issubdtype(resolved, np.integer):
+        kind = "int16" if resolved.itemsize <= 2 else "int32"
+    else:
+        kind = "float"
+
+    for candidate in _PREFERENCE_BY_KIND[kind]:
+        if candidate in available:
+            return candidate
+
+    default = sf.default_subtype(normalized)
+    if default is None:
+        raise ValueError(f"{fmt!r} has no default subtype; name one explicitly")
+    return default
+
+
+def resolve_subtype(
+    fmt: str,
+    dtype: Union[np.dtype, type, str] = np.float32,
+    subtype: Optional[str] = None,
+) -> str:
+    """Decide the subtype for a write, validating an explicit request against the format.
+
+    Args:
+        fmt: A libsndfile format name.
+        dtype: The dtype of the array about to be written.
+        subtype: The caller's request, or None to preserve as much as ``fmt`` allows.
+
+    Returns:
+        The subtype to write.
+
+    Raises:
+        ValueError: If ``subtype`` is not one ``fmt`` can carry. ``subtype="FLOAT"`` with a FLAC
+            destination is the case worth naming: FLAC has no float subtype at any depth, so
+            "preserve exactly" and "write FLAC" are mutually exclusive and must not resolve to a
+            quiet quantization.
+    """
+    normalized = fmt.upper()
+    if subtype is None:
+        return widest_subtype(normalized, dtype)
+    requested = subtype.upper()
+    if not sf.check_format(normalized, requested):
+        raise ValueError(
+            f"{normalized} cannot carry subtype {requested}; it supports "
+            f"{sorted(sf.available_subtypes(normalized))}. "
+            f"{'FLAC is an integer codec and has no float subtype at any depth. ' if normalized == 'FLAC' else ''}"
+            "Choose a format that supports it, or a subtype this one has."
+        )
+    return requested
+
+
+def subtype_preference(
+    fmt: str,
+    preferred: Optional[str],
+    dtype: Union[np.dtype, type, str] = np.float32,
+) -> Optional[str]:
+    """Degrade a subtype *preference* to what ``fmt`` can carry.
+
+    The distinction from :func:`resolve_subtype` is the point. An explicit subtype is a demand and
+    must raise when the format cannot carry it, because a caller asking for FLOAT and silently
+    receiving PCM_16 is the defect this module exists to remove. A preference -- a codec hint
+    derived from a source stream, say -- is not a demand: the caller wants as much fidelity as the
+    container allows and has no opinion beyond that.
+
+    Args:
+        fmt: A libsndfile format name.
+        preferred: The subtype the caller would like, or None.
+        dtype: The dtype of the array about to be written.
+
+    Returns:
+        ``preferred`` when ``fmt`` can carry it, otherwise None, which leaves
+        :func:`resolve_subtype` to pick the widest subtype the format has.
+    """
+    if preferred is None:
+        return None
+    normalized, requested = fmt.upper(), preferred.upper()
+    return requested if sf.check_format(normalized, requested) else None
+
+
+def out_of_range_fraction(samples: Union[np.ndarray, Sequence[float]]) -> float:
+    """Fraction of samples a fixed-point subtype would clip, i.e. those outside ±1.
+
+    Args:
+        samples: Samples, in any shape.
+
+    Returns:
+        The fraction in ``[0, 1]``; ``0.0`` for an empty array.
+    """
+    arr = np.asarray(samples)
+    if arr.size == 0:
+        return 0.0
+    return float(np.count_nonzero(np.abs(arr) > 1.0) / arr.size)
+
+
+def apply_range_policy(
+    samples: np.ndarray,
+    fmt: str,
+    subtype: str,
+    out_of_range: str = RAISE,
+    destination: str = "",
+) -> Tuple[np.ndarray, float, float, float]:
+    """Enforce the range policy for a write that is about to happen.
+
+    The one place the "can this data be represented, and if not, what then" question is answered.
+    :func:`write_audio` calls it, and so does ``Audio.save_to_file`` on the paths where libsndfile
+    is not the writer -- so a float-incapable destination behaves identically either way.
+
+    Args:
+        samples: The samples about to be written.
+        fmt: The resolved libsndfile format name (used only in messages).
+        subtype: The resolved subtype. A float one makes this a no-op.
+        out_of_range: ``"raise"`` (default), ``"warn"`` or ``"normalize"``.
+        destination: The path, for the message.
+
+    Returns:
+        ``(samples, peak, fraction, gain)``. ``samples`` is rescaled only under ``"normalize"``,
+        and ``gain`` is the factor applied, so the original is recoverable by dividing by it.
+
+    Raises:
+        ValueError: If ``out_of_range`` is not a known policy, or if it is ``"raise"`` and the
+            samples do not fit.
+    """
+    if out_of_range not in OUT_OF_RANGE_POLICIES:
+        raise ValueError(f"out_of_range must be one of {OUT_OF_RANGE_POLICIES}, got {out_of_range!r}")
+
+    peak = float(np.abs(samples).max()) if samples.size else 0.0
+    if is_float_subtype(subtype) or peak <= 1.0:
+        return samples, peak, 0.0, 1.0
+
+    fraction = out_of_range_fraction(samples)
+    where = f" writing {destination}" if destination else ""
+    detail = (
+        f"{100 * fraction:.4g}% of samples exceed ±1 (peak {peak:.6g}) and {fmt}/{subtype} cannot represent them{where}"
+    )
+    if out_of_range == RAISE:
+        raise ValueError(
+            detail + ". Write a float-capable format (wav, aiff, w64, caf leave subtype=None and "
+            "get FLOAT), or pass out_of_range='normalize' to rescale with the gain reported, or "
+            "out_of_range='warn' to accept the clipping."
+        )
+    if out_of_range == WARN:
+        logger.warning("%s; those samples are being clipped.", detail)
+        return samples, peak, fraction, 1.0
+
+    gain = 1.0 / peak
+    logger.warning("%s; rescaling by %.6g. Divide by that gain to recover the original.", detail, gain)
+    return (samples * gain).astype(samples.dtype, copy=False), peak, fraction, gain
+
+
+def write_audio(
+    path: Union[str, os.PathLike],
+    samples: np.ndarray,
+    sampling_rate: int,
+    format: Optional[str] = None,
+    subtype: Optional[str] = None,
+    out_of_range: str = RAISE,
+    channels_first: bool = True,
+) -> AudioWriteReport:
+    """Write audio, preserving it exactly unless the destination cannot or the caller says otherwise.
+
+    Args:
+        path: Destination file. Its extension picks the format when ``format`` is None.
+        samples: 1-D samples, or 2-D shaped by ``channels_first``.
+        sampling_rate: Sample rate in Hz.
+        format: Explicit libsndfile format name, case-insensitive.
+        subtype: Explicit subtype. None resolves to the widest the format supports, which is
+            ``FLOAT`` for WAV -- so a plain ``.wav`` write preserves float samples exactly.
+        out_of_range: What to do when the resolved subtype cannot represent the samples:
+            ``"raise"`` (default), ``"warn"`` (clip, loudly) or ``"normalize"`` (rescale, with
+            the gain in the returned report).
+        channels_first: For 2-D ``samples``, whether the first axis is channels (senselab's
+            convention). Ignored for 1-D input.
+
+    Returns:
+        An :class:`AudioWriteReport` naming what was written.
+
+    Raises:
+        ValueError: If the format cannot be written, the subtype does not fit it, or the samples
+            do not fit the subtype under ``out_of_range="raise"``.
+    """
+    fmt = format_for(path, format)
+    if not libsndfile_can_write(fmt):
+        raise ValueError(f"{fmt!r} is not a format soundfile can write; got destination {os.fspath(path)!r}")
+
+    array = np.asarray(samples)
+    if array.ndim == 2 and channels_first:
+        array = array.T
+
+    resolved = resolve_subtype(fmt, array.dtype, subtype)
+    array, peak, fraction, gain = apply_range_policy(array, fmt, resolved, out_of_range, os.fspath(path))
+
+    sf.write(os.fspath(path), array, sampling_rate, subtype=resolved, format=fmt)
+    return AudioWriteReport(
+        path=os.fspath(path),
+        format=fmt,
+        subtype=resolved,
+        peak=peak,
+        out_of_range_fraction=fraction,
+        gain=gain,
+    )
+
+
+def read_audio(
+    path: Union[str, os.PathLike],
+    always_2d: bool = False,
+    channels_first: bool = True,
+) -> Tuple[np.ndarray, int]:
+    """Read audio as float32, in senselab's axis order.
+
+    Args:
+        path: Source file.
+        always_2d: Return a 2-D array even for mono.
+        channels_first: For 2-D output, put channels on the first axis. Ignored when the result
+            is 1-D.
+
+    Returns:
+        ``(samples, sampling_rate)``.
+    """
+    data, sampling_rate = sf.read(os.fspath(path), dtype="float32", always_2d=always_2d)
+    if data.ndim == 2 and channels_first:
+        data = data.T
+    return data, int(sampling_rate)

--- a/src/senselab/utils/subprocess_venv.py
+++ b/src/senselab/utils/subprocess_venv.py
@@ -5,7 +5,7 @@ that conflict with the core senselab installation. IPC uses a temp
 directory with:
 - manifest.json: call spec + JSON-serializable args + file metadata
 - *.safetensors: tensor data (via safetensors, already a dep)
-- *.flac: audio data (lossless compressed via torchaudio)
+- *.wav: audio data (float, written through the range policy)
 - *.npy: numpy arrays
 
 File references include optional integrity metadata:
@@ -708,7 +708,7 @@ def _pack_value(key: str, value: object, data_dir: Path) -> dict:
     - FileRef → path reference with integrity metadata
     - torch.Tensor → safetensors (fast, safe, HF standard)
     - numpy.ndarray → .npy (native numpy)
-    - senselab Audio → .flac (lossless compressed audio)
+    - senselab Audio → .wav (float, via its own writer)
     - senselab Video / Path to video → path reference (no copy)
     - PIL.Image → .png (lossless)
     - bytes/bytearray → .bin (raw binary)
@@ -737,8 +737,7 @@ def _pack_value(key: str, value: object, data_dir: Path) -> dict:
         np.save(str(path), value)
         return {"type": "ndarray", "file": f"{key}.npy"}
 
-    # senselab Audio (has waveform + sampling_rate) → WAV/FLOAT via its own writer, which applies
-    # the range policy. FLAC would clip anything past ±1 (it has no float subtype at any depth).
+    # senselab Audio (has waveform + sampling_rate) → WAV/FLOAT via its own writer.
     if hasattr(value, "waveform") and hasattr(value, "sampling_rate") and hasattr(value, "save_to_file"):
         path = data_dir / f"{key}.wav"
         value.save_to_file(str(path))

--- a/src/senselab/utils/subprocess_venv.py
+++ b/src/senselab/utils/subprocess_venv.py
@@ -592,6 +592,31 @@ def venv_python(venv_dir: Path) -> str:
     return str(venv_dir / "bin" / "python")
 
 
+def stage_portable_audio_io(directory: "str | Path") -> str:
+    """Copy the portable audio I/O module into ``directory`` and return that directory.
+
+    A worker runs in a venv where senselab is absent, so it cannot import the range policy --
+    it gets the file handed to it instead. The worker adds the returned directory to
+    ``sys.path`` and does ``from portable_audio_io import read_audio, write_audio``.
+
+    Copying the file rather than inlining its source into the worker string keeps the worker
+    readable and keeps one copy of the policy on disk: an inlined prelude would be a second
+    rendering of the same module, and a reader of the worker could not tell which one ran.
+
+    Args:
+        directory: A directory the worker can read, normally the parent's ``TemporaryDirectory``.
+
+    Returns:
+        ``directory`` as a string, for the worker payload.
+    """
+    from senselab.utils import portable_audio_io
+
+    source = Path(portable_audio_io.__file__)
+    destination = Path(directory) / source.name
+    shutil.copyfile(source, destination)
+    return str(directory)
+
+
 def _clean_subprocess_env() -> dict:
     """Return a copy of os.environ fit for a subprocess venv.
 
@@ -712,13 +737,12 @@ def _pack_value(key: str, value: object, data_dir: Path) -> dict:
         np.save(str(path), value)
         return {"type": "ndarray", "file": f"{key}.npy"}
 
-    # senselab Audio (has waveform + sampling_rate) → FLAC
-    if hasattr(value, "waveform") and hasattr(value, "sampling_rate"):
-        import torchaudio
-
-        path = data_dir / f"{key}.flac"
-        torchaudio.save(str(path), value.waveform.cpu(), value.sampling_rate, format="flac")
-        return {"type": "audio", "file": f"{key}.flac", "sr": value.sampling_rate}
+    # senselab Audio (has waveform + sampling_rate) → WAV/FLOAT via its own writer, which applies
+    # the range policy. FLAC would clip anything past ±1 (it has no float subtype at any depth).
+    if hasattr(value, "waveform") and hasattr(value, "sampling_rate") and hasattr(value, "save_to_file"):
+        path = data_dir / f"{key}.wav"
+        value.save_to_file(str(path))
+        return {"type": "audio", "file": f"{key}.wav", "sr": value.sampling_rate}
 
     # senselab Video or file path → pass path reference (no copy)
     if hasattr(value, "_file_path") and getattr(value, "_file_path", None) is not None:
@@ -799,6 +823,11 @@ container = Path(sys.stdin.read().strip())
 manifest = json.loads((container / "manifest.json").read_text())
 data_dir = container / "data"
 
+# senselab is not installed in this venv; the parent stages the audio I/O policy alongside the
+# payload so a result audio is written under the same range policy the host applies.
+sys.path.insert(0, str(container))
+from portable_audio_io import write_audio
+
 try:
     from safetensors.torch import load_file as _st_load, save_file as _st_save
 except ImportError:
@@ -855,9 +884,10 @@ def pack(name, obj):
         np.save(str(rd / f"{name}.npy"), obj)
         return {"type": "ndarray", "file": f"{name}.npy"}
     if hasattr(obj, "waveform") and hasattr(obj, "sampling_rate"):
-        import torchaudio
-        torchaudio.save(str(rd / f"{name}.flac"), obj.waveform.cpu(), obj.sampling_rate, format="flac")
-        return {"type": "audio", "file": f"{name}.flac"}
+        samples = obj.waveform
+        samples = samples.detach().cpu().numpy() if hasattr(samples, "detach") else np.asarray(samples)
+        write_audio(str(rd / f"{name}.wav"), samples, int(obj.sampling_rate))
+        return {"type": "audio", "file": f"{name}.wav"}
     if isinstance(obj, Path):
         return {"type": "path", "value": str(obj)}
     if isinstance(obj, (bytes, bytearray)):
@@ -903,7 +933,7 @@ def call_in_venv(
     Data is serialized using efficient codecs:
     - torch.Tensor → safetensors (fast, safe, HF standard)
     - numpy.ndarray → .npy
-    - senselab Audio → .flac (lossless compressed)
+    - senselab Audio → .wav (FLOAT, exactly preserving values beyond ±1)
     - FileRef → path with checksum/lock metadata
     - PIL Image → .png, bytes → .bin, Pydantic → JSON
     - everything else → JSON
@@ -960,6 +990,8 @@ def call_in_venv(
             container = Path(tmpdir)
             data_dir = container / "data"
             data_dir.mkdir()
+            # The worker writes audio results, so it needs the range policy staged next to them.
+            stage_portable_audio_io(container)
 
             # Pack args
             entries: dict[str, object] = {}

--- a/src/senselab/video/tasks/input_output.py
+++ b/src/senselab/video/tasks/input_output.py
@@ -7,10 +7,22 @@ from typing import Any, Dict, List, Union
 
 import av
 import numpy as np
-import soundfile as sf
+import torch
 
+from senselab.audio.data_structures import Audio
 from senselab.utils.data_structures import from_strings_to_files, get_common_directory, logger
+from senselab.utils.portable_audio_io import subtype_preference
 from senselab.utils.tasks.input_output import read_files_from_disk
+
+# The codec hints a caller can pass, mapped to what the file is actually written at. An
+# unlisted hint resolves to whatever preserves most of what the container can hold.
+_SUBTYPE_FOR_ACODEC = {
+    "pcm_s16le": "PCM_16",
+    "pcm_s24le": "PCM_24",
+    "pcm_s32le": "PCM_32",
+    "pcm_f32le": "FLOAT",
+    "pcm_f64le": "DOUBLE",
+}
 
 
 def extract_audios_from_local_videos(
@@ -26,8 +38,12 @@ def extract_audios_from_local_videos(
     Args:
         files: Path(s) to video files.
         audio_format: Output audio format (default: wav).
-        acodec: Audio codec hint (default: pcm_s16le). Used to select
-            output sample format (16-bit signed int for pcm_s16le).
+        acodec: Audio codec hint (default: pcm_s16le), mapped to the subtype the file is
+            written at -- ``pcm_s16le`` to PCM_16, ``pcm_s24le`` to PCM_24, ``pcm_f32le`` to
+            FLOAT, anything else to whatever preserves most of what ``audio_format`` can hold.
+            A lossy decode can overshoot ±1; where the requested subtype cannot hold that,
+            the excess is clipped and the loss is logged rather than raising, because a bulk
+            extraction should not abort on one transient.
 
     Returns:
         A dataset dict of the extracted audio files.
@@ -57,17 +73,17 @@ def extract_audios_from_local_videos(
         if not frames:
             return False
 
-        audio_data = np.concatenate(frames)
+        audio_data = np.concatenate(frames).astype(np.float32)
 
-        # Match codec hint to sample format
-        if "s16" in codec:
-            audio_data = (
-                (audio_data * 32767).clip(-32768, 32767).astype(np.int16)
-                if audio_data.dtype != np.int16
-                else audio_data
-            )
-
-        sf.write(output_audio_path, audio_data, sample_rate, format=fmt.upper())
+        # Through Audio, so the subtype resolution and the range policy are the ones every
+        # other senselab write uses. out_of_range="warn": the caller chose the container, and a
+        # bulk extraction should report a clipped transient rather than abort on it.
+        Audio(waveform=torch.from_numpy(audio_data).unsqueeze(0), sampling_rate=sample_rate).save_to_file(
+            output_audio_path,
+            format=fmt,
+            subtype=subtype_preference(fmt, _SUBTYPE_FOR_ACODEC.get(codec)),
+            out_of_range="warn",
+        )
         return True
 
     if isinstance(files, str):

--- a/src/tests/audio/data_structures/audio_test.py
+++ b/src/tests/audio/data_structures/audio_test.py
@@ -192,7 +192,7 @@ def test_audio_save_to_file(audio_fixture: str, request: pytest.FixtureRequest) 
         temp_file_path = Path(temp_dir) / "test_audio.wav"
 
         # Call save_to_file to save the audio
-        audio_sample.save_to_file(file_path=temp_file_path, format="wav", bits_per_sample=16)
+        audio_sample.save_to_file(file_path=temp_file_path, format="wav", subtype="PCM_16")
 
         # Check if the file was created
         assert temp_file_path.exists(), "The audio file was not saved."

--- a/src/tests/audio/tasks/classification/yamnet_test.py
+++ b/src/tests/audio/tasks/classification/yamnet_test.py
@@ -25,9 +25,9 @@ import numpy as np
 import pytest
 
 from senselab.audio.tasks.classification.yamnet import (
-    LOSSLESS_WAV_SUBTYPE,
     write_worker_wav,
 )
+from senselab.utils.portable_audio_io import LOSSLESS_WAV_SUBTYPE
 
 SR = 16000
 

--- a/src/tests/audio/tasks/source_separation_test.py
+++ b/src/tests/audio/tasks/source_separation_test.py
@@ -830,7 +830,8 @@ def test_separate_audios_forwards_device(mono_audio_sample: Audio, monkeypatch: 
 def test_input_windows_are_written_as_float_not_pcm16(monkeypatch: pytest.MonkeyPatch) -> None:
     """The window files the host hands the worker are FLOAT, and samples past +-1 survive.
 
-    soundfile's WAV default is PCM_16, which clips every such sample before the worker reads it.
+    Both defaults used to clip here: ``sf.write`` picks PCM_16 for a ``.wav``, and
+    ``Audio.save_to_file`` wrote PCM_16 through torchcodec, which offers no encoding control.
     """
     captured: dict = {}
     u = _stub_worker(monkeypatch, captured)
@@ -852,18 +853,26 @@ def test_input_windows_are_written_as_float_not_pcm16(monkeypatch: pytest.Monkey
     assert captured["in_peak"] > 1.5, "an out-of-range sample was clipped on write"
 
 
-def test_every_worker_wav_write_names_an_explicit_subtype() -> None:
-    """No ``sf.write`` in the worker relies on soundfile's PCM_16 default.
+def test_the_worker_writes_through_the_staged_policy() -> None:
+    """The worker must not write audio itself, and its parent must stage what it imports.
 
-    That default has silently corrupted a measurement three times in this repository.
+    The repo-wide boundary is ``src/tests/utils/audio_write_boundary_test.py``; this keeps the
+    check local to the backend that has to carry the two halves in one file.
     """
+    assert "from portable_audio_io import" in unasdiff._WORKER_SCRIPT, (
+        "the worker must import the staged range policy rather than calling soundfile itself"
+    )
     tree = ast.parse(unasdiff._WORKER_SCRIPT)
-    writes = [
-        node
+    raw_writes = [
+        node.lineno
         for node in ast.walk(tree)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "write"
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"write", "save"}
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in {"sf", "soundfile", "torchaudio"}
     ]
-    assert writes, "test premise: the worker writes WAV files"
-    for node in writes:
-        keywords = {kw.arg for kw in node.keywords}
-        assert "subtype" in keywords, f"sf.write at worker line {node.lineno} relies on the PCM_16 default"
+    assert not raw_writes, f"worker line(s) {raw_writes} write audio directly, bypassing the range policy"
+    assert "stage_portable_audio_io(" in Path(unasdiff.__file__).read_text(), (
+        "the parent must stage portable_audio_io.py into the worker's temp dir"
+    )

--- a/src/tests/audio/tasks/speech_enhancement_test.py
+++ b/src/tests/audio/tasks/speech_enhancement_test.py
@@ -309,24 +309,25 @@ def test_checkpoint_override_skips_the_hub_entirely(
         driftse.enhance_audios_with_driftse([mono_audio_sample], model=model)
 
 
-def test_every_driftse_worker_wav_write_names_an_explicit_subtype() -> None:
-    """No ``sf.write`` in the DriftSE worker relies on soundfile's PCM_16 default.
-
-    That default clips every sample past +-1, and it has silently corrupted a measurement three
-    times in this repository -- once costing three SepFormer streams up to 8.9% of their samples
-    and 9.5 dB of agreement with the CPU run.
-    """
+def test_the_driftse_worker_writes_through_the_staged_policy() -> None:
+    """The worker must not write audio itself, and its parent must stage what it imports."""
+    assert "from portable_audio_io import" in driftse._WORKER_SCRIPT, (
+        "the worker must import the staged range policy rather than calling soundfile itself"
+    )
     tree = ast.parse(driftse._WORKER_SCRIPT)
-    writes = [
-        node
+    raw_writes = [
+        node.lineno
         for node in ast.walk(tree)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "write"
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"write", "save"}
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in {"sf", "soundfile", "torchaudio"}
     ]
-    assert writes, "test premise: the worker writes WAV files"
-    for node in writes:
-        assert "subtype" in {kw.arg for kw in node.keywords}, (
-            f"sf.write at worker line {node.lineno} relies on the PCM_16 default"
-        )
+    assert not raw_writes, f"worker line(s) {raw_writes} write audio directly, bypassing the range policy"
+    assert "stage_portable_audio_io(" in Path(driftse.__file__).read_text(), (
+        "the parent must stage portable_audio_io.py into the worker's temp dir"
+    )
 
 
 def test_driftse_input_wavs_are_written_as_float_not_pcm16(
@@ -334,8 +335,9 @@ def test_driftse_input_wavs_are_written_as_float_not_pcm16(
 ) -> None:
     """The WAV the host hands the DriftSE worker is FLOAT, and samples past +-1 survive it.
 
-    ``Audio.save_to_file`` writes PCM_16 for a ``.wav``, so an input peaking above full scale
-    was clipped before the enhancer ever saw it.
+    ``Audio.save_to_file`` used to write PCM_16 for a ``.wav`` -- torchcodec's AudioEncoder has
+    no encoding control -- so an input peaking above full scale was clipped before the enhancer
+    ever saw it.
     """
     monkeypatch.setenv(driftse._DRIFTSE_CHECKPOINT_ENV, str(tmp_path))
     monkeypatch.setattr(driftse, "ensure_venv", lambda *a, **k: Path("/tmp/fake-driftse-venv"))

--- a/src/tests/utils/audio_write_boundary_test.py
+++ b/src/tests/utils/audio_write_boundary_test.py
@@ -1,0 +1,292 @@
+"""No code outside the audio I/O layer may write an audio file itself.
+
+The defect this guards is not one bad default argument. It is that audio writes happened in
+thirteen places through four different APIs, so the range check and the subtype decision had
+thirteen chances to be forgotten -- and were, repeatedly and silently. Enforcing an explicit
+``subtype=`` at each site would have patched the instances; enforcing the boundary makes the class
+of defect structurally unrepeatable.
+
+The layer is two files with one policy: ``audio/data_structures/audio.py`` for in-process callers,
+and ``utils/portable_audio_io.py`` for subprocess workers, which cannot import senselab at all and
+are handed that file instead. Everything else goes through one of those.
+
+Fixing a failure means routing the write through ``Audio.save_to_file`` (in-process) or
+``portable_audio_io.write_audio`` (worker), not adding an allowlist entry. ``UNGUARDED_AUDIO_WRITE``
+exists for an admission with a reason, on the ``revision_pinning_guard_test.py`` pattern, and ships
+empty.
+
+Reasoning and the guard's pre-fix output: ``specs/20260819-091500-wav-subtype-sweep/design.md``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import List, Tuple
+
+# The audio I/O layer, relative to ``src/senselab``. Only these may call a writer directly.
+AUDIO_IO_LAYER = {
+    "audio/data_structures/audio.py",
+    "utils/portable_audio_io.py",
+}
+
+# Writers, as ``(receiver, attribute)``. A receiver of "" matches a bare call by that name.
+_WRITER_CALLS = {
+    ("sf", "write"),
+    ("soundfile", "write"),
+    ("torchaudio", "save"),
+    ("wavfile", "write"),
+    ("sf", "SoundFile"),
+    ("soundfile", "SoundFile"),
+}
+_WRITER_NAMES = {"AudioEncoder"}
+
+# relpath -> why a direct write is unavoidable there. Empty: every write goes through the layer.
+UNGUARDED_AUDIO_WRITE: dict[str, str] = {}
+
+# The one module allowed to define the subtype constant; everything else imports it.
+_CONSTANT_HOME = "utils/portable_audio_io.py"
+
+_STAGER = "stage_portable_audio_io"
+_WORKER_IMPORT = "from portable_audio_io import"
+
+
+def _src_root() -> Path:
+    from tests.utils.hf_load_coverage_test import _SRC
+
+    return _SRC
+
+
+def _is_writer_call(node: ast.AST) -> bool:
+    """Whether ``node`` calls one of the audio writers directly."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in _WRITER_NAMES
+    if isinstance(func, ast.Attribute):
+        receiver = func.value
+        if isinstance(receiver, ast.Name) and (receiver.id, func.attr) in _WRITER_CALLS:
+            return True
+        # scipy.io.wavfile.write -- the receiver is itself an attribute chain.
+        if isinstance(receiver, ast.Attribute) and (receiver.attr, func.attr) in _WRITER_CALLS:
+            return True
+    return False
+
+
+def _opens_for_reading_only(node: ast.Call) -> bool:
+    """Whether a ``SoundFile(...)`` call is a read, which is not a write and not guarded."""
+    func = node.func
+    if not (isinstance(func, ast.Attribute) and func.attr == "SoundFile"):
+        return False
+    modes: List[str] = [a.value for a in node.args if isinstance(a, ast.Constant) and isinstance(a.value, str)]
+    modes += [
+        k.value.value
+        for k in node.keywords
+        if k.arg == "mode" and isinstance(k.value, ast.Constant) and isinstance(k.value.value, str)
+    ]
+    return bool(modes) and all("w" not in mode and "x" not in mode for mode in modes)
+
+
+def _writes_in_source(source: str, origin: str) -> List[str]:
+    """Direct writer calls in ``source``, recursing into worker-script string literals.
+
+    Returned as ``file:line`` labels; a worker-script finding carries both the literal's line in
+    the parent and the line inside the worker. A worker string that mentions a writer and does not
+    parse is reported rather than skipped.
+    """
+    found: List[str] = []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return [f"{origin}: does not parse, so its writes cannot be checked"]
+
+    for node in ast.walk(tree):
+        if _is_writer_call(node):
+            assert isinstance(node, ast.Call)
+            if _opens_for_reading_only(node):
+                continue
+            found.append(f"{origin}:{node.lineno}")
+        elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if not any(f"{recv}.{attr}(" in node.value for recv, attr in _WRITER_CALLS):
+                if not any(f"{name}(" in node.value for name in _WRITER_NAMES):
+                    continue
+            found.extend(_writes_in_source(node.value, f"{origin}:{node.lineno} (worker script)"))
+    return found
+
+
+def _sweep() -> Tuple[List[str], List[str]]:
+    """``(inside_layer, outside_layer)`` direct writer calls across ``src/senselab``."""
+    root = _src_root()
+    inside: List[str] = []
+    outside: List[str] = []
+    for py in sorted(root.rglob("*.py")):
+        relpath = str(py.relative_to(root))
+        findings = _writes_in_source(py.read_text(), relpath)
+        (inside if relpath in AUDIO_IO_LAYER else outside).extend(findings)
+    return inside, outside
+
+
+def test_no_audio_write_happens_outside_the_io_layer() -> None:
+    """The boundary. A write anywhere else has its own chance to forget the range check."""
+    inside, outside = _sweep()
+
+    assert inside, "the sweep found no writes even inside the layer, so it is checking nothing"
+
+    offenders = [w for w in outside if w.split(" ")[0].split(":")[0] not in UNGUARDED_AUDIO_WRITE]
+    assert not offenders, (
+        "Audio write(s) outside the I/O layer, where neither the subtype resolution nor the "
+        "out-of-range policy applies:\n"
+        + "\n".join(f"  {w}" for w in offenders)
+        + "\n\nRoute them through Audio.save_to_file (in-process) or portable_audio_io.write_audio "
+        "(subprocess worker, via stage_portable_audio_io), or add the file to "
+        "UNGUARDED_AUDIO_WRITE in this test with the reason a direct write is unavoidable."
+    )
+
+
+def test_the_allowlist_is_current_and_explained() -> None:
+    """Every allowlist entry must name a real file, with a real reason, that still needs it."""
+    root = _src_root()
+    _, outside = _sweep()
+    outside_files = {w.split(" ")[0].split(":")[0] for w in outside}
+
+    for relpath, reason in UNGUARDED_AUDIO_WRITE.items():
+        assert (root / relpath).is_file(), f"UNGUARDED_AUDIO_WRITE names a file that no longer exists: {relpath}"
+        assert reason.strip(), f"UNGUARDED_AUDIO_WRITE entry {relpath} has no stated reason"
+        assert relpath in outside_files, (
+            f"UNGUARDED_AUDIO_WRITE entry {relpath} no longer writes directly -- remove it, so the "
+            "allowlist keeps meaning 'reviewed and still needed'"
+        )
+
+
+def test_the_layer_files_exist_where_the_guard_expects_them() -> None:
+    """A renamed layer file would silently exempt nothing and guard nothing."""
+    root = _src_root()
+    for relpath in sorted(AUDIO_IO_LAYER | {_CONSTANT_HOME}):
+        assert (root / relpath).is_file(), f"the guard names a layer file that does not exist: {relpath}"
+
+
+def test_the_detector_finds_each_api_and_ignores_reads() -> None:
+    """Pin the detector's verdicts; the caught cases are the pre-fix source of the real sites."""
+    caught = [
+        "sf.write(p, x, sr)",
+        'sf.write(p, x, sr, subtype="FLOAT")',  # explicit subtype is no longer enough
+        "soundfile.write(p, x, sr)",
+        'torchaudio.save(str(path), wf.cpu(), sr, format="flac")',
+        "AudioEncoder(samples=w, sample_rate=sr).to_file(p)",
+        "scipy.io.wavfile.write(p, sr, x)",
+        'sf.SoundFile(p, "w")',
+    ]
+    ignored = [
+        "write_audio(p, x, sr)",
+        "audio.save_to_file(p)",
+        'sf.read(p, dtype="float32")',
+        "sf.info(p)",
+        'sf.SoundFile(stream_source, "r")',
+        "f.write(chunk)",
+        "json.dump(result, f)",
+    ]
+
+    for source in caught:
+        assert _writes_in_source(source, "<caught>"), f"{source} is a direct audio write and must be caught"
+    for source in ignored:
+        assert not _writes_in_source(source, "<ignored>"), f"{source} is not a direct audio write"
+
+    worker = 'WORKER = """\nimport soundfile as sf\nsf.write(o, x, sr)\n"""\n'
+    assert _writes_in_source(worker, "<worker>") == ["<worker>:1 (worker script):3"]
+
+    unparsable = 'WORKER = "sf.write(o, x, sr"\n'
+    found = _writes_in_source(unparsable, "<unparsable>")
+    assert len(found) == 1 and "does not parse" in found[0]
+
+
+def _worker_audio_io_files() -> Tuple[set, set]:
+    """``(workers importing the staged module, parents calling the stager)``, by relpath."""
+    root = _src_root()
+    importers: set = set()
+    stagers: set = set()
+    for py in sorted(root.rglob("*.py")):
+        text = py.read_text()
+        relpath = str(py.relative_to(root))
+        if _WORKER_IMPORT in text:
+            importers.add(relpath)
+        # The stager's own definition is not a call to it.
+        if f"{_STAGER}(" in text and relpath != "utils/subprocess_venv.py":
+            stagers.add(relpath)
+        elif relpath == "utils/subprocess_venv.py" and text.count(f"{_STAGER}(") > 1:
+            stagers.add(relpath)
+    return importers, stagers
+
+
+def test_every_worker_that_imports_the_policy_gets_it_staged() -> None:
+    """A worker importing a module nobody copied fails only at runtime, in a subprocess.
+
+    Both directions: a worker whose parent forgot to stage, and a parent that stages for a worker
+    which no longer imports it (dead plumbing that would keep passing the first check forever).
+    """
+    importers, stagers = _worker_audio_io_files()
+
+    assert importers, "no worker imports the staged policy, so this check is vacuous"
+    unstaged = sorted(importers - stagers)
+    unused = sorted(stagers - importers)
+    assert not unstaged, (
+        "Worker script(s) import portable_audio_io but their parent never calls "
+        f"{_STAGER}(), so the import fails inside the subprocess:\n" + "\n".join(f"  {f}" for f in unstaged)
+    )
+    assert not unused, f"Parent(s) stage portable_audio_io for a worker that does not import it: {unused}"
+
+
+def _subtype_constant_names(tree: ast.AST) -> List[str]:
+    """Constant-cased ``*SUBTYPE*`` string assignments, i.e. second definitions of the policy.
+
+    A *string* constant only. A lowercase local is a use of the policy, and a mapping keyed on
+    someone else's vocabulary -- ``video/tasks/input_output.py``'s PyAV-codec-hint table -- is a
+    translation into it, which belongs with the caller that owns that vocabulary. What must not
+    exist twice is a bare name bound to a subtype literal, which is the shape that drifted.
+    """
+    names: List[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not (isinstance(node.value, ast.Constant) and isinstance(node.value.value, str)):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and "SUBTYPE" in target.id and target.id.isupper():
+                names.append(f"{node.lineno} defines {target.id}")
+    return names
+
+
+def test_the_constant_home_check_tells_a_definition_from_a_use() -> None:
+    """The pre-fix spellings must be caught; the post-fix ones must not be."""
+    caught = ['_WAV_SUBTYPE = "FLOAT"', 'LOSSLESS_WAV_SUBTYPE = "FLOAT"', '_FLAC_SUBTYPE = "PCM_24"']
+    ignored = [
+        "subtype = resolve_subtype(fmt, dtype, subtype)",
+        'wav_subtype = args["wav_subtype"]',
+        "from senselab.utils.portable_audio_io import LOSSLESS_WAV_SUBTYPE",
+        '_SUBTYPE_FOR_ACODEC = {"pcm_s16le": "PCM_16"}',  # a translation table, not a definition
+    ]
+    for source in caught:
+        assert _subtype_constant_names(ast.parse(source)), f"{source} defines the constant again"
+    for source in ignored:
+        assert not _subtype_constant_names(ast.parse(source)), f"{source} uses the constant, not redefines it"
+
+
+def test_the_subtype_constant_has_one_home() -> None:
+    """The literal must be defined once; it previously lived under two names in three modules."""
+    root = _src_root()
+    duplicates: List[str] = []
+    for py in sorted(root.rglob("*.py")):
+        relpath = str(py.relative_to(root))
+        if relpath in {_CONSTANT_HOME, "audio/data_structures/audio.py"}:
+            continue
+        try:
+            tree = ast.parse(py.read_text())
+        except SyntaxError:
+            continue
+        duplicates.extend(f"{relpath}:{found}" for found in _subtype_constant_names(tree))
+
+    assert not duplicates, (
+        f"Subtype constant(s) defined outside {_CONSTANT_HOME}:\n"
+        + "\n".join(f"  {d}" for d in duplicates)
+        + f"\n\nImport it from senselab.{_CONSTANT_HOME[:-3].replace('/', '.')} instead."
+    )

--- a/src/tests/utils/audio_write_boundary_test.py
+++ b/src/tests/utils/audio_write_boundary_test.py
@@ -290,3 +290,60 @@ def test_the_subtype_constant_has_one_home() -> None:
         + "\n".join(f"  {d}" for d in duplicates)
         + f"\n\nImport it from senselab.{_CONSTANT_HOME[:-3].replace('/', '.')} instead."
     )
+
+
+# Formats that carry a float sample beyond +/-1 without clipping it. A subprocess hand-off is an
+# internal intermediate, so it must be one of these; ``resolve_subtype`` gives them FLOAT.
+_FLOAT_CAPABLE_FORMATS = {"wav", "aiff", "aifc", "w64", "caf", "rf64", "au", "nist", "sd2"}
+
+# Hand-off sites admitted with a reason. Ships empty: a range-limited intermediate has no reason.
+RANGE_LIMITED_HANDOFF: dict[str, str] = {}
+
+
+def _handoff_formats(source: str, origin: str) -> List[str]:
+    """Return ``save_to_file`` sites whose literal ``format=`` cannot carry the full range."""
+    offenders = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "save_to_file"):
+            continue
+        for kw in node.keywords:
+            if kw.arg != "format" or not isinstance(kw.value, ast.Constant):
+                continue
+            fmt = str(kw.value.value).lower()
+            if fmt not in _FLOAT_CAPABLE_FORMATS:
+                offenders.append(f"{origin}:{node.lineno} (format={fmt!r})")
+    return offenders
+
+
+def test_no_internal_handoff_writes_a_format_that_cannot_carry_the_range() -> None:
+    """A hand-off to a subprocess worker must not clip the signal the model then sees.
+
+    FLAC tops out at PCM_24, so a waveform peaking above +/-1 -- which resampling routinely
+    produces -- reached eight workers clipped, with the loss invisible to both sides.
+    """
+    offenders: List[str] = []
+    for path in sorted(_src_root().rglob("*.py")):
+        origin = path.relative_to(_src_root()).as_posix()
+        if origin in RANGE_LIMITED_HANDOFF:
+            continue
+        offenders.extend(_handoff_formats(path.read_text(), origin))
+
+    assert not offenders, (
+        "save_to_file called with a format that clips samples beyond +/-1:\n    "
+        + "\n    ".join(offenders)
+        + "\nAn internal hand-off should omit ``format`` (or use one of "
+        + f"{sorted(_FLOAT_CAPABLE_FORMATS)}) so the worker reads what the caller held."
+    )
+
+
+def test_the_handoff_detector_reads_the_format_argument() -> None:
+    """The guard must key on the format, not on the presence of a call."""
+    assert _handoff_formats('a.save_to_file(p, format="flac")', "x.py")
+    assert _handoff_formats("a.save_to_file(p, format='mp3')", "x.py")
+    assert not _handoff_formats('a.save_to_file(p, format="wav")', "x.py")
+    assert not _handoff_formats("a.save_to_file(p)", "x.py")
+    # A computed format is out of scope: only a literal choice is a decision made here.
+    assert not _handoff_formats("a.save_to_file(p, format=fmt)", "x.py")

--- a/src/tests/utils/portable_audio_io_test.py
+++ b/src/tests/utils/portable_audio_io_test.py
@@ -1,0 +1,351 @@
+"""The one audio I/O policy, checked against libsndfile and against its second caller.
+
+Every assertion goes through a real write and a real read-back rather than comparing strings,
+because the defect is that ``sf.write(path, waveform, sr)`` and
+``AudioEncoder(...).to_file(path)`` both look right and substitute different samples.
+
+Reasoning and the measurements: ``specs/20260819-091500-wav-subtype-sweep/design.md``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+import torch
+
+from senselab.audio.data_structures import Audio
+from senselab.utils import portable_audio_io as pio
+from senselab.utils.portable_audio_io import (
+    LOSSLESS_WAV_SUBTYPE,
+    apply_range_policy,
+    is_float_subtype,
+    out_of_range_fraction,
+    read_audio,
+    resolve_subtype,
+    widest_subtype,
+    write_audio,
+)
+
+_SR = 16000
+
+
+def _over_unity_signal(peak: float = 1.6) -> np.ndarray:
+    """A float32 signal peaking past full scale, the excursion DriftSE's plain checkpoint reached."""
+    t = np.linspace(0.0, 1.0, _SR, endpoint=False, dtype=np.float32)
+    return (peak * np.sin(2 * np.pi * 440.0 * t)).astype(np.float32)
+
+
+# --------------------------------------------------------------------------------------------
+# Portability: the property that lets a worker venv use this module at all
+# --------------------------------------------------------------------------------------------
+
+
+def test_the_policy_module_imports_nothing_from_senselab() -> None:
+    """A worker venv has no senselab, so one convenient import here breaks every worker."""
+    tree = ast.parse(Path(pio.__file__).read_text())
+    offenders: list[str] = []
+    allowed = {"numpy", "soundfile", "logging", "os", "typing", "__future__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            offenders += [a.name for a in node.names if a.name.split(".")[0] not in allowed]
+        elif isinstance(node, ast.ImportFrom):
+            root = (node.module or "").split(".")[0]
+            if node.level or root not in allowed:
+                offenders.append(node.module or f"relative level {node.level}")
+
+    assert not offenders, (
+        "portable_audio_io.py must import only numpy, soundfile and the standard library -- it is "
+        f"staged into venvs where senselab is absent. Offending imports: {sorted(set(offenders))}"
+    )
+
+
+def test_the_policy_module_is_importable_from_a_bare_copy(tmp_path: Path) -> None:
+    """Staging is a file copy, so the file must work standing alone, not as part of a package."""
+    from senselab.utils.subprocess_venv import stage_portable_audio_io
+
+    staged_dir = stage_portable_audio_io(tmp_path)
+    copied = Path(staged_dir) / "portable_audio_io.py"
+    assert copied.is_file()
+
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("staged_portable_audio_io", copied)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    path = tmp_path / "staged.wav"
+    report = module.write_audio(str(path), _over_unity_signal(), _SR)
+    assert report.subtype == "FLOAT"
+    assert sf.info(str(path)).subtype == "FLOAT"
+
+
+# --------------------------------------------------------------------------------------------
+# The premise: what the defaults actually do to samples
+# --------------------------------------------------------------------------------------------
+
+
+def test_the_wav_default_really_does_clip_and_float_really_does_not(tmp_path: Path) -> None:
+    """The premise of the whole module, measured rather than asserted from the docs."""
+    signal = _over_unity_signal()
+
+    default_path = tmp_path / "default.wav"
+    sf.write(str(default_path), signal, _SR)  # the defect itself, reproduced deliberately
+    assert sf.info(str(default_path)).subtype == "PCM_16"
+    clipped, _ = sf.read(str(default_path), dtype="float32")
+    assert float(np.abs(clipped).max()) == pytest.approx(1.0, abs=1e-4)
+    assert float(np.count_nonzero(np.abs(clipped) >= 0.9999)) / clipped.size > 0.5
+
+    preserved = tmp_path / "preserved.wav"
+    report = write_audio(preserved, signal, _SR)
+    assert report.subtype == "FLOAT"
+    recovered, _ = sf.read(str(preserved), dtype="float32")
+    assert np.array_equal(recovered, signal), "a FLOAT WAV must round-trip float32 bit-exactly"
+
+
+def _rms_dbfs(x: np.ndarray) -> float:
+    return float(20 * np.log10(float(np.sqrt(np.mean(np.asarray(x, dtype=np.float64) ** 2))) + 1e-30))
+
+
+def test_the_16_bit_floor_replaces_quiet_content_rather_than_dropping_it(tmp_path: Path) -> None:
+    """At 16 bits, both -100 and -120 dBFS read back at the -93 dBFS 1-LSB floor.
+
+    libsndfile truncates toward negative infinity rather than rounding, so at -120 dBFS the
+    surviving int16 codes are ``{0, -1}`` -- a rectified artifact, not silence.
+    """
+    rng = np.random.default_rng(0)
+    pcm16 = tmp_path / "quiet_pcm16.wav"
+
+    for level_dbfs, minimum_error_db in [(-100.0, 3.0), (-120.0, 20.0)]:
+        quiet = (rng.standard_normal(_SR).astype(np.float32) * 10 ** (level_dbfs / 20)).astype(np.float32)
+        write_audio(pcm16, quiet, _SR, subtype="PCM_16")
+        back, _ = sf.read(str(pcm16), dtype="float32")
+        assert _rms_dbfs(back) - _rms_dbfs(quiet) > minimum_error_db, (
+            f"a {level_dbfs:g} dBFS signal must read back louder than itself at 16 bits"
+        )
+        assert _rms_dbfs(back) == pytest.approx(-93.3, abs=1.0), "the read-back level is the 1-LSB floor"
+
+        lossless = tmp_path / "quiet_float.wav"
+        write_audio(lossless, quiet, _SR)
+        recovered, _ = read_audio(lossless)
+        assert np.array_equal(recovered, quiet), "the default must round-trip a -120 dBFS signal exactly"
+
+    codes, _ = sf.read(str(pcm16), dtype="int16")
+    assert set(np.unique(codes).tolist()) <= {0, -1}, "at -120 dBFS nothing but the truncation artifact survives"
+
+
+# --------------------------------------------------------------------------------------------
+# Decision 1: which subtype a destination gets
+# --------------------------------------------------------------------------------------------
+
+
+def test_flac_cannot_take_the_wav_subtype() -> None:
+    """FLAC has no float subtype, which is why the sweep is not "write FLOAT everywhere"."""
+    assert not sf.check_format("FLAC", LOSSLESS_WAV_SUBTYPE)
+    assert sorted(sf.available_subtypes("FLAC")) == ["PCM_16", "PCM_24", "PCM_S8"]
+
+
+@pytest.mark.parametrize(
+    ("fmt", "dtype", "expected"),
+    [
+        ("wav", np.float32, "FLOAT"),
+        ("WAV", np.float64, "FLOAT"),
+        ("wav", np.int16, "PCM_16"),
+        ("wav", np.int32, "PCM_32"),
+        ("flac", np.float32, "PCM_24"),
+        ("flac", np.int16, "PCM_16"),
+        ("aiff", np.float32, "FLOAT"),
+        ("ogg", np.float32, "VORBIS"),
+        ("ogg", np.int16, "VORBIS"),
+        ("mp3", np.float32, "MPEG_LAYER_III"),
+    ],
+)
+def test_widest_subtype_picks_something_the_container_accepts(fmt: str, dtype: type, expected: str) -> None:
+    """Case-insensitive, dtype-aware, and never a subtype the format would reject."""
+    subtype = widest_subtype(fmt, dtype)
+    assert subtype == expected
+    assert sf.check_format(fmt.upper(), subtype)
+
+
+def test_resolve_subtype_refuses_preserve_exactly_plus_flac() -> None:
+    """Preserving exactly and writing FLAC are mutually exclusive, and must fail loudly."""
+    with pytest.raises(ValueError, match="no float subtype at any depth"):
+        resolve_subtype("FLAC", np.float32, "FLOAT")
+    assert resolve_subtype("FLAC", np.float32, None) == "PCM_24"
+    assert resolve_subtype("WAV", np.float32, "pcm_16") == "PCM_16", "a request is normalised, not rejected"
+
+
+def test_widest_subtype_refuses_what_it_cannot_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unknown format must raise; so must a format libsndfile gives no default for.
+
+    The second case is unreachable as libsndfile 1.2 ships (``RAW`` is its only format with no
+    default subtype, and it supports ``FLOAT``), so it is monkeypatched: the alternative to
+    raising is returning ``None``, which ``sf.write`` reads as "use the default".
+    """
+    with pytest.raises(ValueError, match="not a format soundfile can write"):
+        widest_subtype("not-a-format", np.float32)
+
+    monkeypatch.setattr("senselab.utils.portable_audio_io.sf.available_subtypes", lambda fmt: {"ULAW"})
+    monkeypatch.setattr("senselab.utils.portable_audio_io.sf.default_subtype", lambda fmt: None)
+    with pytest.raises(ValueError, match="no default subtype"):
+        widest_subtype("wav", np.float32)
+
+
+def test_write_audio_refuses_a_container_libsndfile_cannot_write(tmp_path: Path) -> None:
+    """The shim has one backend, so an m4a is refused here rather than silently mis-encoded."""
+    with pytest.raises(ValueError, match="not a format soundfile can write"):
+        write_audio(tmp_path / "x.m4a", _over_unity_signal(0.5), _SR)
+
+
+# --------------------------------------------------------------------------------------------
+# Decision 2: what happens when the samples do not fit
+# --------------------------------------------------------------------------------------------
+
+
+def test_out_of_range_fraction_counts_only_what_a_fixed_point_write_would_lose() -> None:
+    """Exactly ±1 is representable, so it must not be counted; an empty array is 0.0."""
+    assert out_of_range_fraction(np.array([0.0, 1.0, -1.0])) == 0.0
+    assert out_of_range_fraction(np.array([0.0, 1.5, -2.0, 0.5])) == pytest.approx(0.5)
+    assert out_of_range_fraction(np.zeros((2, 4))) == 0.0
+    assert out_of_range_fraction(np.array([], dtype=np.float32)) == 0.0
+    assert out_of_range_fraction(_over_unity_signal()) > 0.5
+
+
+def test_is_float_subtype_separates_the_two_that_hold_floats() -> None:
+    """The predicate the range policy short-circuits on."""
+    assert is_float_subtype(LOSSLESS_WAV_SUBTYPE)
+    assert is_float_subtype("DOUBLE")
+    for fixed in ("PCM_16", "PCM_24", "PCM_32", "ULAW", "ALAW", "VORBIS", "MPEG_LAYER_III"):
+        assert not is_float_subtype(fixed)
+
+
+def test_a_float_subtype_makes_the_range_policy_a_no_op() -> None:
+    """Nothing is checked, warned about or rescaled when the destination can hold the values."""
+    signal = _over_unity_signal(3.0)
+    samples, peak, fraction, gain = apply_range_policy(signal, "WAV", "FLOAT", pio.RAISE)
+    assert samples is signal
+    assert (peak, fraction, gain) == (pytest.approx(3.0), 0.0, 1.0)
+
+
+def test_raise_is_the_default_and_names_the_ways_out() -> None:
+    """A refused write is the default, because a silently rescaled measurement is worse."""
+    with pytest.raises(ValueError) as excinfo:
+        apply_range_policy(_over_unity_signal(3.0), "FLAC", "PCM_24", destination="/tmp/x.flac")
+    message = str(excinfo.value)
+    assert "peak 3" in message and "FLAC/PCM_24" in message and "/tmp/x.flac" in message
+    assert "out_of_range='normalize'" in message and "float-capable" in message
+
+
+def test_normalize_records_a_gain_that_recovers_the_original(tmp_path: Path) -> None:
+    """The rescale must be reversible, or it is just a quieter loss."""
+    signal = _over_unity_signal(3.0)
+    path = tmp_path / "normalized.wav"
+    report = write_audio(path, signal, _SR, subtype="PCM_16", out_of_range="normalize")
+
+    assert report.gain == pytest.approx(1.0 / 3.0)
+    assert report.peak == pytest.approx(3.0)
+    assert report.out_of_range_fraction > 0.5
+
+    back, _ = read_audio(path)
+    assert float(np.abs(back).max()) == pytest.approx(1.0, abs=1e-4)
+    assert np.allclose(back / report.gain, signal, atol=1e-4), "dividing by the gain must recover the signal"
+
+
+def test_warn_clips_but_says_so(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """The only policy that loses data does it in the log, not silently."""
+    path = tmp_path / "warned.wav"
+    with caplog.at_level("WARNING", logger="senselab"):
+        report = write_audio(path, _over_unity_signal(3.0), _SR, subtype="PCM_16", out_of_range="warn")
+    assert report.gain == 1.0
+    assert report.out_of_range_fraction > 0.5
+    assert any("clipped" in record.message or "clipped" in record.getMessage() for record in caplog.records)
+    back, _ = read_audio(path)
+    assert float(np.abs(back).max()) == pytest.approx(1.0, abs=1e-4)
+
+
+def test_an_unknown_policy_is_rejected() -> None:
+    """A typo in the policy name must not fall through to the permissive branch."""
+    with pytest.raises(ValueError, match="out_of_range must be one of"):
+        apply_range_policy(_over_unity_signal(3.0), "WAV", "PCM_16", "clip")
+
+
+# --------------------------------------------------------------------------------------------
+# The agreement test: two callers, one policy
+# --------------------------------------------------------------------------------------------
+
+_AGREEMENT_CASES = [
+    ("in-range wav", 0.9, "test.wav", None, "raise"),
+    ("out-of-range wav, preserved by default", 3.0, "test.wav", None, "raise"),
+    ("out-of-range wav, subtype forces the question", 3.0, "test.wav", "PCM_16", "normalize"),
+    ("out-of-range wav, clipping accepted", 3.0, "test.wav", "PCM_16", "warn"),
+    ("in-range flac", 0.9, "test.flac", None, "raise"),
+    ("out-of-range flac", 3.0, "test.flac", None, "raise"),
+    ("float-preserving wav, asked for by name", 3.0, "test.wav", "FLOAT", "raise"),
+]
+
+
+@pytest.mark.parametrize(("label", "peak", "name", "subtype", "policy"), _AGREEMENT_CASES)
+def test_audio_and_the_shim_make_the_same_decision(
+    tmp_path: Path, label: str, peak: float, name: str, subtype: str | None, policy: str
+) -> None:
+    """``Audio.save_to_file`` and ``write_audio`` must agree, byte for byte and error for error.
+
+    ``save_to_file`` delegates today, so this passes structurally. It is here for the day someone
+    reimplements one of the two: a shim that has drifted is worse than no shim, because the policy
+    then only looks applied.
+    """
+    signal = _over_unity_signal(peak)
+    audio = Audio(waveform=torch.from_numpy(signal).unsqueeze(0), sampling_rate=_SR)
+
+    shim_path = tmp_path / f"shim_{name}"
+    audio_path = tmp_path / f"audio_{name}"
+
+    shim_error: Exception | None = None
+    audio_error: Exception | None = None
+    shim_report = audio_report = None
+    try:
+        shim_report = write_audio(shim_path, signal, _SR, subtype=subtype, out_of_range=policy)
+    except Exception as exc:  # noqa: BLE001 -- the error itself is what is being compared
+        shim_error = exc
+    try:
+        audio_report = audio.save_to_file(audio_path, subtype=subtype, out_of_range=policy)
+    except Exception as exc:  # noqa: BLE001
+        audio_error = exc
+
+    assert (shim_error is None) == (audio_error is None), f"{label}: one path raised and the other did not"
+    if shim_error is not None:
+        assert type(shim_error) is type(audio_error)
+        assert str(shim_error).replace(str(shim_path), "") == str(audio_error).replace(str(audio_path), "")
+        return
+
+    assert shim_report is not None and audio_report is not None
+    assert (shim_report.format, shim_report.subtype) == (audio_report.format, audio_report.subtype), label
+    assert (shim_report.peak, shim_report.gain) == (audio_report.peak, audio_report.gain), label
+    assert shim_report.out_of_range_fraction == audio_report.out_of_range_fraction, label
+    assert shim_path.read_bytes() == audio_path.read_bytes(), f"{label}: the files differ"
+
+
+def test_read_audio_returns_senselab_axis_order(tmp_path: Path) -> None:
+    """Channels first for 2-D, and 1-D left alone, so a worker's array matches the host's."""
+    stereo = np.stack([_over_unity_signal(0.5), _over_unity_signal(0.25)])
+    path = tmp_path / "stereo.wav"
+    write_audio(path, stereo, _SR, channels_first=True)
+
+    channels_first, sampling_rate = read_audio(path, channels_first=True)
+    assert sampling_rate == _SR
+    assert channels_first.shape == (2, _SR)
+    assert np.allclose(channels_first, stereo)
+
+    time_first, _ = read_audio(path, channels_first=False)
+    assert time_first.shape == (_SR, 2)
+
+    mono_path = tmp_path / "mono.wav"
+    write_audio(mono_path, _over_unity_signal(0.5), _SR)
+    mono, _ = read_audio(mono_path)
+    assert mono.ndim == 1, "a mono read stays 1-D unless always_2d is asked for"
+    mono_2d, _ = read_audio(mono_path, always_2d=True)
+    assert mono_2d.shape == (1, _SR)

--- a/src/tests/video/tasks/input_output_test.py
+++ b/src/tests/video/tasks/input_output_test.py
@@ -1,0 +1,107 @@
+"""Audio extraction from video: the written file's subtype must match the container asked for.
+
+The extractor writes into a ``TemporaryDirectory`` that is gone by the time it returns, so these
+tests intercept ``read_files_from_disk`` -- called while the directory is still alive -- and copy the
+real files out. The write under test is the production one, not a reimplementation.
+
+Reasoning: ``specs/20260819-091500-wav-subtype-sweep/design.md``.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List
+
+import av
+import numpy as np
+import pytest
+import soundfile as sf
+
+from senselab.video.tasks import input_output as vio
+
+_VIDEO = Path(__file__).resolve().parents[2] / "data_for_testing" / "video_48khz_stereo_16bits.mp4"
+
+
+@pytest.fixture
+def extracted(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:  # noqa: ANN401 -- returns a closure
+    """Return a callable that extracts audio and yields the written file paths."""
+
+    def _extract(**kwargs: Any) -> List[Path]:  # noqa: ANN401
+        captured: List[Path] = []
+
+        def _copy_out(paths: List[str]) -> Dict[str, Any]:
+            for i, path in enumerate(paths):
+                destination = tmp_path / f"captured_{i}{Path(path).suffix}"
+                shutil.copyfile(path, destination)
+                captured.append(destination)
+            return {}
+
+        monkeypatch.setattr(vio, "read_files_from_disk", _copy_out)
+        vio.extract_audios_from_local_videos(str(_VIDEO), **kwargs)
+        return captured
+
+    return _extract
+
+
+def test_the_fixture_decodes_as_float_so_the_float_path_is_reachable() -> None:
+    """The premise of the tests below: PyAV hands back ``fltp`` for this stream, not ``s16``."""
+    with av.open(str(_VIDEO)) as container:
+        stream = container.streams.audio[0]
+        assert stream.format.name == "fltp"
+        frame = next(container.decode(audio=0))
+    assert np.asarray(frame.to_ndarray()).dtype == np.float32
+
+
+def test_the_s16_codec_hint_still_writes_pcm_16(extracted: Any) -> None:  # noqa: ANN401
+    """The default path is unchanged: an int16 array belongs in PCM_16."""
+    paths = extracted()
+    assert paths
+    assert sf.info(str(paths[0])).subtype == "PCM_16"
+
+
+def test_a_float_codec_hint_writes_float_not_pcm_16(extracted: Any) -> None:  # noqa: ANN401
+    """Pre-fix this wrote PCM_16, clipping every decoded sample beyond +-1."""
+    paths = extracted(acodec="pcm_f32le")
+    assert paths
+    info = sf.info(str(paths[0]))
+    assert info.format == "WAV"
+    assert info.subtype == "FLOAT"
+
+
+def test_a_flac_container_gets_the_widest_integer_subtype_it_has(extracted: Any) -> None:  # noqa: ANN401
+    """FLAC has no float subtype, so FLOAT would raise and PCM_16 would clip; PCM_24 is the answer."""
+    paths = extracted(audio_format="flac", acodec="pcm_f32le")
+    assert paths
+    info = sf.info(str(paths[0]))
+    assert info.format == "FLAC"
+    assert info.subtype == "PCM_24"
+
+
+def test_a_lossy_container_is_still_writable(extracted: Any) -> None:  # noqa: ANN401
+    """The fix must not force FLOAT onto a container that rejects it."""
+    paths = extracted(audio_format="ogg", acodec="pcm_f32le")
+    assert paths
+    assert sf.info(str(paths[0])).subtype == "VORBIS"
+
+
+def test_a_video_with_no_audio_track_yields_nothing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Pre-existing behaviour, held while the write below it changed."""
+    silent = tmp_path / "silent.mp4"
+    with av.open(str(silent), "w") as out:
+        stream = out.add_stream("mpeg4", rate=5)
+        stream.width, stream.height = 16, 16
+        for _ in range(3):
+            frame = av.VideoFrame.from_ndarray(np.zeros((16, 16, 3), dtype=np.uint8), format="rgb24")
+            out.mux(stream.encode(frame))
+        out.mux(stream.encode(None))
+
+    called: List[Any] = []
+
+    def _record(paths: Any) -> Dict[str, Any]:  # noqa: ANN401
+        called.append(paths)
+        return {}
+
+    monkeypatch.setattr(vio, "read_files_from_disk", _record)
+    assert vio.extract_audios_from_local_videos(str(silent)) == {}
+    assert not called, "a video with no audio track must not reach the reader at all"


### PR DESCRIPTION
Audio writes were clipping out-of-range samples silently, in the canonical path. This routes every write through one policy and adds a guard so the class of defect cannot come back.

## The defect, measured

`Audio.save_to_file` wrote `.wav` as **PCM_16** and `.flac` as **PCM_24**, inheriting the container default. A waveform peaking at 3.0 came back at 1.0. A flat 1.5 signal became **one distinct value** — an entire signal flattened to a DC rail, and it reads back as a perfectly plausible constant.

Nothing warns. `torchcodec`'s `AudioEncoder` raises **zero Python warnings** for this, and its API has no encoding control at all: `to_file(dest, *, bit_rate=None, num_channels=None, sample_rate=None)` — `bit_rate` is bits-per-second for lossy codecs, not PCM bit depth. So the check cannot be delegated downward; it has to live in senselab.

This had already corrupted **four measurements** in this repository, one of which was reported as a model hallucinating before being traced to a 98.5 %-clipped square wave.

## Why the fix is not thirteen `subtype=` arguments

Audio writes happened in **thirteen places through four different APIs**, so the range check and the subtype decision had thirteen chances to be forgotten — and were, repeatedly and silently. Enforcing an explicit `subtype=` at each site patches the instances; enforcing the *boundary* makes the class of defect structurally unrepeatable.

There is now **one policy in two files**: `audio/data_structures/audio.py` for in-process callers, and `utils/portable_audio_io.py` for subprocess workers, which cannot import senselab at all and are handed that module instead. `audio_write_boundary_test.py` asserts by AST sweep that no other file in `src/senselab` writes audio itself, on the `revision_pinning_guard_test.py` pattern. **Its allowlist ships empty** — fixing a failure means routing the write through the layer, not adding an entry.

## What `save_to_file` does now

It **resolves** the subtype rather than inheriting a default, so a plain `.wav` write gets `FLOAT` and round-trips float samples bit-exactly, including beyond ±1. Where the destination cannot represent the samples it **refuses**: FLAC has no float subtype at any depth, so "preserve exactly" and "write FLAC" are mutually exclusive and must not resolve to a quiet quantisation. `out_of_range='normalize'` rescales and **reports the applied gain** so it is reversible; `'warn'` accepts the clipping deliberately.

`encoding` and `bits_per_sample` are gone. They were documented as feeding "the soundfile fallback" — soundfile does not appear in that function — and torchcodec ignores them entirely. Keeping parameters that do nothing is how the next person writes 16-bit output believing they asked for 24. Pre-alpha policy is replace outright.

`subtype_preference` draws a distinction the video path needed: an **explicit** subtype is a demand and raises when the format cannot carry it, whereas a **codec hint** derived from a source stream is a preference and degrades to the widest subtype the container has. That is why a FLAC extraction from a float source now gets `PCM_24` and an OGG one gets `VORBIS`, rather than raising.

## Tests

- `portable_audio_io_test.py` — the policy itself, including the round-trip exactness cases
- `audio_write_boundary_test.py` — the AST guard, with its pre-fix output recorded in the spec
- `video/tasks/input_output_test.py` — per-container subtype resolution, including the two cases that drove `subtype_preference`
- **429 passed, 25 skipped** across `src/tests/utils`, `src/tests/video`, `src/tests/audio/data_structures` and `src/tests/audio/tasks/classification`; `pre-commit run --all-files` green

`codespell` needed `caf` added to its ignore list — Apple's Core Audio Format, one of the float-capable containers named in an error message.

## Provenance

Most of this was written by an agent that was killed by repeated API 529s with the work uncommitted. It was recovered, committed as-is, then completed and verified here: two failing video cases, four lint failures, and the codespell false positive.

Spec: `specs/20260819-091500-wav-subtype-sweep/design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
