### PR TITLE
The I/O invariants audit: what decode guarantees, and one mp3 defect

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,8 +49,11 @@ repos:
     args: [--maxkb=15000]
   - id: check-case-conflict
   - id: end-of-file-fixer
+    exclude: ^specs/.*/raw/
   - id: trailing-whitespace
+    exclude: ^specs/.*/raw/
   - id: pretty-format-json
+    exclude: ^specs/.*/raw/
     args:
     - --autofix
     - --indent=4
@@ -69,9 +72,12 @@ repos:
     # AER: alignment error rate. FPR: false-positive rate. PASE: Problem-Agnostic Speech
     # Encoder, a model name. preemptable: Slurm's own spelling (PreemptMode, the
     # mit_preemptable partition) -- codespell wants "preemptible", but that is not the
-    # partition's actual name. All four are terms codespell reads as misspellings of other
-    # words. caf: Apple's Core Audio Format, a libsndfile format name.
-    args: [--skip=*.ipynb, --ignore-words-list, 'AER,FPR,PASE,preemptable,caf']
+    # partition's actual name. caf: Apple Core Audio Format. als: MPEG-4 ALS, both file
+    # extensions in the I/O format matrix. Each is a term codespell reads as a misspelling of
+    # another word. Raw captured output is excluded rather than corrected: it is a verbatim
+    # record, and a truncated word in a printed table is part of what was printed.
+    exclude: ^specs/.*/raw/
+    args: [--skip=*.ipynb, --ignore-words-list, 'AER,FPR,PASE,preemptable,caf,als']
     additional_dependencies:
     - tomli
 - repo: local

--- a/specs/20260819-120600-io-invariants/README.md
+++ b/specs/20260819-120600-io-invariants/README.md
@@ -1,0 +1,30 @@
+# senselab audio I/O audit — 2026-08-19
+
+Read-only investigation. No repo changes; nothing filed upstream.
+
+| file | contents |
+|---|---|
+| `upstream.md` | **Part 1.** Upstream status: torchcodec #1576 (clamping — acknowledged, intended, closed `not_planned`, with the maintainer's verbatim rationale); the unreported bit-depth gap; the active chunking/seeking workstream (#1448/#1449/#1601/#1610/#1614/#1645); pytorch/audio #4211; the torchaudio I/O position; and a measured **0.11.1 vs 0.16.0** comparison. |
+| `matrix.md` | **Part 2a.** The format matrix: what each of 4 encoders writes for 11 targets, extension→codec maps, input-type constraints, float→int16 rounding, round-trip exactness per cell, out-of-range behaviour, sample-rate/channel/length/metadata preservation, video-container support, and senselab's measured end-to-end behaviour. |
+| `invariants.md` | **Part 2b + Part 3.** The decode side: source-independence, no normalisation (whole-file *and* per-segment at 60 dB), range-transparency on read, and chunk-equals-slice per format with max abs differences. Ends with the invariant list a test can pin, and the recommendation argued against the alternatives. |
+| `torchcodec-issue-draft.md` | Two **drafts, not filed**: (A) the unreported MP3 1105-sample timeline disagreement; (B) the unreported request for sample-format control. Explains why the clamping issue must *not* be re-filed. |
+| `scripts/` | Reproduction scripts, runnable via `uv run --project <senselab>`. |
+| `raw/` | Raw outputs: `matrix.json`, the printed matrices, the three invariant runs, and the 0.16.0 comparison. |
+
+## The four things that most changed the picture
+
+1. **`torchaudio.save`/`load` are not a fallback — they are torchcodec.** In 2.11.0 both import
+   from torchcodec and raise `ImportError` without it, and `torchaudio.info`,
+   `list_audio_backends`, `io`, `backend` and `AudioMetaData` are gone. senselab's
+   "torchcodec else torchaudio" branch has no second branch.
+2. **Upstream will not add the range check** (#1576, closed `not_planned`, on `O(n)` cost
+   grounds). The check must live in senselab — which is what PR #570 does.
+3. **Decode is clean and the invariants hold**: one dtype, one amplitude convention, nothing
+   normalised at any scope, out-of-range float survives bit-exactly, and chunk == slice
+   bit-for-bit for WAV and FLAC. The exception is MP3 through
+   `get_samples_played_in_range`: a constant −1105-sample shift, unreported upstream, still
+   present on 0.16.0.
+4. **The pinned 0.11.1 gets chunked resampling wrong** — `AudioDecoder(sample_rate=N)` read in
+   chunks differs from one-go by up to 0.996 in amplitude. senselab does not currently trip it
+   (it always decodes at native rate), but it forecloses the obvious speedup. Fixed in 0.16.0 by
+   PR #1614 — which in turn introduces an AAC tail discrepancy 0.11.1 did not have.

--- a/specs/20260819-120600-io-invariants/invariants.md
+++ b/specs/20260819-120600-io-invariants/invariants.md
@@ -1,0 +1,353 @@
+# The decode side: which invariants hold, measured
+
+Companion to `matrix.md` (which covers the format matrix and the encode side). Versions:
+Python 3.12.0, torch/torchaudio 2.11.0, torchcodec 0.11.1, soundfile 0.13.1 / libsndfile 1.2.2,
+librosa 0.11.0, numpy 2.4.4, ffmpeg 8.1. Scripts: `scripts/invariants*.py`; raw output in
+`raw/invariants_run{1,2,3}.txt`.
+
+Method note that changes a conclusion: the first pass compared every chunker against a
+*torchcodec* full decode, which conflates "this library decodes differently" with "this
+library's chunking is broken". Everything below compares **each library against its own full
+decode**, with the alignment searched over ±3000–4000 samples so a shifted chunk is reported as
+a shift rather than as noise. Cross-library agreement is reported separately.
+
+---
+
+## Invariant 1 — decode is source-independent in dtype and amplitude. HOLDS.
+
+One float32 signal (peak 0.799973, RMS 0.461799, 44100 samples at 22050 Hz) encoded into 11
+containers, all decoded by `torchcodec.AudioDecoder`:
+
+| source | dtype | n | sr | peak | RMS | bit-exact vs. reference |
+|---|---|---|---|---|---|---|
+| wav PCM_16 | float32 | 44100 | 22050 | 0.799988 | 0.461799 | no (quantised) |
+| wav PCM_24 | float32 | 44100 | 22050 | 0.799973 | 0.461799 | no (quantised) |
+| wav PCM_32 | float32 | 44100 | 22050 | 0.799973 | 0.461799 | no (quantised) |
+| **wav FLOAT32** | float32 | 44100 | 22050 | 0.799973 | 0.461799 | **YES** |
+| **wav FLOAT64** | float32 | 44100 | 22050 | 0.799973 | 0.461799 | **YES** |
+| flac 16 | float32 | 44100 | 22050 | 0.799988 | 0.461799 | no |
+| flac 24 | float32 | 44100 | 22050 | 0.799973 | 0.461799 | no |
+| mp3 192k | float32 | 44100 | 22050 | 1.060308 | 0.418184 | no |
+| opus | float32 | 44100 | 48000 | 1.632722 | 0.423055 | no |
+| m4a aac | float32 | **45056** | 22050 | 1.521272 | 0.450459 | no |
+| **mp4 (h264 video + aac)** | float32 | **45056** | 22050 | 1.521272 | 0.450459 | no |
+
+- **dtype**: always `float32`, from every source, from torchcodec, torchaudio, soundfile(f32)
+  and librosa. `float64` only if you explicitly ask soundfile for it.
+- **amplitude convention**: identical everywhere. A WAV/PCM_16 holding the literal int16 values
+  `[-32768, -32767, -16384, 0, 16384, 32766, 32767]` decodes to
+  `[-1.0, -0.99996948, -0.5, 0.0, 0.5, 0.99993896, 0.99996948]` — the `/32768` convention, to
+  the last bit, from **all six** readers (torchcodec, torchaudio, soundfile f32, soundfile f64,
+  librosa, ffmpeg). No reader disagrees.
+- **audio from a video container is indistinguishable** from the same audio in a bare container:
+  identical length, identical values.
+- What is **not** source-independent: **length** (AAC adds 956 samples; nothing trims the padding)
+  and **sample rate** (taken from the file, so an Opus file reports 48000 however it was made,
+  and for one Opus file ffprobe says 48000 while libsndfile says 24000).
+
+## Invariant 2 — decode does NOT clamp out-of-range float. HOLDS.
+
+A WAV/FLOAT and a WAV/DOUBLE file with samples spanning ±4.0:
+
+| reader | peak read back | bit-exact vs. source |
+|---|---|---|
+| torchcodec.AudioDecoder | 4.00000 | **YES** |
+| torchaudio.load | 4.00000 | **YES** |
+| soundfile.read(float32) | 4.00000 | **YES** |
+| soundfile.read(float64) | 4.00000 | **YES** |
+| librosa.load | 4.00000 | **YES** |
+| ffmpeg CLI | 4.00000 | **YES** |
+
+Same result whether the file was written by soundfile or by ffmpeg. **The asymmetry is precise:
+torchcodec's read path is fully range-transparent; its write path is not.** Out-of-range audio
+can be read into senselab; before PR #570 it could not be written back out again.
+
+Lossy sources also return un-clamped: the reference signal at peak 0.7999 comes back at peak
+1.0603 from mp3, 1.6327 from opus, 1.5213 from AAC. So `peak <= 1` is **not** an invariant a
+caller may assume after decode, for any source.
+
+## Invariant 3 — nothing normalises, at any scope. HOLDS.
+
+Two tests, because whole-file and per-segment normalisation fail differently.
+
+**Whole-file.** Two files identical except a `x0.1` gain, all six readers:
+
+| source format | peak ratio (expect 0.1) | RMS ratio (expect 0.1) |
+|---|---|---|
+| WAV/FLOAT | 0.100000 | 0.100000 |
+| WAV/PCM_16 | 0.100010 | 0.100000 |
+| FLAC/PCM_24 | 0.100000 | 0.100000 |
+
+The 0.100010 on PCM_16 is 16-bit quantisation of the single peak sample, not gain: the RMS
+ratio is exactly 0.1.
+
+**Per-segment — the one that would invalidate every windowed measurement in this project.** A
+6 s file whose first half is at peak 0.899982 and second half at peak 0.000900 (−60 dB). Decode
+the quiet half as a seeked chunk, and compare to the same range sliced out of that library's
+own full decode. A per-segment peak or RMS normaliser would boost the quiet chunk; the ratio
+would be ~1000, not 1.
+
+| format | reader | quiet-chunk peak | slice peak | chunk/slice | bit-exact |
+|---|---|---|---|---|---|
+| wav FLOAT32 | torchcodec / torchaudio / soundfile / ffmpeg | 0.000899961 | 0.000899961 | **1.000000** | **True** |
+| wav PCM_16 | all four | 0.000915527 | 0.000915527 | **1.000000** | **True** |
+| flac PCM_24 | all four | 0.000899911 | 0.000899911 | **1.000000** | **True** |
+| m4a aac | torchcodec / torchaudio / ffmpeg | 0.150671810 | 0.150671810 | **1.000000** | **True** |
+| **mp3 192k** | **torchcodec** | **1.163850546** | 0.117209934 | **9.929624** | **False** |
+| mp3 192k | torchaudio / soundfile / ffmpeg | 0.117209934 | 0.117209934 | 1.000000 | True |
+
+**No decode path in this set normalises, per file or per segment**, at 60 dB of dynamic range.
+The single failing cell is *not* normalisation — it is Invariant 4's MP3 offset defect showing
+its consequences: the chunk landed 1105 samples early, straddling the loud/quiet boundary, so a
+windowed measurement of the quiet half reads **9.93x too loud**. That is the concrete shape of
+the corruption, and it is an indexing bug, not a gain bug.
+
+(Per-segment normalisation *does* exist in this codebase — DriftSE's per-chunk peak
+normalisation — but it is introduced by senselab's own worker code, above the I/O boundary. The
+decode layer is innocent.)
+
+## Invariant 4 — chunk equals slice. HOLDS for WAV and FLAC. FAILS for MP3 via torchcodec.
+
+Each library vs. its own full decode; `off` = how far the returned chunk actually sits from
+where it was requested, in samples; requests at an aligned offset (0), an odd offset (5001) and
+mid-file (44877).
+
+| format | torchcodec range | torchaudio (=tc) | soundfile `start=` | ffmpeg `-ss` **before** `-i` | ffmpeg `-ss` **after** `-i` |
+|---|---|---|---|---|---|
+| wav PCM_16 | **EXACT** 0.0e+00 | **EXACT** | **EXACT** | **EXACT** | **EXACT** |
+| wav FLOAT32 | **EXACT** 0.0e+00 | **EXACT** | **EXACT** | **EXACT** | **EXACT** |
+| flac PCM_24 | **EXACT** 0.0e+00 | **EXACT** | **EXACT** | **EXACT** | **EXACT** |
+| mp3 192k | values exact but **off = −1105**; short read at t=0 (943 of 2048) | **EXACT** 0.0e+00 | off=0, **1.8e−07** | off=0, **1.2e+00 — wrong data** | **EXACT** 0.0e+00 |
+| m4a aac | **EXACT** 0.0e+00 | **EXACT** 0.0e+00 | cannot open | off=0, **up to 1.1e+00 — wrong data** | **EXACT** 0.0e+00 |
+| opus 48k | **EXACT** 0.0e+00 | **EXACT** 0.0e+00 | **EXACT** 0.0e+00 | **EXACT** | **EXACT** 0.0e+00 |
+
+**Contiguity** (concatenate consecutive 2048-sample chunks, compare to the full decode):
+bit-for-bit identical, 0 mismatched samples, for WAV/PCM_16, WAV/FLOAT32 and FLAC/PCM_24 via
+torchcodec, soundfile and torchaudio alike. senselab's `Audio.from_stream` (soundfile blocks)
+also reconstructs the full decode bit-for-bit at 0.25 s chunks on all three. For MP3 via
+torchcodec the concatenation is **1105 samples short** (131195 vs 132300).
+
+### The MP3 defect, exactly
+
+torchcodec's two entry points use two different timelines for the same file:
+
+| requested start | n returned (2048 asked) | `pts_seconds` reported | offset vs. `get_all_samples()` |
+|---|---|---|---|
+| 0 | **943** | 0.050113379 (= sample 1105) | 0 |
+| 1 | 944 | 0.050113379 (sample 1105) | −1 |
+| 100 | 1043 | 0.050113379 (sample 1105) | −100 |
+| 576 | 1519 | 0.050113379 (sample 1105) | −576 |
+| 1105 | 2048 | 0.050113379 (sample 1105) | −1105 |
+| 2048 | 2048 | 0.092879819 (sample 2048) | −1105 |
+| 5001 | 2048 | 0.226802721 (sample 5001) | −1105 |
+| 22050 | 2048 | 1.000000000 (sample 22050) | −1105 |
+
+`get_all_samples()` prepends **1105 samples** of MP3 decoder pre-roll (576 + 529 — the standard
+MDCT + LAME delay) which `get_samples_played_in_range()` excludes. So for an MP3, index `i` of a
+full decode is presentation sample `i − 1105`, and **a windowed measurement taken via offsets is
+shifted by 1105 samples — 50.1 ms at 22.05 kHz — relative to a whole-file measurement of the same
+file.** Below `start = 1105` the range API additionally short-reads, returning
+`n − (1105 − start)` samples with no warning.
+
+The chunk *values* are exact once aligned (0.0e+00 at off = −1105), so this is purely an
+indexing defect. Two further properties, both measured:
+
+- **It is not frame-boundary dependent.** Sweeping the seek offset across a full MP3 frame
+  (1152 samples) at +0, +1, +288, +576, +1151, +1152, +1153, +2304 gives off = −1105 and
+  diff = 0.0e+00 at *every* offset. A constant shift, not jitter — which makes it correctable.
+- **`pts_seconds` on the returned `AudioSamples` reports the true position**, and aligning
+  against it is bit-exact in every row. So the information needed to detect and fix this is
+  present in the API. **senselab discards it**:
+  `Audio._lazy_load_data_from_filepath` returns `samples.data` and drops the rest, so
+  `Audio(filepath=..., offset_in_sec=...)` inherits the shift verbatim — measured off = −1105
+  for mp3, 0 for wav / flac / m4a / opus.
+
+`torchaudio.load(frame_offset=, num_frames=)` is exact for mp3 despite being a torchcodec
+wrapper, because it decodes then slices rather than seeking.
+
+### Two traps worth pinning in a test
+
+- **ffmpeg `-ss` placement.** `-ss` *before* `-i` (fast/keyframe seek) returns **wrong data** for
+  mp3 (max diff 1.2) and aac (up to 1.1) — a different part of the signal, silently. `-ss`
+  *after* `-i` (decode-and-discard) is bit-exact for every format tested. Same for AAC and Opus,
+  which are otherwise clean at every offset swept across their frame sizes (1024 and 960).
+- **soundfile + mp3** is positionally correct (off = 0) but **not** bit-identical to its own full
+  decode: tolerance **1.2e−07 to 1.8e−07**, present at every offset except a full-frame multiple.
+  Correct to float32 rounding, not to the bit.
+
+### Cross-library agreement on a full decode (decoder identity, not chunking)
+
+| format | torchcodec vs torchaudio | vs soundfile | vs ffmpeg |
+|---|---|---|---|
+| wav PCM_16 / FLOAT32 | EXACT | EXACT | EXACT |
+| flac PCM_24 | EXACT | EXACT | EXACT |
+| mp3 192k | EXACT | **2.46e−06** | EXACT |
+| m4a aac | EXACT | cannot open | EXACT |
+| opus 48k | EXACT | **1.13e−06** | EXACT |
+
+For lossless formats all four decoders are bit-identical, so the choice is free. For lossy
+formats libsndfile's decoders (mpg123, libopusfile) differ from ffmpeg's by ~1–2e−06, so "which
+library decoded this mp3" is a provenance fact, not a free choice.
+
+---
+
+## The invariants a caller may rely on, stated for a test to pin
+
+Given the primary decode path below, these hold and are cheap to assert:
+
+1. **dtype is always `float32`**, shape `(channels, samples)`, for every format and container,
+   including audio inside a video file.
+2. **Amplitude is the `/32768` convention** and is never rescaled: full-scale negative int16 is
+   exactly `−1.0`, and a `x g` gain in the file is a `x g` gain in the array, to float precision.
+3. **Nothing is normalised** — not per file, not per segment. Two windows of one recording are
+   directly comparable, at 60 dB of dynamic range.
+4. **Out-of-range float survives decode unclamped and bit-exact.** `peak <= 1` must not be
+   assumed, especially from a lossy source (measured up to 1.63).
+5. **`read(path)[a:b] == read(path, offset=a, duration=b-a)`, bit-for-bit**, for WAV (any
+   subtype) and FLAC, at aligned, odd and mid-file offsets, and consecutive chunks concatenate
+   back to the whole file with 0 mismatched samples.
+6. **Invariant 5 does not hold for MP3 through `torchcodec.get_samples_played_in_range`** — a
+   constant −1105-sample shift plus a silent short read below sample 1105. It does hold via
+   `torchaudio.load(frame_offset=...)`, `soundfile.read(start=...)` (to 1.8e−07) and
+   `ffmpeg -i … -ss` (bit-exact).
+7. **Sample rate and channel count are preserved** by every path for wav / flac / mp3 /
+   ogg-vorbis. **Not for Opus** (forced to a supported rate; two readers can disagree about
+   which). **Length is not preserved for AAC** (up to one 1024-sample frame of untrimmed
+   padding).
+
+`portable_audio_io`'s read side must honour 1–5 identically, or a worker's read will disagree
+with the parent's. Since the workers have only numpy + soundfile, and since soundfile is
+bit-identical to torchcodec on WAV and FLAC for both whole-file and chunked reads, that is
+achievable **for lossless formats only** — which is the right constraint for an IPC boundary
+anyway.
+
+---
+
+## Recommendation
+
+### Decode: `torchcodec.AudioDecoder` primary; `soundfile` first fallback; `ffmpeg -i … -ss` last.
+
+Argued against the alternatives:
+
+- **Why not soundfile primary?** It cannot open any video container (`Format not recognised` on
+  mp4, mkv, mov), cannot open m4a/aac at all, and cannot open the Ogg-FLAC that torchcodec
+  itself writes for `.ogg`. senselab handles video. That rules it out as the primary.
+- **Why not librosa?** It reads m4a and video only through `audioread`, which emits
+  `FutureWarning: Deprecated as of librosa version 0.10.0. It will be removed in …`. Building on
+  a path that announces its own removal, to get a capability torchcodec already has, is a bad
+  trade. It also gave a different length for AAC-in-MP4 than every other reader (48000 vs 48128).
+- **Why not ffmpeg CLI primary?** It is bit-identical to torchcodec everywhere and the most
+  capable, but it is a subprocess per read, it has the `-ss` placement trap, and it is an
+  external binary rather than a pinned wheel. Ideal as the last resort, wrong as the default.
+- **Why not torchaudio?** In 2.11.0 it *is* torchcodec (`torchaudio/_torchcodec.py` imports
+  `AudioDecoder` and raises `ImportError` without it), with `torchaudio.info`,
+  `list_audio_backends`, `io` and `backend` already removed. Depending on it adds a deprecation
+  surface and buys nothing — with one exception worth exploiting: its `frame_offset` slicing is
+  exact for MP3 where the torchcodec range API is not.
+- **So: torchcodec primary**, because it is the only single path covering every format *and*
+  video, it returns float32 with a consistent amplitude convention, it never normalises, and it
+  is bit-identical to soundfile and ffmpeg on all lossless formats. Its decode side has none of
+  the defects its encode side has.
+
+With two required guards, both measured, not speculative:
+
+- **MP3 must not use `get_samples_played_in_range`.** Either read the whole file and slice, or
+  use the returned `pts_seconds` to correct the offset (bit-exact in every row tested), or route
+  MP3 offsets through `soundfile.read(start=)`. Left alone, every windowed MP3 measurement in
+  the project is shifted 50.1 ms against its whole-file counterpart — and at a level transition
+  that read 9.93x too loud in the test above.
+- **`Audio` should stop discarding `pts_seconds`.** It is the only evidence available at runtime
+  that a chunk is not where it was asked for.
+
+Formats covered: everything measured — wav (all subtypes), flac, ogg-vorbis, ogg-flac, opus,
+mp3, m4a/aac, wavpack, and audio inside mp4/mkv/mov. Not covered by the fallback (soundfile):
+m4a/aac, ogg-flac, wavpack, and all video. That gap is exactly why the fallback is second.
+
+### Exactness: achievable, and where it is impossible in principle
+
+- **Exact for arbitrary float32**: WAV `FLOAT` / `DOUBLE` only, and WavPack (`.wv`). Written by
+  soundfile or ffmpeg, read by any of the six paths — bit-exact, and out-of-range values
+  preserved (peak 4.0 survived).
+- **Exact only for values already on the target integer grid**: WAV PCM_16/24/32, FLAC 16/24.
+  A signal on the 16-bit grid round-trips bit-exactly through all of them; arbitrary float32
+  does not, by construction (1.5e−05 at 16 bits, 1.2e−07 at 24, 2.3e−10 at 32).
+- **Impossible in principle**: **FLAC cannot carry float at any depth** — the format is integer
+  PCM only (libsndfile offers PCM_S8/16/24 and nothing else). No encoder choice fixes this;
+  FLAC is the wrong container for a float measurement artifact, full stop. Likewise every lossy
+  codec, which additionally *overshoots* rather than clamps (peak 3.0 in, 4.9 out).
+
+### Sample-format control on `Audio.save_to_file`
+
+**Keep the capability; #570 changed its spelling to `subtype`.** Before #570 they were pure
+decoration: `save_to_file` accepted both and passed neither to `AudioEncoder`, so the measured
+result was zero warnings and a silent PCM_16 write — worse than not offering them, because a
+caller who set `encoding="PCM_F", bits_per_sample=32` got 16-bit integer and was told nothing.
+The argument for removal ("only some backends honour them") is answered the other way round: the
+two backends that *can* honour them, soundfile and ffmpeg, are the two that can write float at
+all, and the one that cannot — torchcodec — cannot express a float write under any argument. So
+the parameters are not backend-specific decoration, they are the only way to say the one thing
+that matters, and the correct place to resolve them is exactly where #570 put them: above the
+backend, in senselab, where an unsatisfiable request can be refused rather than silently
+downgraded.
+
+What #570 shipped is that argument with a different interface. `encoding` and `bits_per_sample`
+are gone, replaced by one `subtype` plus an `out_of_range` policy. The pair said the same thing
+twice and could disagree with itself (`encoding="PCM_S"` with `bits_per_sample=32` is not a
+libsndfile subtype), whereas `subtype` is libsndfile's own vocabulary — `PCM_16`, `PCM_24`,
+`FLOAT` — so every accepted value names a format that exists. `resolve_subtype` supplies the
+default (`FLOAT` for a float-capable container), and `subtype_preference` separates a demand,
+which raises when the container cannot carry it, from a codec hint, which degrades to the widest
+the container has.
+
+One inconsistency inside senselab that the matrix exposed, **measured against `triage` before
+#570 merged and resolved by it** — all six sites now route through the layer: `driftse.py:49`, `unasdiff.py:237` and `yamnet.py:19` each define a module constant
+`= "FLOAT"` and pass it to `sf.write(..., subtype=...)` — the correct, bit-exact,
+range-transparent path. But `sparc.py:126,165`, `qwen_tts.py:212` and
+`video/tasks/input_output.py:70` call `sf.write` with **no subtype**, and libsndfile's default
+for WAV is `PCM_16`. Three worker boundaries quantise to 16 bits and clamp; three do not.
+
+### Different paths for different purposes
+
+| purpose | path | why |
+|---|---|---|
+| read anything, including video | `torchcodec.AudioDecoder` (guard MP3 offsets) | only path covering every format; float32, no normalisation, no clamping |
+| write a measurement artifact | WAV `FLOAT` via soundfile (or ffmpeg `pcm_f32le`) | the only bit-exact, range-transparent target |
+| worker IPC (numpy + soundfile only) | WAV `FLOAT` via soundfile both ways | bit-identical to torchcodec on WAV, chunk-exact, no senselab import |
+| archive / distribute | FLAC 24 via soundfile, **after** an explicit in-range check | lossless and small, but integer-only — the check cannot be delegated |
+| read a lossy or video source at an offset | `soundfile.read(start=)` for mp3; `ffmpeg -i … -ss` otherwise | avoids torchcodec's MP3 shift and ffmpeg's `-ss`-before-`-i` trap |
+
+How a caller knows: by the invariant list above, asserted in tests, rather than by reading
+backend source. That is the deliverable.
+
+---
+
+## Version-dependence of these invariants (added after cross-checking 0.16.0)
+
+The invariants above were measured on the pinned **torchcodec 0.11.1**. Re-measured on **0.16.0**
+(isolated venv, torch 2.13.0, FFmpeg 8.1; raw output `raw/torchcodec_0.16.0_check.txt`):
+
+- Invariants 1–4 (dtype, amplitude, no normalisation, no clamp on read) are **unchanged**.
+- Invariant 5 holds on both for WAV, FLAC and Opus.
+- Invariant 6 (the MP3 exception) is **unchanged on 0.16.0** — same −1105 shift, same 943-sample
+  short read, same 1105 samples lost over a chunked pass. Not fixed, and unreported upstream.
+- **New on 0.11.1 and fixed in 0.16.0:** chunked decoding *with the decoder's own resampler*
+  (`AudioDecoder(path, sample_rate=N)`) does **not** equal one-go decoding on 0.11.1 — max abs
+  difference **2.0e−01 at 16 kHz** and **9.96e−01 at 8 kHz**. Order-unity, not rounding. Fixed by
+  upstream PR #1614, bit-exact on 0.16.0 at both rates.
+
+  senselab does not currently trip this: all three `AudioDecoder(...)` call sites
+  (`audio.py:144`, `audio.py:204`, `video/data_structures/video.py:186`) decode at the native rate
+  and resample separately. So this is a **latent** hazard, not an active corruption — but it means
+  "let the decoder resample, it's cheaper" is not a safe optimisation on 0.11.1, and someone will
+  eventually propose it.
+- **New on 0.16.0 and absent on 0.11.1:** chunked AAC contiguity is no longer bit-exact — 256
+  samples differ from index 132160 (the file tail), max abs difference **9.9e−01**. Consistent
+  with upstream #1601 ("drops 1 sample in final fractional-second chunk"), which is marked
+  completed but which the reporter still reproduces and the maintainer describes as "not trivial".
+
+**Implication for the recommendation.** Upgrading torchcodec is not a free win: 0.16.0 buys the
+resampling-chunk fix and costs an AAC tail discrepancy, while the MP3 shift survives both. So the
+MP3 offset guard and a chunked-AAC check are required at either version, and the invariant list
+above should be asserted in senselab's own tests rather than assumed from a version pin. That is
+the practical argument for writing them down as tests: they are the only thing that will notice
+when a torchcodec upgrade moves one of them.

--- a/specs/20260819-120600-io-invariants/matrix.md
+++ b/specs/20260819-120600-io-invariants/matrix.md
@@ -1,0 +1,433 @@
+# senselab audio I/O audit — measured matrix
+
+All measurements on this host, 2026-08-19. Reproduction scripts:
+`/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/{matrix,summarize,probes,invariants,invariants2}.py`
+Raw results: `matrix.json` in the same directory (copied here as `matrix.json`).
+
+## Versions
+
+| component | version |
+|---|---|
+| Python | 3.12.0 |
+| numpy | 2.4.4 |
+| torch | 2.11.0 |
+| torchaudio | 2.11.0 |
+| torchcodec | 0.11.1 |
+| soundfile | 0.13.1 |
+| libsndfile | 1.2.2 |
+| librosa | 0.11.0 |
+| PyAV | 17.0.1 |
+| ffmpeg / ffprobe CLI | 8.1 (homebrew, `--enable-libopus --enable-libmp3lame`; **no `--enable-libvorbis`**) |
+
+Test signals, 22050 Hz unless noted:
+
+- `q16` — 2000 float32 samples on the exact 16-bit grid (`k/32768`, integer `k`). Any
+  lossless integer path of ≥16 bits should return this bit-for-bit; failure means a
+  scaling-convention mismatch.
+- `f32` — 2000 float32 samples uniform in (−0.9, 0.9). Not representable at any integer depth.
+- `oor` — `f32` scaled to peak 3.0, plus a 400-sample flat block at 1.5.
+- `q16_stereo` — two independent `q16` channels.
+
+---
+
+## Finding 0: `torchaudio.save` / `torchaudio.load` are not a fallback — they *are* torchcodec
+
+`torchaudio/__init__.py` in 2.11.0 routes `save` → `save_with_torchcodec` and `load` →
+`load_with_torchcodec`, each of which does `from torchcodec.encoders import AudioEncoder`
+(resp. `.decoders import AudioDecoder`) and raises `ImportError` if torchcodec is missing
+(`torchaudio/_torchcodec.py`, import guards at lines 82–86 and 246–250). Its own docstring:
+
+> As of TorchAudio 2.9, this function relies on TorchCodec's encoding capabilities under the
+> hood. […] Because of the reliance on Torchcodec, the parameters `format`, `encoding`,
+> `bits_per_sample`, `buffer_size`, and `backend`, are ignored and accepted only for
+> backwards compatibility.
+
+Measured consequence: every `torchaudio.save` cell in the matrix below is **byte-identical in
+size and content** to the corresponding `torchcodec.AudioEncoder` cell, and `torchaudio.save`
+emits a `UserWarning` per ignored argument rather than honouring it. `torchaudio.info`,
+`torchaudio.list_audio_backends`, `torchaudio.io`, `torchaudio.backend` and
+`torchaudio.AudioMetaData` are **gone** in 2.11.0 (verified by attribute check; the migration
+landed in pytorch/audio#3975 "Add save_with_torchcodec, modify save()'s warnings" and #4039
+"Let `torchaudio.load()` and `torchaudio.save()` rely on `load_with_torchcodec()` and
+`save_with_torchcodec()`", both closed).
+
+So senselab's `TORCHCODEC_AVAILABLE ? AudioEncoder : torchaudio.save` structure has no second
+branch in practice: if torchcodec is importable the first branch runs, and if it is not, the
+second branch raises `ImportError` from inside torchaudio. The only real fallbacks are
+`soundfile`, `ffmpeg`, or `scipy.io.wavfile`.
+
+---
+
+## Matrix 1 — what each encoder actually writes
+
+Requested target vs. what landed on disk (`ffprobe` codec/`sample_fmt`, and libsndfile's view).
+`torchaudio.save` is omitted where it is identical to torchcodec (it always is).
+
+| target requested | torchcodec / torchaudio | soundfile.write | ffmpeg CLI |
+|---|---|---|---|
+| wav PCM_16 | `pcm_s16le` s16 → WAV/PCM_16 | WAV/PCM_16 | WAV/PCM_16 |
+| wav PCM_24 | **`pcm_s16le` s16 → WAV/PCM_16** | WAV/PCM_24 | WAVEX/PCM_24 |
+| wav PCM_32 | **`pcm_s16le` s16 → WAV/PCM_16** | WAV/PCM_32 | WAVEX/PCM_32 |
+| wav FLOAT32 | **`pcm_s16le` s16 → WAV/PCM_16** | WAV/FLOAT | WAV/FLOAT |
+| wav FLOAT64 | **`pcm_s16le` s16 → WAV/PCM_16** | WAV/DOUBLE | WAV/DOUBLE |
+| flac 16 | **`flac` s32 / 24 bit → FLAC/PCM_24** | FLAC/PCM_16 | FLAC/PCM_16 |
+| flac 24 | `flac` s32 / 24 → FLAC/PCM_24 | FLAC/PCM_24 | FLAC/PCM_24 |
+| ogg / vorbis | **`flac` in Ogg — libsndfile CANNOT READ** | OGG/VORBIS | mono FAILS (native `vorbis` encoder, no libvorbis in this build); stereo OK |
+| opus | FAILS: `invalid sample rate=22050. Supported … 48000, 24000, 16000, 12000, 8000` | FAILS: same constraint, libsndfile message | OK, but resampled (see below) |
+| mp3 | MP3/MPEG_LAYER_III | MP3/MPEG_LAYER_III | MP3/MPEG_LAYER_III |
+| m4a / aac | `aac` in mp4 — libsndfile CANNOT READ | **not supported by libsndfile** | `aac` in mp4 |
+
+The torchcodec extension→codec map, measured exhaustively (there is **no parameter to override
+it** — `to_file` takes only `bit_rate`, `num_channels`, `sample_rate`):
+
+| ext | codec / sample_fmt | libsndfile can read? |
+|---|---|---|
+| `.wav`, `.w64` | `pcm_s16le` / s16 | yes |
+| `.caf`, `.aiff`, `.au` | `pcm_s16be` / s16 | yes |
+| `.flac` | `flac` / s32, 24 bits_per_raw_sample | yes |
+| `.ogg`, `.oga` | **`flac` in Ogg** / s32, 24 | **no** — `unknown error in flac decoder` |
+| `.opus` | `opus` / fltp | yes (OGG/OPUS) |
+| `.mp3` | `mp3` / fltp | yes |
+| `.m4a`, `.mp4`, `.aac` | `aac` / fltp | no |
+| `.webm` | `opus` / fltp | no |
+| `.wv` | **`wavpack` / fltp** | no |
+| `.tta` | `tta` / s32 | no |
+| `.mka` | fails (`validateSampleRate`) | — |
+| `.rf64`, `.ape`, `.als`, `.dts`, `.wma` | `RuntimeError` in `AudioEncoder`/`initializeEncoder` | — |
+
+Two consequences worth naming:
+
+- **`.ogg` from torchcodec is Ogg-FLAC, not Ogg-Vorbis.** It is lossless, which is *better*
+  than asked for, but libsndfile refuses it — so a file senselab writes as `.ogg` cannot be
+  read by `soundfile`, which is exactly the reader senselab's own metadata fallback
+  (`Audio.sampling_rate` → `sf.info`) and `Audio.from_stream` use.
+- **`.wv` (WavPack, fltp) is the only torchcodec extension that preserves float.** Writing the
+  out-of-range signal (peak 4.0) to `.wv` and reading it back with `AudioDecoder` is
+  **bit-exact, peak 4.0 preserved**. Every other lossless torchcodec target clamps to 1.0.
+
+### Input-type constraints, `torchcodec.AudioEncoder`
+
+| input | result |
+|---|---|
+| `torch.float32` (C, N) | OK |
+| `torch.float32` (N,) 1-D | OK (treated as mono) |
+| `torch.float32` non-contiguous | OK |
+| `torch.float64` | `ValueError: Expected float32 samples, got samples.dtype = torch.float64` |
+| `torch.float16`, `torch.int16`, `torch.int32` | same `ValueError` |
+| `numpy.ndarray` float32 | `ValueError: Expected samples to be a Tensor` |
+| (N, 1) time-first | `RuntimeError` in `validateSamples` (reads dim 0 as channels) |
+
+`soundfile.write` accepts float32, float64, int16, int32 numpy arrays **and** torch tensors,
+and writes the requested subtype regardless of input dtype.
+
+### float → int16 conversion rule (all three agree on scale, differ on rounding)
+
+| input float | torchcodec | soundfile PCM_16 | ffmpeg pcm_s16le |
+|---|---|---|---|
+| 1.0 | 32767 | 32767 | 32767 |
+| −1.0 | −32768 | −32768 | −32768 |
+| 0.5 | 16384 | 16384 | 16384 |
+| 1.5/32768 | **2** | **1** | **2** |
+| 2.5/32768 | 2 | 2 | 2 |
+
+Scale is `×32768` with a clamp at `+32767` in all three — no convention mismatch. Rounding
+differs: measured max error writing arbitrary float32 to WAV/PCM_16 is **1.53e-05 (½ LSB) for
+torchcodec and ffmpeg, 3.05e-05 (1 full LSB) for soundfile** — i.e. round-to-nearest vs.
+truncation. This is the only encoder disagreement on lossless integer targets.
+
+---
+
+## Matrix 2 — round-trip exactness, `read(write(x)) == x`
+
+Every cell was read back by all six decode paths. **In every case all six decoders agreed
+exactly with each other for WAV and FLAC**, so the tables below collapse the decoder axis; the
+lossy-format decoder disagreements are called out separately.
+
+### Signal on the exact 16-bit grid (`q16`)
+
+| target | torchcodec / torchaudio | soundfile | ffmpeg |
+|---|---|---|---|
+| wav PCM_16 | **EXACT** | **EXACT** | **EXACT** |
+| wav PCM_24 | **EXACT** (file is really PCM_16) | **EXACT** | **EXACT** |
+| wav PCM_32 | **EXACT** (really PCM_16) | **EXACT** | **EXACT** |
+| wav FLOAT32 | **EXACT** (really PCM_16) | **EXACT** | **EXACT** |
+| wav FLOAT64 | **EXACT** (really PCM_16) | **EXACT** | **EXACT** |
+| flac 16 | **EXACT** (really 24-bit) | **EXACT** | **EXACT** |
+| flac 24 | **EXACT** | **EXACT** | **EXACT** |
+| ogg/vorbis | **EXACT** (it's Ogg-FLAC) — but soundfile cannot open it | 8.8e−01 (lossy) | write failed (mono) |
+| opus | write failed | write failed | 2.2e+00 (lossy + resampled) |
+| mp3 | 1.2e+00 | 1.0e+00 | 1.2e+00 |
+| m4a/aac | 1.4e+00 | unsupported | 1.4e+00 |
+
+### Arbitrary in-range float32 (`f32`), max abs difference
+
+| target | torchcodec / torchaudio | soundfile | ffmpeg |
+|---|---|---|---|
+| wav PCM_16 | 1.5e−05 | 3.0e−05 | 1.5e−05 |
+| wav PCM_24 | **1.5e−05** (silently 16-bit) | 1.2e−07 | 1.2e−07 |
+| wav PCM_32 | **1.5e−05** (silently 16-bit) | 2.3e−10 | 2.3e−10 |
+| wav FLOAT32 | **1.5e−05** (silently 16-bit) | **EXACT** | **EXACT** |
+| wav FLOAT64 | **1.5e−05** (silently 16-bit) | **EXACT** | **EXACT** |
+| flac 16 | 1.2e−07 (silently 24-bit) | 1.5e−05 | 1.5e−05 |
+| flac 24 | 1.2e−07 | 6.0e−08 | 1.2e−07 |
+| ogg/vorbis | 1.2e−07 (Ogg-FLAC) | 7.6e−01 | — |
+| mp3 / opus / m4a | 1.5e+00 / — / 1.7e+00 | 1.1e+00 / — / — | 1.5e+00 / 2.1e+00 / 1.7e+00 |
+
+**The exactness answer, stated plainly.** For arbitrary float32 data there are exactly two
+`(encode, decode)` families that are bit-exact, and neither of them is torchcodec:
+
+- `soundfile.write(..., subtype="FLOAT")` or `subtype="DOUBLE"` → read by **any** of
+  torchcodec, torchaudio, soundfile, librosa, ffmpeg. EXACT.
+- `ffmpeg -c:a pcm_f32le` / `pcm_f64le` → read by any of the six. EXACT.
+
+Every torchcodec encode path is inexact for arbitrary float32, because the best lossless
+container it will select is PCM_16 (WAV) or 24-bit (FLAC) — with the sole exception of `.wv`,
+which is bit-exact but readable only by torchcodec/ffmpeg.
+
+### Out-of-range data (peak 3.0, flat 1.5 block)
+
+Warnings emitted at write time, across all 176 encode cells: **zero**, from every encoder. The
+only warnings anywhere were `torchaudio.save`'s `UserWarning`s about ignored arguments.
+
+| target | torchcodec / torchaudio | soundfile | ffmpeg |
+|---|---|---|---|
+| wav PCM_16/24/32 | peak → 1.0000, silently | peak → 1.0000, silently | peak → 1.0000, silently |
+| **wav FLOAT32** | **peak → 1.0000** (it wrote PCM_16) | **peak 2.9985 preserved** | **peak 2.9985 preserved** |
+| **wav FLOAT64** | **peak → 1.0000** (it wrote PCM_16) | **peak 2.9985 preserved** | **peak 2.9985 preserved** |
+| flac 16/24 | peak → 1.0000 | peak → 1.0000 | peak → 1.0000 |
+| ogg/vorbis | peak → 1.0000 (Ogg-FLAC) | peak 3.5540 (overshoot) | — |
+| mp3 | peak 4.8797 | peak 5.2681 | peak 4.8797 |
+| opus | — | — | peak 4.5479 |
+| m4a/aac | peak 5.0081 | — | peak 5.0081 |
+
+Clamping is inherent to integer PCM and is not torchcodec-specific. What *is* torchcodec-
+specific is that **there is no way to opt out**: no argument selects a float sample format for
+`.wav` or `.flac`. Note also that lossy codecs do not clamp — they *overshoot*, so a signal
+that leaves at peak 3.0 comes back at 4.9.
+
+The flat-1.5 collapse reported in the brief reproduces exactly: through `Audio.save_to_file` to
+`.wav`, a 500-sample block at 1.5 becomes 500 identical samples at 1.0, one distinct value, and
+`save_to_file` returns normally.
+
+### Sample rate, channels, length, metadata
+
+- **Sample rate preserved** by every path for wav, flac, mp3, ogg-vorbis. **Not preserved for
+  opus**: writing 22050 Hz forces a resample, ffprobe then reports 48000 while libsndfile
+  reports 24000 for the same file — two readers disagreeing about the rate of one file.
+- **Channel count preserved** by every path, every format tested (mono and stereo).
+- **Length**: exact for wav, flac, and mp3 (LAME's Xing header lets every decoder trim). Not
+  exact for `m4a`/`aac`: 2000 in → 2048 out via torchcodec/ffmpeg, and `librosa`/`audioread`
+  returns yet another length. AAC padding is not trimmed by torchcodec.
+- **Metadata**: `soundfile` writes and reads tags (`SoundFile.title`, `.comment`); `ffmpeg`
+  writes and reads tags. **torchcodec has no metadata parameter at all** — it writes only
+  `encoder=Lavf62.12.100` — and `AudioDecoder.metadata` exposes no tag fields
+  (`begin_stream_seconds, bit_rate, codec, duration_seconds, num_channels, sample_format,
+  sample_rate, stream_index` only). So no torchcodec path can carry provenance in the file.
+
+### Audio from a video container
+
+| path | mp4 (h264+aac) | mkv (vp9+opus) | mov (h264+pcm_s16le) |
+|---|---|---|---|
+| `torchcodec.AudioDecoder` | OK (48128 samples) | OK (48000) | OK (48000) |
+| `torchaudio.load` (= torchcodec) | OK (48128) | OK (48000) | OK (48000) |
+| **`soundfile.read`** | **`Format not recognised`** | **`Format not recognised`** | **`Format not recognised`** |
+| `librosa.load` | OK (48000) via `audioread` + `UserWarning: PySoundFile failed` + `FutureWarning: audioread_load deprecated as of librosa 0.10.0, will be removed` | OK (48000) | OK (48000) |
+| `ffmpeg` CLI | OK (48128) | OK (48000) | OK (48000) |
+
+libsndfile reads **no** video container. librosa reads them only through the deprecated
+`audioread` fallback. So for video, torchcodec or ffmpeg are the only durable options — and
+torchcodec/ffmpeg return 128 more samples than librosa for AAC-in-MP4, i.e. the paths disagree
+on where the audio starts and ends.
+
+---
+
+## Priority question 1 — is decode source-independent, and does anything normalise?
+
+### Amplitude convention: unanimous
+
+A WAV/PCM_16 file containing the literal int16 values `[-32768, -32767, -16384, 0, 16384,
+32766, 32767]`, read by all six paths:
+
+| reader | −32768 | 32767 |
+|---|---|---|
+| `/32768` reference | −1.00000000 | 0.99996948 |
+| torchcodec.AudioDecoder | −1.00000000 | 0.99996948 |
+| torchaudio.load | −1.00000000 | 0.99996948 |
+| soundfile.read(float32) | −1.00000000 | 0.99996948 |
+| soundfile.read(float64) | −1.00000000 | 0.99996948 |
+| librosa.load | −1.00000000 | 0.99996948 |
+| ffmpeg CLI | −1.00000000 | 0.99996948 |
+
+All six use the `/32768` convention, identically, to the last bit. dtype returned: `float32`
+from torchcodec, torchaudio, soundfile(f32), librosa; `float64` only if you ask soundfile for it.
+
+### Does the read path clamp out-of-range float? **No.**
+
+A WAV/FLOAT and a WAV/DOUBLE file with samples spanning ±4.0:
+
+| reader | peak read back | bit-exact vs. source |
+|---|---|---|
+| torchcodec.AudioDecoder | 4.00000 | **YES** |
+| torchaudio.load | 4.00000 | **YES** |
+| soundfile.read(f32) | 4.00000 | **YES** |
+| soundfile.read(f64) | 4.00000 | **YES** |
+| librosa.load | 4.00000 | **YES** |
+| ffmpeg CLI | 4.00000 | **YES** |
+
+Identical result whether the file was written by soundfile or by ffmpeg. **The asymmetry is
+precise: torchcodec's read path is fully range-transparent; its write path is not.** So
+out-of-range audio can be read into senselab but cannot be written back out of it, except via
+`.wv` or a non-torchcodec encoder.
+
+Lossy sources also come back un-clamped: the same reference signal (peak 0.7999) decoded from
+mp3 returns peak 1.0603, from opus 1.6327, from AAC 1.5213. Decoders do not clip codec
+overshoot, which is correct but means "peak ≤ 1" is not an invariant a caller may assume.
+
+### Does anything normalise? **No — measured, not assumed.**
+
+Two files identical except for a `×0.1` gain, decoded by all six paths:
+
+| source format | peak ratio (expected 0.1) | RMS ratio (expected 0.1) |
+|---|---|---|
+| WAV/FLOAT | 0.100000 | 0.100000 |
+| WAV/PCM_16 | 0.100010 | 0.100000 |
+| FLAC/PCM_24 | 0.100000 | 0.100000 |
+
+Identical for every reader. The 0.100010 on PCM_16 is 16-bit quantisation of the peak sample,
+not normalisation — the RMS ratio is exactly 0.1. **No decode path in this set performs peak,
+RMS, or filter-graph normalisation, per file or per segment.** The per-segment hazard the brief
+warns about (DriftSE's per-chunk peak normalisation) does **not** exist at the decode layer;
+it is introduced by senselab's own worker code, above the I/O boundary.
+
+### Source-independence, one signal in 11 containers, decoded by torchcodec
+
+| source | dtype | n | sr | peak | RMS | bit-exact vs. reference |
+|---|---|---|---|---|---|---|
+| reference float32 | float32 | 44100 | 22050 | 0.799973 | 0.461799 | — |
+| wav PCM_16 | float32 | 44100 | 22050 | 0.799988 | 0.461799 | no (quantised) |
+| wav PCM_24 | float32 | 44100 | 22050 | 0.799973 | 0.461799 | no (quantised) |
+| wav PCM_32 | float32 | 44100 | 22050 | 0.799973 | 0.461799 | no (quantised) |
+| **wav FLOAT32** | float32 | 44100 | 22050 | 0.799973 | 0.461799 | **YES** |
+| **wav FLOAT64** | float32 | 44100 | 22050 | 0.799973 | 0.461799 | **YES** |
+| flac 16 | float32 | 44100 | 22050 | 0.799988 | 0.461799 | no |
+| flac 24 | float32 | 44100 | 22050 | 0.799973 | 0.461799 | no |
+| mp3 192k | float32 | 44100 | 22050 | 1.060308 | 0.418184 | no |
+| opus | float32 | 44100 | 48000 | 1.632722 | 0.423055 | no |
+| m4a aac | float32 | **45056** | 22050 | 1.521272 | 0.450459 | no |
+| mp4 (video+aac) | float32 | **45056** | 22050 | 1.521272 | 0.450459 | no |
+
+Decode is source-independent in **dtype** (always float32) and in **amplitude convention**
+(always `/32768`, never normalised, never clamped). It is *not* source-independent in **length**
+(AAC adds 956 samples) or **sample rate** (preserved from the file, so an Opus file reports 48000
+however it was made). Audio from a video container is indistinguishable from the same audio in a
+bare container — same length, same values.
+
+---
+
+## Priority question 2 — does a streamed chunk equal the slice of a full decode?
+
+Method note: the first run compared every chunker against a *torchcodec* full decode, which
+conflates decoder identity with chunking. The table below compares **each library against its
+own full decode**, with the alignment searched over ±4000 samples so that a shifted chunk is
+reported as a shift rather than as noise. Source: 6 s of 16-bit-grid float32.
+
+`off` = how far the returned chunk actually sits from where it was requested, in samples.
+
+| format | torchcodec range | torchaudio (=tc) | soundfile `start=` | ffmpeg `-ss` **before** `-i` | ffmpeg `-ss` **after** `-i` |
+|---|---|---|---|---|---|
+| wav PCM_16 | **EXACT**, off=0 | **EXACT** | **EXACT** | **EXACT** | **EXACT** |
+| wav FLOAT32 | **EXACT**, off=0 | **EXACT** | **EXACT** | **EXACT** | **EXACT** |
+| flac PCM_24 | **EXACT**, off=0 | **EXACT** | **EXACT** | **EXACT** | **EXACT** |
+| mp3 192k | exact values, **off = −1105** (and a short read at t=0: 943 of 2048) | **EXACT**, off=0 | off=0, diff 1.2e−07 | off=0, **diff 1.2e+00 — wrong data** | **EXACT** |
+| m4a aac | **EXACT**, off=0 | **EXACT** | libsndfile cannot open | off=0, **diff up to 1.1e+00** | **EXACT** |
+| opus 48k | **EXACT**, off=0 | **EXACT** | **EXACT** | **EXACT** | **EXACT** |
+
+**Lossless formats: the invariant holds, bit-for-bit, for every path, at aligned, odd and
+mid-file offsets.** Contiguity too: concatenating 2048-sample chunks reconstructs the full
+decode bit-for-bit, 0 mismatched samples, for WAV/PCM_16, WAV/FLOAT32 and FLAC/PCM_24 via
+torchcodec, soundfile and torchaudio alike. senselab's `Audio.from_stream` (soundfile blocks)
+also reconstructs the full decode bit-for-bit at 0.25 s chunks on all three.
+
+**MP3 breaks it, and the mechanism is exact.** torchcodec's two entry points use two different
+timelines for the same file:
+
+| requested start | `n` returned (2048 asked) | `pts_seconds` reported | offset from requested, vs. `get_all_samples()` |
+|---|---|---|---|
+| 0 | **943** | 0.050113379 (= sample 1105) | 0 |
+| 1 | 944 | 0.050113379 (sample 1105) | −1 |
+| 100 | 1043 | 0.050113379 (sample 1105) | −100 |
+| 576 | 1519 | 0.050113379 (sample 1105) | −576 |
+| 1105 | 2048 | 0.050113379 (sample 1105) | −1105 |
+| 2048 | 2048 | 0.092879819 (sample 2048) | −1105 |
+| 5001 | 2048 | 0.226802721 (sample 5001) | −1105 |
+| 22050 | 2048 | 1.000000000 (sample 22050) | −1105 |
+
+`get_all_samples()` prepends **1105 samples** of MP3 decoder pre-roll (576 + 529, the standard
+MDCT + LAME delay) that `get_samples_played_in_range()` excludes. So for an MP3, index `i` of a
+full decode is presentation sample `i − 1105`, and **a windowed measurement taken via offsets
+is shifted 1105 samples — 50.1 ms at 22.05 kHz — relative to a whole-file measurement of the
+same file.** Below `start=1105` the range API additionally silently short-reads, returning
+`n − (1105 − start)` samples with no warning.
+
+The chunk values themselves are exact once aligned (diff 0.00e+00 at off = −1105), so this is a
+pure indexing defect, not a decoding one. `pts_seconds` on the returned `AudioSamples` reports
+the true position and would let a caller detect and correct it — `align_vs_pts` is exact in
+every row. **senselab ignores `pts_seconds`**: `Audio._lazy_load_data_from_filepath` returns
+`samples.data` and discards the rest, so `Audio(filepath=..., offset_in_sec=...)` inherits the
+shift verbatim — measured off = −1105 for mp3, 0 for wav/flac/m4a/opus.
+
+`torchaudio.load(frame_offset=, num_frames=)`, despite being a torchcodec wrapper, is **exact
+for mp3** — it decodes and slices rather than seeking, so it does not hit the bug.
+
+**ffmpeg `-ss` placement matters and is a real trap**: `-ss` *before* `-i` (fast/keyframe seek)
+returns wrong data for mp3 and aac — max diff 1.2 and 1.1 respectively, i.e. a different part of
+the signal. `-ss` *after* `-i` (decode-and-discard) is bit-exact for every format tested.
+
+**Cross-library agreement on a full decode** (decoder identity, separate from chunking):
+
+| format | torchcodec vs. torchaudio | vs. soundfile | vs. ffmpeg |
+|---|---|---|---|
+| wav PCM_16 / FLOAT32 | EXACT | EXACT | EXACT |
+| flac PCM_24 | EXACT | EXACT | EXACT |
+| mp3 192k | EXACT | diff 2.46e−06 | EXACT |
+| m4a aac | EXACT | cannot open | EXACT |
+| opus 48k | EXACT | diff 1.13e−06 | EXACT |
+
+For lossless formats all four decoders are bit-identical. For lossy formats libsndfile's
+decoders (mpg123, libopusfile) differ from ffmpeg's by ~1–2e−06 — small, but it means "which
+library decoded this mp3" is a recorded-provenance question, not a free choice.
+
+---
+
+## What senselab does today, measured end-to-end
+
+`Audio.save_to_file(path, encoding="PCM_F", bits_per_sample=32)` then `Audio(filepath=path)`:
+
+| input | ext | file actually written | round-trip | in peak | out peak | warnings |
+|---|---|---|---|---|---|---|
+| in-range float32 | wav | WAV/PCM_16 | max diff 1.53e−05 | 0.8998 | 0.8998 | **0** |
+| in-range float32 | flac | FLAC/PCM_24 | max diff 1.19e−07 | 0.8998 | 0.8998 | **0** |
+| in-range float32 | ogg | **libsndfile cannot read** | max diff 1.19e−07 | 0.8998 | 0.8998 | **0** |
+| 16-bit grid | wav | WAV/PCM_16 | **exact** | 0.9999 | 0.9999 | 0 |
+| **out-of-range (peak 3.0)** | wav | WAV/PCM_16 | **max diff 2.00** | **3.0000** | **1.0000** | **0** |
+| **out-of-range (peak 3.0)** | flac | FLAC/PCM_24 | **max diff 2.00** | **3.0000** | **1.0000** | **0** |
+
+`encoding` and `bits_per_sample` are accepted by `Audio.save_to_file`
+(`src/senselab/audio/data_structures/audio.py:310`) and are **never passed to torchcodec** —
+the torchcodec branch constructs `AudioEncoder(samples=..., sample_rate=...)` and calls
+`encoder.to_file(file_path)`. They reach `torchaudio.save` only in the dead fallback branch,
+which would itself ignore them (with a `UserWarning`). So today they are pure decoration, and
+not even the upstream warning surfaces: **zero warnings**.
+
+Two further senselab-side notes from the same read:
+
+- `Audio.convert_to_tensor` ends with `.to(torch.float32)` — so float64 input is silently
+  narrowed on the way in, independently of any file format. Bit-exact float64 cannot survive
+  the `Audio` object regardless of the encoder chosen.
+- The workers already converged on the right answer without saying so: `driftse.py:49`,
+  `unasdiff.py:237` and `yamnet.py:19` all define a module constant `= "FLOAT"` and pass it as
+  `sf.write(..., subtype=...)`, which the matrix above shows is the only bit-exact,
+  range-transparent path. But `sparc.py:126,165`, `qwen_tts.py:212` and
+  `video/tasks/input_output.py:70` call `sf.write` with **no subtype**, and libsndfile's default
+  for WAV is `PCM_16` — so three worker boundaries quantise to 16 bits and clamp, while three
+  others do not. That inconsistency is inside senselab, not upstream.

--- a/specs/20260819-120600-io-invariants/raw/invariants_run1.txt
+++ b/specs/20260819-120600-io-invariants/raw/invariants_run1.txt
@@ -1,0 +1,273 @@
+
+======================================================================================================================
+## A1. Amplitude convention: full-scale integer sources. Is int16 -32768 -> -1.0 and 32767 -> 32767/32768?
+======================================================================================================================
+reader                         -32768       -32767       -16384            0        16384        32766        32767
+/32768 reference          -1.00000000  -0.99996948  -0.50000000   0.00000000   0.50000000   0.99993896   0.99996948
+torchcodec.AudioDecoder   -1.00000000  -0.99996948  -0.50000000   0.00000000   0.50000000   0.99993896   0.99996948
+torchaudio.load           -1.00000000  -0.99996948  -0.50000000   0.00000000   0.50000000   0.99993896   0.99996948
+soundfile.read(f32)       -1.00000000  -0.99996948  -0.50000000   0.00000000   0.50000000   0.99993896   0.99996948
+soundfile.read(f64)       -1.00000000  -0.99996948  -0.50000000   0.00000000   0.50000000   0.99993896   0.99996948
+librosa.load              -1.00000000  -0.99996948  -0.50000000   0.00000000   0.50000000   0.99993896   0.99996948
+ffmpeg-cli(f64)           -1.00000000  -0.99996948  -0.50000000   0.00000000   0.50000000   0.99993896   0.99996948
+dtype returned           torchcodec.AudioDecoder=float32, torchaudio.load=float32, soundfile.read(f32)=float32, soundfile.read(f64)=float64, librosa.load=float32
+
+======================================================================================================================
+## A2. THE KEY TEST: float32 WAV with samples beyond +/-1 -- does decode clamp?
+======================================================================================================================
+
+  source: WAV/FLOAT written by soundfile, true peak = 4.0000
+    torchcodec.AudioDecoder  peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    torchaudio.load          peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    soundfile.read(f32)      peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    soundfile.read(f64)      peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    librosa.load             peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    ffmpeg-cli(f64)          peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    (same source written by ffmpeg) torchcodec peak=4.00000
+
+  source: WAV/DOUBLE written by soundfile, true peak = 4.0000
+    torchcodec.AudioDecoder  peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    torchaudio.load          peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    soundfile.read(f32)      peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    soundfile.read(f64)      peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    librosa.load             peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    ffmpeg-cli(f64)          peak=4.00000    min=-4.00000   max=4.00000    clamped=no   exact_vs_source=YES
+    (same source written by ffmpeg) torchcodec peak=4.00000
+
+======================================================================================================================
+## A3. Does any decode path normalise? Two files differing only by a known gain of 0.1
+======================================================================================================================
+
+  WAV/FLOAT: expected peak ratio quiet/loud = 0.1 exactly (no normalisation)
+    torchcodec.AudioDecoder  peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+    torchaudio.load          peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+    soundfile.read(f32)      peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+    soundfile.read(f64)      peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+    librosa.load             peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+    ffmpeg-cli(f64)          peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+
+  WAV/PCM_16: expected peak ratio quiet/loud = 0.1 exactly (no normalisation)
+    torchcodec.AudioDecoder  peak 0.899872/0.089996 ratio=0.100010   rms ratio=0.100000
+    torchaudio.load          peak 0.899872/0.089996 ratio=0.100010   rms ratio=0.100000
+    soundfile.read(f32)      peak 0.899872/0.089996 ratio=0.100010   rms ratio=0.100000
+    soundfile.read(f64)      peak 0.899872/0.089996 ratio=0.100010   rms ratio=0.100000
+    librosa.load             peak 0.899872/0.089996 ratio=0.100010   rms ratio=0.100000
+    ffmpeg-cli(f64)          peak 0.899872/0.089996 ratio=0.100010   rms ratio=0.100000
+
+  FLAC/PCM_24: expected peak ratio quiet/loud = 0.1 exactly (no normalisation)
+    torchcodec.AudioDecoder  peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+    torchaudio.load          peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+    soundfile.read(f32)      peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+    soundfile.read(f64)      peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+    librosa.load             peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+    ffmpeg-cli(f64)          peak 0.899845/0.089985 ratio=0.100000   rms ratio=0.100000
+
+======================================================================================================================
+## A4. Source-independence: identical audio in 8 containers, decoded by torchcodec. dtype / peak / RMS / length
+======================================================================================================================
+  reference: dtype=float32 n=44100 peak=0.799973 rms=0.461799
+
+  source             dtype     n        sr      peak       rms        peak/ref  exact 
+  wav PCM_16         float32   44100    22050   0.799988   0.461799   1.00002   False 
+  wav PCM_24         float32   44100    22050   0.799973   0.461799   1.00000   False 
+  wav PCM_32         float32   44100    22050   0.799973   0.461799   1.00000   False 
+  wav FLOAT32        float32   44100    22050   0.799973   0.461799   1.00000   True  
+  wav FLOAT64        float32   44100    22050   0.799973   0.461799   1.00000   True  
+  flac 16            float32   44100    22050   0.799988   0.461799   1.00002   False 
+  flac 24            float32   44100    22050   0.799973   0.461799   1.00000   False 
+  mp3 192k           float32   44100    22050   1.060308   0.418184   1.32543   False 
+  opus (48k src)     float32   44100    48000   1.632722   0.423055   2.04097   False 
+  m4a aac            float32   45056    22050   1.521272   0.450459   1.90165   False 
+  mp4 (video+aac)    float32   45056    22050   1.521272   0.450459   1.90165   False 
+
+======================================================================================================================
+## B. CHUNK == SLICE.  full = decode whole file; chunk = decode [t0, t1). Compare bit-for-bit.
+======================================================================================================================
+
+  --- wav PCM_16   (file sr=22050, full decode n=132300, input n=132300)
+      chunker                request      got_n   nominal_off_delta  max|diff|    bitexact
+      torchcodec range       aligned 0    2048    0                  0.000e+00    True
+      torchaudio.load(off)   aligned 0    2048    0                  0.000e+00    True
+      soundfile.read(start)  aligned 0    2048    0                  0.000e+00    True
+      librosa(offset)        aligned 0    2048    0                  0.000e+00    True
+      ffmpeg -ss/-t          aligned 0    2048    0                  0.000e+00    True
+      senselab Audio(off)    aligned 0    2048    0                  0.000e+00    True
+      torchcodec range       odd offset   2048    0                  0.000e+00    True
+      torchaudio.load(off)   odd offset   2048    0                  0.000e+00    True
+      soundfile.read(start)  odd offset   2048    0                  0.000e+00    True
+      librosa(offset)        odd offset   2048    0                  0.000e+00    True
+      ffmpeg -ss/-t          odd offset   2048    0                  0.000e+00    True
+      senselab Audio(off)    odd offset   2048    0                  0.000e+00    True
+      torchcodec range       mid-file     4096    0                  0.000e+00    True
+      torchaudio.load(off)   mid-file     4096    0                  0.000e+00    True
+      soundfile.read(start)  mid-file     4096    0                  0.000e+00    True
+      librosa(offset)        mid-file     4096    0                  0.000e+00    True
+      ffmpeg -ss/-t          mid-file     4096    0                  0.000e+00    True
+      senselab Audio(off)    mid-file     4096    0                  0.000e+00    True
+      torchcodec range       late         8192    0                  0.000e+00    True
+      torchaudio.load(off)   late         8192    0                  0.000e+00    True
+      soundfile.read(start)  late         8192    0                  0.000e+00    True
+      librosa(offset)        late         8192    0                  0.000e+00    True
+      ffmpeg -ss/-t          late         8192    0                  0.000e+00    True
+      senselab Audio(off)    late         8192    0                  0.000e+00    True
+
+  --- wav FLOAT32   (file sr=22050, full decode n=132300, input n=132300)
+      chunker                request      got_n   nominal_off_delta  max|diff|    bitexact
+      torchcodec range       aligned 0    2048    0                  0.000e+00    True
+      torchaudio.load(off)   aligned 0    2048    0                  0.000e+00    True
+      soundfile.read(start)  aligned 0    2048    0                  0.000e+00    True
+      librosa(offset)        aligned 0    2048    0                  0.000e+00    True
+      ffmpeg -ss/-t          aligned 0    2048    0                  0.000e+00    True
+      senselab Audio(off)    aligned 0    2048    0                  0.000e+00    True
+      torchcodec range       odd offset   2048    0                  0.000e+00    True
+      torchaudio.load(off)   odd offset   2048    0                  0.000e+00    True
+      soundfile.read(start)  odd offset   2048    0                  0.000e+00    True
+      librosa(offset)        odd offset   2048    0                  0.000e+00    True
+      ffmpeg -ss/-t          odd offset   2048    0                  0.000e+00    True
+      senselab Audio(off)    odd offset   2048    0                  0.000e+00    True
+      torchcodec range       mid-file     4096    0                  0.000e+00    True
+      torchaudio.load(off)   mid-file     4096    0                  0.000e+00    True
+      soundfile.read(start)  mid-file     4096    0                  0.000e+00    True
+      librosa(offset)        mid-file     4096    0                  0.000e+00    True
+      ffmpeg -ss/-t          mid-file     4096    0                  0.000e+00    True
+      senselab Audio(off)    mid-file     4096    0                  0.000e+00    True
+      torchcodec range       late         8192    0                  0.000e+00    True
+      torchaudio.load(off)   late         8192    0                  0.000e+00    True
+      soundfile.read(start)  late         8192    0                  0.000e+00    True
+      librosa(offset)        late         8192    0                  0.000e+00    True
+      ffmpeg -ss/-t          late         8192    0                  0.000e+00    True
+      senselab Audio(off)    late         8192    0                  0.000e+00    True
+
+  --- flac PCM_24   (file sr=22050, full decode n=132300, input n=132300)
+      chunker                request      got_n   nominal_off_delta  max|diff|    bitexact
+      torchcodec range       aligned 0    2048    0                  0.000e+00    True
+      torchaudio.load(off)   aligned 0    2048    0                  0.000e+00    True
+      soundfile.read(start)  aligned 0    2048    0                  0.000e+00    True
+      librosa(offset)        aligned 0    2048    0                  0.000e+00    True
+      ffmpeg -ss/-t          aligned 0    2048    0                  0.000e+00    True
+      senselab Audio(off)    aligned 0    2048    0                  0.000e+00    True
+      torchcodec range       odd offset   2048    0                  0.000e+00    True
+      torchaudio.load(off)   odd offset   2048    0                  0.000e+00    True
+      soundfile.read(start)  odd offset   2048    0                  0.000e+00    True
+      librosa(offset)        odd offset   2048    0                  0.000e+00    True
+      ffmpeg -ss/-t          odd offset   2048    0                  0.000e+00    True
+      senselab Audio(off)    odd offset   2048    0                  0.000e+00    True
+      torchcodec range       mid-file     4096    0                  0.000e+00    True
+      torchaudio.load(off)   mid-file     4096    0                  0.000e+00    True
+      soundfile.read(start)  mid-file     4096    0                  0.000e+00    True
+      librosa(offset)        mid-file     4096    0                  0.000e+00    True
+      ffmpeg -ss/-t          mid-file     4096    0                  0.000e+00    True
+      senselab Audio(off)    mid-file     4096    0                  0.000e+00    True
+      torchcodec range       late         8192    0                  0.000e+00    True
+      torchaudio.load(off)   late         8192    0                  0.000e+00    True
+      soundfile.read(start)  late         8192    0                  0.000e+00    True
+      librosa(offset)        late         8192    0                  0.000e+00    True
+      ffmpeg -ss/-t          late         8192    0                  0.000e+00    True
+      senselab Audio(off)    late         8192    0                  0.000e+00    True
+
+  --- mp3 192k   (file sr=22050, full decode n=132300, input n=132300)
+      chunker                request      got_n   nominal_off_delta  max|diff|    bitexact
+      torchcodec range       aligned 0    943     0                  0.000e+00    True
+      torchaudio.load(off)   aligned 0    2048    0                  0.000e+00    True
+      soundfile.read(start)  aligned 0    2048    0                  1.669e-06    False
+      librosa(offset)        aligned 0    2048    0                  1.669e-06    False
+      ffmpeg -ss/-t          aligned 0    2048    0                  1.206e+00    False
+      senselab Audio(off)    aligned 0    943     0                  0.000e+00    True
+      torchcodec range       odd offset   2048    -193               1.835e+00    False
+      torchaudio.load(off)   odd offset   2048    0                  0.000e+00    True
+      soundfile.read(start)  odd offset   2048    0                  1.729e-06    False
+      librosa(offset)        odd offset   2048    0                  1.729e-06    False
+      ffmpeg -ss/-t          odd offset   2048    0                  1.217e+00    False
+      senselab Audio(off)    odd offset   2048    -193               1.835e+00    False
+      torchcodec range       mid-file     4096    63                 1.931e+00    False
+      torchaudio.load(off)   mid-file     4096    0                  0.000e+00    True
+      soundfile.read(start)  mid-file     4096    0                  1.550e-06    False
+      librosa(offset)        mid-file     4096    0                  1.550e-06    False
+      ffmpeg -ss/-t          mid-file     4096    0                  1.233e+00    False
+      senselab Audio(off)    mid-file     4096    63                 1.931e+00    False
+      torchcodec range       late         8192    140                2.001e+00    False
+      torchaudio.load(off)   late         8192    0                  0.000e+00    True
+      soundfile.read(start)  late         8192    0                  1.788e-06    False
+      librosa(offset)        late         8192    0                  1.788e-06    False
+      ffmpeg -ss/-t          late         8192    0                  1.164e+00    False
+      senselab Audio(off)    late         8192    140                2.001e+00    False
+
+  --- m4a aac   (file sr=22050, full decode n=133120, input n=132300)
+      chunker                request      got_n   nominal_off_delta  max|diff|    bitexact
+      torchcodec range       aligned 0    2048    0                  0.000e+00    True
+      torchaudio.load(off)   aligned 0    2048    0                  0.000e+00    True
+      soundfile.read(start)  aligned 0    LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-aud
+      librosa(offset)        aligned 0    2048    0                  1.118e+00    False
+      ffmpeg -ss/-t          aligned 0    2048    0                  1.113e+00    False
+      senselab Audio(off)    aligned 0    2048    0                  0.000e+00    True
+      torchcodec range       odd offset   2048    0                  0.000e+00    True
+      torchaudio.load(off)   odd offset   2048    0                  0.000e+00    True
+      soundfile.read(start)  odd offset   LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-aud
+      librosa(offset)        odd offset   2048    0                  3.482e-02    False
+      ffmpeg -ss/-t          odd offset   2048    0                  4.060e-02    False
+      senselab Audio(off)    odd offset   2048    0                  0.000e+00    True
+      torchcodec range       mid-file     4096    0                  0.000e+00    True
+      torchaudio.load(off)   mid-file     4096    0                  0.000e+00    True
+      soundfile.read(start)  mid-file     LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-aud
+      librosa(offset)        mid-file     4096    0                  1.467e-02    False
+      ffmpeg -ss/-t          mid-file     4096    0                  9.308e-02    False
+      senselab Audio(off)    mid-file     4096    0                  0.000e+00    True
+      torchcodec range       late         8192    0                  0.000e+00    True
+      torchaudio.load(off)   late         8192    0                  0.000e+00    True
+      soundfile.read(start)  late         LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-aud
+      librosa(offset)        late         8192    0                  2.479e-02    False
+      ffmpeg -ss/-t          late         8192    0                  1.131e+00    False
+      senselab Audio(off)    late         8192    0                  0.000e+00    True
+
+  --- opus 48k   (file sr=48000, full decode n=132300, input n=132300)
+      chunker                request      got_n   nominal_off_delta  max|diff|    bitexact
+      torchcodec range       aligned 0    4458    0                  0.000e+00    True
+      torchaudio.load(off)   aligned 0    4458    0                  0.000e+00    True
+      soundfile.read(start)  aligned 0    4458    0                  7.898e-07    False
+      librosa(offset)        aligned 0    4458    0                  7.898e-07    False
+      ffmpeg -ss/-t          aligned 0    4458    0                  0.000e+00    True
+      senselab Audio(off)    aligned 0    4458    0                  0.000e+00    True
+      torchcodec range       odd offset   4458    0                  0.000e+00    True
+      torchaudio.load(off)   odd offset   4458    0                  0.000e+00    True
+      soundfile.read(start)  odd offset   4458    0                  8.643e-07    False
+      librosa(offset)        odd offset   4458    0                  8.643e-07    False
+      ffmpeg -ss/-t          odd offset   4458    0                  0.000e+00    True
+      senselab Audio(off)    odd offset   4458    0                  0.000e+00    True
+      torchcodec range       mid-file     8916    0                  0.000e+00    True
+      torchaudio.load(off)   mid-file     8916    0                  0.000e+00    True
+      soundfile.read(start)  mid-file     8916    0                  8.345e-07    False
+      librosa(offset)        mid-file     8916    0                  8.345e-07    False
+      ffmpeg -ss/-t          mid-file     8916    0                  0.000e+00    True
+      senselab Audio(off)    mid-file     8916    0                  0.000e+00    True
+      torchcodec range       late         RuntimeError: getFramesPlayedInRangeAudio, /Users/runner/work/torchcodec/t
+      torchaudio.load(off)   late         0       None               inf          False
+      soundfile.read(start)  late         0       None               inf          False
+      librosa(offset)        late         0       None               inf          False
+      ffmpeg -ss/-t          late         0       None               inf          False
+      senselab Audio(off)    late         RuntimeError: getFramesPlayedInRangeAudio, /Users/runner/work/torchcodec/t
+
+======================================================================================================================
+## B2. Contiguity: do consecutive chunks concatenate back to the full decode exactly?
+======================================================================================================================
+  wav PCM_16     torchcodec range       concat_n=132300   full_n=132300   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+  wav PCM_16     soundfile.read(start)  concat_n=132300   full_n=132300   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+  wav PCM_16     torchaudio.load(off)   concat_n=132300   full_n=132300   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+  wav FLOAT32    torchcodec range       concat_n=132300   full_n=132300   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+  wav FLOAT32    soundfile.read(start)  concat_n=132300   full_n=132300   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+  wav FLOAT32    torchaudio.load(off)   concat_n=132300   full_n=132300   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+  flac PCM_24    torchcodec range       concat_n=132300   full_n=132300   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+  flac PCM_24    soundfile.read(start)  concat_n=132300   full_n=132300   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+  flac PCM_24    torchaudio.load(off)   concat_n=132300   full_n=132300   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+  mp3 192k       torchcodec range       concat_n=131195   full_n=132300   bitexact=False  max|diff|=0.000e+00 mismatched_samples=0
+  mp3 192k       soundfile.read(start)  concat_n=132300   full_n=132300   bitexact=False  max|diff|=2.446e-06 mismatched_samples=122651
+  mp3 192k       torchaudio.load(off)   concat_n=132300   full_n=132300   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+  m4a aac        torchcodec range       concat_n=133120   full_n=133120   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+  m4a aac        soundfile.read(start)  LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work3/c
+  m4a aac        torchaudio.load(off)   concat_n=133120   full_n=133120   bitexact=True   max|diff|=0.000e+00 mismatched_samples=0
+
+======================================================================================================================
+## B3. senselab Audio.from_stream (soundfile blocks) vs full decode
+======================================================================================================================
+  wav PCM_16     stream_n=132300   full_n=132300   bitexact=True max|diff|=0.000e+00
+  wav FLOAT32    stream_n=132300   full_n=132300   bitexact=True max|diff|=0.000e+00
+  flac PCM_24    stream_n=132300   full_n=132300   bitexact=True max|diff|=0.000e+00

--- a/specs/20260819-120600-io-invariants/raw/invariants_run2.txt
+++ b/specs/20260819-120600-io-invariants/raw/invariants_run2.txt
@@ -1,0 +1,115 @@
+
+======================================================================================================================
+## B4. chunk == slice, EACH LIBRARY AGAINST ITS OWN FULL DECODE, alignment searched over +/-4000 samples
+======================================================================================================================
+   'off' = how far the returned chunk actually sits from where it was requested (samples).
+
+  --- wav PCM_16 (sr=22050)
+      torchcodec             full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      torchaudio(=tc)        full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      soundfile              full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      ffmpeg -ss BEFORE -i   full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      ffmpeg -ss AFTER -i    full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+
+  --- wav FLOAT32 (sr=22050)
+      torchcodec             full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      torchaudio(=tc)        full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      soundfile              full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      ffmpeg -ss BEFORE -i   full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      ffmpeg -ss AFTER -i    full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+
+  --- flac PCM_24 (sr=22050)
+      torchcodec             full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      torchaudio(=tc)        full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      soundfile              full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      ffmpeg -ss BEFORE -i   full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      ffmpeg -ss AFTER -i    full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+
+  --- mp3 192k (sr=22050)
+      torchcodec             full_n=132300 | start 0: n=943 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=-1105 diff=0.00e+00 EXACT | mid: n=4096 off=-1105 diff=0.00e+00 EXACT
+      torchaudio(=tc)        full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      soundfile              full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=1.19e-07 - | mid: n=4096 off=0 diff=1.79e-07 -
+      ffmpeg -ss BEFORE -i   full_n=132300 | start 0: n=2048 off=0 diff=1.21e+00 - | odd 5001: n=2048 off=0 diff=1.22e+00 - | mid: n=4096 off=0 diff=1.23e+00 -
+      ffmpeg -ss AFTER -i    full_n=132300 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+
+  --- m4a aac (sr=22050)
+      torchcodec             full_n=133120 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      torchaudio(=tc)        full_n=133120 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+      soundfile              full decode failed: LibsndfileError
+      ffmpeg -ss BEFORE -i   full_n=133120 | start 0: n=2048 off=0 diff=1.11e+00 - | odd 5001: n=2048 off=0 diff=4.06e-02 - | mid: n=4096 off=0 diff=9.31e-02 -
+      ffmpeg -ss AFTER -i    full_n=133120 | start 0: n=2048 off=0 diff=0.00e+00 EXACT | odd 5001: n=2048 off=0 diff=0.00e+00 EXACT | mid: n=4096 off=0 diff=0.00e+00 EXACT
+
+  --- opus 48k (sr=48000)
+      torchcodec             full_n=132300 | start 0: n=4458 off=0 diff=0.00e+00 EXACT | odd 5001: n=4458 off=0 diff=0.00e+00 EXACT | mid: n=8916 off=0 diff=0.00e+00 EXACT
+      torchaudio(=tc)        full_n=132300 | start 0: n=4458 off=0 diff=0.00e+00 EXACT | odd 5001: n=4458 off=0 diff=0.00e+00 EXACT | mid: n=8916 off=0 diff=0.00e+00 EXACT
+      soundfile              full_n=132300 | start 0: n=4458 off=0 diff=0.00e+00 EXACT | odd 5001: n=4458 off=0 diff=0.00e+00 EXACT | mid: n=8916 off=0 diff=0.00e+00 EXACT
+      ffmpeg -ss BEFORE -i   full_n=132300 | start 0: n=4458 off=0 diff=0.00e+00 EXACT | odd 5001: n=4458 off=0 diff=0.00e+00 EXACT | mid: n=8916 off=0 diff=0.00e+00 EXACT
+      ffmpeg -ss AFTER -i    full_n=132300 | start 0: n=4458 off=0 diff=0.00e+00 EXACT | odd 5001: n=4458 off=0 diff=0.00e+00 EXACT | mid: n=8916 off=0 diff=0.00e+00 EXACT
+
+======================================================================================================================
+## B5. Does AudioSamples.pts_seconds report the true start of the returned chunk?
+======================================================================================================================
+
+  --- wav PCM_16
+      start 0    requested_start=0       pts_seconds=0.000000000 (= sample 0.0)  n=2048  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+      odd 5001   requested_start=5001    pts_seconds=0.226802721 (= sample 5001.0)  n=2048  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+      mid        requested_start=44877   pts_seconds=2.035238095 (= sample 44877.0)  n=4096  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+
+  --- wav FLOAT32
+      start 0    requested_start=0       pts_seconds=0.000000000 (= sample 0.0)  n=2048  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+      odd 5001   requested_start=5001    pts_seconds=0.226802721 (= sample 5001.0)  n=2048  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+      mid        requested_start=44877   pts_seconds=2.035238095 (= sample 44877.0)  n=4096  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+
+  --- flac PCM_24
+      start 0    requested_start=0       pts_seconds=0.000000000 (= sample 0.0)  n=2048  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+      odd 5001   requested_start=5001    pts_seconds=0.226802721 (= sample 5001.0)  n=2048  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+      mid        requested_start=44877   pts_seconds=2.035238095 (= sample 44877.0)  n=4096  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+
+  --- mp3 192k
+      start 0    requested_start=0       pts_seconds=0.050113379 (= sample 1105.0)  n=943   align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=-1105 diff=0.00e+00 exact=True
+      odd 5001   requested_start=5001    pts_seconds=0.226802721 (= sample 5001.0)  n=2048  align_vs_requested off=-1105 diff=0.00e+00  align_vs_pts off=-1105 diff=0.00e+00 exact=True
+      mid        requested_start=44877   pts_seconds=2.035238095 (= sample 44877.0)  n=4096  align_vs_requested off=-1105 diff=0.00e+00  align_vs_pts off=-1105 diff=0.00e+00 exact=True
+
+  --- m4a aac
+      start 0    requested_start=0       pts_seconds=0.000000000 (= sample 0.0)  n=2048  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+      odd 5001   requested_start=5001    pts_seconds=0.226802721 (= sample 5001.0)  n=2048  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+      mid        requested_start=44877   pts_seconds=2.035238095 (= sample 44877.0)  n=4096  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+
+  --- opus 48k
+      start 0    requested_start=0       pts_seconds=0.000000000 (= sample 0.0)  n=4458  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+      odd 5001   requested_start=10887   pts_seconds=0.226812500 (= sample 10887.0)  n=4458  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+      mid        requested_start=97691   pts_seconds=2.035229167 (= sample 97691.0)  n=8916  align_vs_requested off=0 diff=0.00e+00  align_vs_pts off=0 diff=0.00e+00 exact=True
+
+======================================================================================================================
+## B6. mp3: what exactly does the range API drop? sweep chunk starts, report returned length
+======================================================================================================================
+  full decode n=132300; input was 132300
+    request start=0       n_req=2048 -> n_got=943    pts=0.050113379 (sample 1105.0)  best_off_vs_requested=0 diff=0.00e+00 exact=True
+    request start=1       n_req=2048 -> n_got=944    pts=0.050113379 (sample 1105.0)  best_off_vs_requested=-1 diff=0.00e+00 exact=True
+    request start=100     n_req=2048 -> n_got=1043   pts=0.050113379 (sample 1105.0)  best_off_vs_requested=-100 diff=0.00e+00 exact=True
+    request start=576     n_req=2048 -> n_got=1519   pts=0.050113379 (sample 1105.0)  best_off_vs_requested=-576 diff=0.00e+00 exact=True
+    request start=1105    n_req=2048 -> n_got=2048   pts=0.050113379 (sample 1105.0)  best_off_vs_requested=-1105 diff=0.00e+00 exact=True
+    request start=1106    n_req=2048 -> n_got=2048   pts=0.050158730 (sample 1106.0)  best_off_vs_requested=-1105 diff=0.00e+00 exact=True
+    request start=2048    n_req=2048 -> n_got=2048   pts=0.092879819 (sample 2048.0)  best_off_vs_requested=-1105 diff=0.00e+00 exact=True
+    request start=5001    n_req=2048 -> n_got=2048   pts=0.226802721 (sample 5001.0)  best_off_vs_requested=-1105 diff=0.00e+00 exact=True
+    request start=22050   n_req=2048 -> n_got=2048   pts=1.000000000 (sample 22050.0)  best_off_vs_requested=-1105 diff=0.00e+00 exact=True
+
+======================================================================================================================
+## B7. Cross-library agreement on a FULL decode of the same file (decoder identity, not chunking)
+======================================================================================================================
+  wav PCM_16     torchcodec: n=132300 EXACT | torchaudio(=tc): n=132300 EXACT | soundfile: n=132300 EXACT | ffmpeg -ss BEFORE -i: n=132300 EXACT
+  wav FLOAT32    torchcodec: n=132300 EXACT | torchaudio(=tc): n=132300 EXACT | soundfile: n=132300 EXACT | ffmpeg -ss BEFORE -i: n=132300 EXACT
+  flac PCM_24    torchcodec: n=132300 EXACT | torchaudio(=tc): n=132300 EXACT | soundfile: n=132300 EXACT | ffmpeg -ss BEFORE -i: n=132300 EXACT
+  mp3 192k       torchcodec: n=132300 EXACT | torchaudio(=tc): n=132300 EXACT | soundfile: n=132300 diff=2.46e-06 | ffmpeg -ss BEFORE -i: n=132300 EXACT
+  m4a aac        torchcodec: n=133120 EXACT | torchaudio(=tc): n=133120 EXACT | soundfile=ERR | ffmpeg -ss BEFORE -i: n=133120 EXACT
+  opus 48k       torchcodec: n=132300 EXACT | torchaudio(=tc): n=132300 EXACT | soundfile: n=132300 diff=1.13e-06 | ffmpeg -ss BEFORE -i: n=132300 EXACT
+
+======================================================================================================================
+## B8. senselab Audio: does its offset/duration path inherit the mp3 defect? (uses torchcodec range)
+======================================================================================================================
+  wav PCM_16     full_n=132300   chunk_n=2048   off_from_requested=0 max|diff|=0.000e+00 bitexact=True
+  wav FLOAT32    full_n=132300   chunk_n=2048   off_from_requested=0 max|diff|=0.000e+00 bitexact=True
+  flac PCM_24    full_n=132300   chunk_n=2048   off_from_requested=0 max|diff|=0.000e+00 bitexact=True
+  mp3 192k       full_n=132300   chunk_n=2048   off_from_requested=-1105 max|diff|=0.000e+00 bitexact=True
+  m4a aac        full_n=133120   chunk_n=2048   off_from_requested=0 max|diff|=0.000e+00 bitexact=True
+  opus 48k       full_n=132300   chunk_n=4458   off_from_requested=0 max|diff|=0.000e+00 bitexact=True

--- a/specs/20260819-120600-io-invariants/raw/invariants_run3.txt
+++ b/specs/20260819-120600-io-invariants/raw/invariants_run3.txt
@@ -1,0 +1,55 @@
+
+================================================================================================================
+## C. Per-segment normalisation test: loud half (peak 0.9) then quiet half (peak 0.0009, -60 dB)
+================================================================================================================
+  file: loud-half peak=0.899982  quiet-half peak=0.000900000  ratio=1.000e-03
+
+  format        reader               quiet-chunk peak   slice peak     chunk/slice   bitexact
+  wav FLOAT32   torchcodec           0.000899961        0.000899961    1.000000      True
+  wav FLOAT32   torchaudio           0.000899961        0.000899961    1.000000      True
+  wav FLOAT32   soundfile            0.000899961        0.000899961    1.000000      True
+  wav FLOAT32   ffmpeg -ss after -i  0.000899961        0.000899961    1.000000      True
+  wav PCM_16    torchcodec           0.000915527        0.000915527    1.000000      True
+  wav PCM_16    torchaudio           0.000915527        0.000915527    1.000000      True
+  wav PCM_16    soundfile            0.000915527        0.000915527    1.000000      True
+  wav PCM_16    ffmpeg -ss after -i  0.000915527        0.000915527    1.000000      True
+  flac PCM_24   torchcodec           0.000899911        0.000899911    1.000000      True
+  flac PCM_24   torchaudio           0.000899911        0.000899911    1.000000      True
+  flac PCM_24   soundfile            0.000899911        0.000899911    1.000000      True
+  flac PCM_24   ffmpeg -ss after -i  0.000899911        0.000899911    1.000000      True
+  mp3 192k      torchcodec           1.163850546        0.117209934    9.929624      False
+  mp3 192k      torchaudio           0.117209934        0.117209934    1.000000      True
+  mp3 192k      soundfile            0.117209956        0.117209956    1.000000      True
+  mp3 192k      ffmpeg -ss after -i  0.117209934        0.117209934    1.000000      True
+  m4a aac       torchcodec           0.150671810        0.150671810    1.000000      True
+  m4a aac       torchaudio           0.150671810        0.150671810    1.000000      True
+  m4a aac       soundfile            LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/
+  m4a aac       ffmpeg -ss after -i  0.150671810        0.150671810    1.000000      True
+  opus 48k      torchcodec           RuntimeError: getFramesPlayedInRangeAudio, /Users/runner/work/to
+  opus 48k      torchaudio           ValueError: zero-size array to reduction operation maximum whi
+  opus 48k      soundfile            ValueError: zero-size array to reduction operation maximum whi
+  opus 48k      ffmpeg -ss after -i  ValueError: zero-size array to reduction operation maximum whi
+
+================================================================================================================
+## D. Frame-boundary dependence: sweep seek offset over one codec frame, chunk vs own-full-decode slice
+================================================================================================================
+
+  --- mp3 192k (frame=1152 samples).  base offset = 1.0 s, then +0..frame in steps
+      torchcodec           +0:n=2048,off=-1105,d=0.0e+00  +1:n=2048,off=-1105,d=0.0e+00  +288:n=2048,off=-1105,d=0.0e+00  +576:n=2048,off=-1105,d=0.0e+00  +1151:n=2048,off=-1105,d=0.0e+00  +1152:n=2048,off=-1105,d=0.0e+00  +1153:n=2048,off=-1105,d=0.0e+00  +2304:n=2048,off=-1105,d=0.0e+00
+      torchaudio           +0:n=2048,off=0,d=0.0e+00  +1:n=2048,off=0,d=0.0e+00  +288:n=2048,off=0,d=0.0e+00  +576:n=2048,off=0,d=0.0e+00  +1151:n=2048,off=0,d=0.0e+00  +1152:n=2048,off=0,d=0.0e+00  +1153:n=2048,off=0,d=0.0e+00  +2304:n=2048,off=0,d=0.0e+00
+      soundfile            +0:n=2048,off=0,d=1.8e-07!  +1:n=2048,off=0,d=1.8e-07!  +288:n=2048,off=0,d=1.8e-07!  +576:n=2048,off=0,d=1.2e-07!  +1151:n=2048,off=0,d=1.2e-07!  +1152:n=2048,off=0,d=1.2e-07!  +1153:n=2048,off=0,d=1.2e-07!  +2304:n=2048,off=0,d=0.0e+00
+      ffmpeg -ss after -i  +0:n=2048,off=0,d=0.0e+00  +1:n=2048,off=0,d=0.0e+00  +288:n=2048,off=0,d=0.0e+00  +576:n=2048,off=0,d=0.0e+00  +1151:n=2048,off=0,d=0.0e+00  +1152:n=2048,off=0,d=0.0e+00  +1153:n=2048,off=0,d=0.0e+00  +2304:n=2048,off=0,d=0.0e+00
+
+  --- m4a aac (frame=1024 samples).  base offset = 1.0 s, then +0..frame in steps
+      torchcodec           +0:n=2048,off=0,d=0.0e+00  +1:n=2048,off=0,d=0.0e+00  +256:n=2048,off=0,d=0.0e+00  +512:n=2048,off=0,d=0.0e+00  +1023:n=2048,off=0,d=0.0e+00  +1024:n=2048,off=0,d=0.0e+00  +1025:n=2048,off=0,d=0.0e+00  +2048:n=2048,off=0,d=0.0e+00
+      torchaudio           +0:n=2048,off=0,d=0.0e+00  +1:n=2048,off=0,d=0.0e+00  +256:n=2048,off=0,d=0.0e+00  +512:n=2048,off=0,d=0.0e+00  +1023:n=2048,off=0,d=0.0e+00  +1024:n=2048,off=0,d=0.0e+00  +1025:n=2048,off=0,d=0.0e+00  +2048:n=2048,off=0,d=0.0e+00
+      soundfile            full decode LibsndfileError
+      ffmpeg -ss after -i  +0:n=2048,off=0,d=0.0e+00  +1:n=2048,off=0,d=0.0e+00  +256:n=2048,off=0,d=0.0e+00  +512:n=2048,off=0,d=0.0e+00  +1023:n=2048,off=0,d=0.0e+00  +1024:n=2048,off=0,d=0.0e+00  +1025:n=2048,off=0,d=0.0e+00  +2048:n=2048,off=0,d=0.0e+00
+
+  --- opus 48k (frame=960 samples).  base offset = 1.0 s, then +0..frame in steps
+      torchcodec           +0:n=2048,off=0,d=0.0e+00  +1:n=2048,off=0,d=0.0e+00  +240:n=2048,off=0,d=0.0e+00  +480:n=2048,off=0,d=0.0e+00  +959:n=2048,off=0,d=0.0e+00  +960:n=2048,off=0,d=0.0e+00  +961:n=2048,off=0,d=0.0e+00  +1920:n=2048,off=0,d=0.0e+00
+      torchaudio           +0:n=2048,off=0,d=0.0e+00  +1:n=2048,off=0,d=0.0e+00  +240:n=2048,off=0,d=0.0e+00  +480:n=2048,off=0,d=0.0e+00  +959:n=2048,off=0,d=0.0e+00  +960:n=2048,off=0,d=0.0e+00  +961:n=2048,off=0,d=0.0e+00  +1920:n=2048,off=0,d=0.0e+00
+      soundfile            +0:n=2048,off=0,d=0.0e+00  +1:n=2048,off=0,d=0.0e+00  +240:n=2048,off=0,d=0.0e+00  +480:n=2048,off=0,d=0.0e+00  +959:n=2048,off=0,d=0.0e+00  +960:n=2048,off=0,d=0.0e+00  +961:n=2048,off=0,d=0.0e+00  +1920:n=2048,off=0,d=0.0e+00
+      ffmpeg -ss after -i  +0:n=2048,off=0,d=0.0e+00  +1:n=2048,off=0,d=0.0e+00  +240:n=2048,off=0,d=0.0e+00  +480:n=2048,off=0,d=0.0e+00  +959:n=2048,off=0,d=0.0e+00  +960:n=2048,off=0,d=0.0e+00  +961:n=2048,off=0,d=0.0e+00  +1920:n=2048,off=0,d=0.0e+00
+
+  ('!' marks a chunk that is NOT bit-identical to the slice of that same library's full decode)

--- a/specs/20260819-120600-io-invariants/raw/matrix.json
+++ b/specs/20260819-120600-io-invariants/raw/matrix.json
@@ -1,0 +1,22010 @@
+{
+ "versions": {
+  "python": "3.12.0",
+  "numpy": "2.4.4",
+  "torch": "2.11.0",
+  "torchaudio": "2.11.0",
+  "torchcodec": "0.11.1",
+  "soundfile": "0.13.1",
+  "libsndfile": "1.2.2",
+  "librosa": "0.11.0",
+  "ffmpeg": "ffmpeg version 8.1 Copyright (c) 2000-2026 the FFmpeg developers"
+ },
+ "sr": 22050,
+ "results": [
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "DeprecationWarning: 'aifc' is deprecated and slated for removal in Python 3.13",
+      "DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13",
+      "DeprecationWarning: 'sunau' is deprecated and slated for removal in Python 3.13"
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4878,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4878,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4044,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4044,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.0487775802612305e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1974,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.0487775802612305e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1974,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.0487775802612305e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1974,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.0487775802612305e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1974,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.0487775802612305e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1974,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.0487775802612305e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1974,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4844,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8044,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4878,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm16",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4878,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4878,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s24le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "529200",
+    "bits_per_raw_sample": "24",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 6044,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s24le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "529200",
+    "bits_per_raw_sample": "24",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 6044,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s24le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "529200",
+    "bits_per_raw_sample": "24",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 7244,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s24le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "1058400",
+    "bits_per_raw_sample": "24",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 12044,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s24le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "529200",
+    "bits_per_raw_sample": "24",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAVEX",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 6102,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s24le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "529200",
+    "bits_per_raw_sample": "24",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAVEX",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 6102,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s24le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "529200",
+    "bits_per_raw_sample": "24",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAVEX",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 7302,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm24",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s24le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "1058400",
+    "bits_per_raw_sample": "24",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAVEX",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 12102,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4878,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4878,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s32le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "bits_per_raw_sample": "32",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_32",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 8044,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s32le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "bits_per_raw_sample": "32",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_32",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 8044,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s32le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "bits_per_raw_sample": "32",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_32",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 9644,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s32le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "1411200",
+    "bits_per_raw_sample": "32",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_32",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 16044,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s32le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "bits_per_raw_sample": "32",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAVEX",
+    "subtype": "PCM_32",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 8102,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s32le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "bits_per_raw_sample": "32",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAVEX",
+    "subtype": "PCM_32",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 8102,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 2.3283064365386963e-10,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s32le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "bits_per_raw_sample": "32",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAVEX",
+    "subtype": "PCM_32",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 9702,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_pcm32",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s32le",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "1411200",
+    "bits_per_raw_sample": "32",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAVEX",
+    "subtype": "PCM_32",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 16102,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4878,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4878,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f32le",
+    "sample_fmt": "flt",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "FLOAT",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 8080,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f32le",
+    "sample_fmt": "flt",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "FLOAT",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 8080,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f32le",
+    "sample_fmt": "flt",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "FLOAT",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 9680,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f32le",
+    "sample_fmt": "flt",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "1411200",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "FLOAT",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 16088,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f32le",
+    "sample_fmt": "flt",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "FLOAT",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 8092,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f32le",
+    "sample_fmt": "flt",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "FLOAT",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 8092,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f32le",
+    "sample_fmt": "flt",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "FLOAT",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 9692,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float32",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f32le",
+    "sample_fmt": "flt",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "1411200",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "FLOAT",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 16092,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4878,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "352800",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4878,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "torchaudio.save",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "pcm_s16le",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "705600",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8078,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f64le",
+    "sample_fmt": "dbl",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "1411200",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "DOUBLE",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 16080,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f64le",
+    "sample_fmt": "dbl",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "1411200",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "DOUBLE",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 16080,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f64le",
+    "sample_fmt": "dbl",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "1411200",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "DOUBLE",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 19280,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "soundfile.write",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f64le",
+    "sample_fmt": "dbl",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "2822400",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "DOUBLE",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 32088,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f64le",
+    "sample_fmt": "dbl",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "1411200",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "DOUBLE",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 16092,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f64le",
+    "sample_fmt": "dbl",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "1411200",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "DOUBLE",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 16092,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.8994070887565613,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f64le",
+    "sample_fmt": "dbl",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "1411200",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "DOUBLE",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 19292,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 2.998509168624878,
+     "got_distinct": 2001,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "wav_float64",
+   "ext": "wav",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "pcm_f64le",
+    "sample_fmt": "dbl",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "2822400",
+    "format_name": "wav"
+   },
+   "sf_info": {
+    "format": "WAV",
+    "subtype": "DOUBLE",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 32092,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 12426,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 14385,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 15222,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 16894,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "torchaudio.save",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 12426,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "torchaudio.save",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 14385,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "torchaudio.save",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 15222,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "torchaudio.save",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 16894,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "soundfile.write",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "16",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4097,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "soundfile.write",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "16",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4097,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "soundfile.write",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "16",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4790,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "soundfile.write",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bits_per_raw_sample": "16",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8098,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "16",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 12425,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "ffmpeg-cli",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "16",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 12385,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "ffmpeg-cli",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "16",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 12917,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_16",
+   "ext": "flac",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s16",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bits_per_raw_sample": "16",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_16",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 16570,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 12426,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 14385,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 15222,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 16894,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "torchaudio.save",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 12426,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "torchaudio.save",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 14385,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "torchaudio.save",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 15222,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "torchaudio.save",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.",
+    "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 16894,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "soundfile.write",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4098,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "soundfile.write",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 6097,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 5.960464477539063e-08,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 5.960464477539063e-08,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 5.960464477539063e-08,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 5.960464477539063e-08,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 5.960464477539063e-08,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 5.960464477539063e-08,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "soundfile.write",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 6593,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "soundfile.write",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 8100,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 12426,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "ffmpeg-cli",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 14385,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "ffmpeg-cli",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 15222,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "flac_24",
+   "ext": "flac",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bits_per_raw_sample": "24",
+    "format_name": "flac"
+   },
+   "sf_info": {
+    "format": "FLAC",
+    "subtype": "PCM_24",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 16894,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__q16.ogg': Error : unknown error in flac decoder."
+   },
+   "size_bytes": 4339,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__q16.ogg': Error : unknown error in flac decoder."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__q16.ogg': Error : unknown error in flac decoder."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__f32.ogg': Error : unknown error in flac decoder."
+   },
+   "size_bytes": 6305,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__f32.ogg': Error : unknown error in flac decoder."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__f32.ogg': Error : unknown error in flac decoder."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__oor.ogg': Error : unknown error in flac decoder."
+   },
+   "size_bytes": 7147,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__oor.ogg': Error : unknown error in flac decoder."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__oor.ogg': Error : unknown error in flac decoder."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bits_per_raw_sample": "24",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__q16_stereo.ogg': Error : unknown error in flac decoder."
+   },
+   "size_bytes": 8824,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__q16_stereo.ogg': Error : unknown error in flac decoder."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__q16_stereo.ogg': Error : unknown error in flac decoder."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "torchaudio.save",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__q16.ogg': Error : unknown error in flac decoder."
+   },
+   "size_bytes": 4339,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__q16.ogg': Error : unknown error in flac decoder."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__q16.ogg': Error : unknown error in flac decoder."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 0.9996337890625,
+     "got_distinct": 1967,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "torchaudio.save",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__f32.ogg': Error : unknown error in flac decoder."
+   },
+   "size_bytes": 6305,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__f32.ogg': Error : unknown error in flac decoder."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__f32.ogg': Error : unknown error in flac decoder."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.52587890625e-05,
+     "got_peak": 0.8994140625,
+     "got_distinct": 1969,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.1886004358530045e-07,
+     "got_peak": 0.899407148361206,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "torchaudio.save",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bits_per_raw_sample": "24",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__oor.ogg': Error : unknown error in flac decoder."
+   },
+   "size_bytes": 7147,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__oor.ogg': Error : unknown error in flac decoder."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__oor.ogg': Error : unknown error in flac decoder."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 651,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.998509168624878,
+     "got_peak": 1.0,
+     "got_distinct": 652,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "torchaudio.save",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "flac",
+    "sample_fmt": "s32",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bits_per_raw_sample": "24",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__q16_stereo.ogg': Error : unknown error in flac decoder."
+   },
+   "size_bytes": 8824,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__q16_stereo.ogg': Error : unknown error in flac decoder."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__q16_stereo.ogg': Error : unknown error in flac decoder."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": true,
+     "allclose_bitwise": true,
+     "max_abs_diff": 0.0,
+     "got_peak": 1.0,
+     "got_distinct": 3860,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "soundfile.write",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "vorbis",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "45111",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "format": "OGG",
+    "subtype": "VORBIS",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4303,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 0.8813436031341553,
+     "got_peak": 1.588793158531189,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 0.8813436031341553,
+     "got_peak": 1.588793158531189,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.8813434839248657,
+     "got_peak": 1.5887932777404785,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.8813434839248657,
+     "got_peak": 1.5887932777404785,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.8813434839248657,
+     "got_peak": 1.5887932777404785,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 0.8813436031341553,
+     "got_peak": 1.588793158531189,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "soundfile.write",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "vorbis",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "45111",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "format": "OGG",
+    "subtype": "VORBIS",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 4329,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 0.755659818649292,
+     "got_peak": 1.4634156227111816,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 0.755659818649292,
+     "got_peak": 1.4634156227111816,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.7556599676609039,
+     "got_peak": 1.4634156227111816,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.7556599676609039,
+     "got_peak": 1.4634156227111816,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.7556599676609039,
+     "got_peak": 1.4634156227111816,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 0.755659818649292,
+     "got_peak": 1.4634156227111816,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "soundfile.write",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "vorbis",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "45111",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "format": "OGG",
+    "subtype": "VORBIS",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 4787,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2688
+     ],
+     "exact": false,
+     "note": "length differs by 288",
+     "max_abs_diff_prefix": 0.9733618497848511,
+     "got_peak": 3.553997039794922,
+     "got_distinct": 2688,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2688
+     ],
+     "exact": false,
+     "note": "length differs by 288",
+     "max_abs_diff_prefix": 0.9733618497848511,
+     "got_peak": 3.553997039794922,
+     "got_distinct": 2688,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.9733613729476929,
+     "got_peak": 3.55399751663208,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.9733613729476929,
+     "got_peak": 3.55399751663208,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.9733613729476929,
+     "got_peak": 3.55399751663208,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2688
+     ],
+     "exact": false,
+     "note": "length differs by 288",
+     "max_abs_diff_prefix": 0.9733618497848511,
+     "got_peak": 3.553997039794922,
+     "got_distinct": 2688,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "soundfile.write",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "vorbis",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "77333",
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "format": "OGG",
+    "subtype": "VORBIS",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 5197,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.7079612016677856,
+     "got_peak": 2.128934621810913,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.7079612016677856,
+     "got_peak": 2.128934621810913,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.707961082458496,
+     "got_peak": 2.128934383392334,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.707961082458496,
+     "got_peak": 2.128934383392334,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.707961082458496,
+     "got_peak": 2.128934383392334,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.7079612016677856,
+     "got_peak": 2.128934621810913,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "RuntimeError: : -1 (Operation not permitted)\n[af#0:0 @ 0x824c2c000] Terminating thread with return code -1 (Operation not permitted)\n[aost#0:0/vorbis @ 0x825020000] [enc:vorbis @ 0x825005810] Could not open encoder before EOF\n[aost#0:0/vorbis @ 0x825020000] Task finished with error code: -22 (Invalid argument)\n[aost#0:0/vorbis @ 0x825020000] Terminating thread with return code -22 (Invalid argumen",
+   "write_warnings": []
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "ffmpeg-cli",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "RuntimeError: : -1 (Operation not permitted)\n[af#0:0 @ 0x7d8818000] Terminating thread with return code -1 (Operation not permitted)\n[aost#0:0/vorbis @ 0x7d940c000] [enc:vorbis @ 0x7d9005810] Could not open encoder before EOF\n[aost#0:0/vorbis @ 0x7d940c000] Task finished with error code: -22 (Invalid argument)\n[aost#0:0/vorbis @ 0x7d940c000] Terminating thread with return code -22 (Invalid argumen",
+   "write_warnings": []
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "ffmpeg-cli",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "RuntimeError: : -1 (Operation not permitted)\n[af#0:0 @ 0xa1cc2c000] Terminating thread with return code -1 (Operation not permitted)\n[aost#0:0/vorbis @ 0xa1d024000] [enc:vorbis @ 0xa1cc20230] Could not open encoder before EOF\n[aost#0:0/vorbis @ 0xa1d024000] Task finished with error code: -22 (Invalid argument)\n[aost#0:0/vorbis @ 0xa1d024000] Terminating thread with return code -22 (Invalid argumen",
+   "write_warnings": []
+  },
+  {
+   "target": "ogg_vorbis",
+   "ext": "ogg",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "vorbis",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 2,
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "format": "OGG",
+    "subtype": "VORBIS",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2048
+   },
+   "size_bytes": 7106,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      1024
+     ],
+     "exact": false,
+     "note": "length differs by -976",
+     "max_abs_diff_prefix": 0.9676597714424133,
+     "got_peak": 1.438965916633606,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      1024
+     ],
+     "exact": false,
+     "note": "length differs by -976",
+     "max_abs_diff_prefix": 0.9676597714424133,
+     "got_peak": 1.438965916633606,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 0.9454207420349121,
+     "got_peak": 1.450430154800415,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 0.9454207420349121,
+     "got_peak": 1.450430154800415,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 0.9454207420349121,
+     "got_peak": 1.450430154800415,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      1024
+     ],
+     "exact": false,
+     "note": "length differs by -976",
+     "max_abs_diff_prefix": 0.9676597714424133,
+     "got_peak": 1.438965916633606,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "RuntimeError: validateSampleRate, /Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/Encoder.cpp:65, invalid sample rate=22050. Supported sample rate values are: 48000, 24000, 16000, 12000, 8000",
+   "write_warnings": []
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "RuntimeError: validateSampleRate, /Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/Encoder.cpp:65, invalid sample rate=22050. Supported sample rate values are: 48000, 24000, 16000, 12000, 8000",
+   "write_warnings": []
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "RuntimeError: validateSampleRate, /Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/Encoder.cpp:65, invalid sample rate=22050. Supported sample rate values are: 48000, 24000, 16000, 12000, 8000",
+   "write_warnings": []
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "FAIL",
+   "write_error": "RuntimeError: validateSampleRate, /Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/Encoder.cpp:65, invalid sample rate=22050. Supported sample rate values are: 48000, 24000, 16000, 12000, 8000",
+   "write_warnings": []
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "torchaudio.save",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "RuntimeError: Failed to save audio to /Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/opus__torchaudio_save__q16.opus: validateSampleRate, /Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/Encoder.cpp:65, invalid sample rate=22050. Supported sample rate values are: 48000, 24000, 16000, 12000, 8000",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ]
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "torchaudio.save",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "RuntimeError: Failed to save audio to /Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/opus__torchaudio_save__f32.opus: validateSampleRate, /Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/Encoder.cpp:65, invalid sample rate=22050. Supported sample rate values are: 48000, 24000, 16000, 12000, 8000",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ]
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "torchaudio.save",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "RuntimeError: Failed to save audio to /Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/opus__torchaudio_save__oor.opus: validateSampleRate, /Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/Encoder.cpp:65, invalid sample rate=22050. Supported sample rate values are: 48000, 24000, 16000, 12000, 8000",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ]
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "torchaudio.save",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "FAIL",
+   "write_error": "RuntimeError: Failed to save audio to /Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/opus__torchaudio_save__q16_stereo.opus: validateSampleRate, /Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/Encoder.cpp:65, invalid sample rate=22050. Supported sample rate values are: 48000, 24000, 16000, 12000, 8000",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ]
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "soundfile.write",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/opus__soundfile_write__q16.opus': Error : Opus only supports sample rates of 8000, 12000, 16000, 24000, and 48000.",
+   "write_warnings": []
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "soundfile.write",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/opus__soundfile_write__f32.opus': Error : Opus only supports sample rates of 8000, 12000, 16000, 24000, and 48000.",
+   "write_warnings": []
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "soundfile.write",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/opus__soundfile_write__oor.opus': Error : Opus only supports sample rates of 8000, 12000, 16000, 24000, and 48000.",
+   "write_warnings": []
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "soundfile.write",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "FAIL",
+   "write_error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/opus__soundfile_write__q16_stereo.opus': Error : Opus only supports sample rates of 8000, 12000, 16000, 24000, and 48000.",
+   "write_warnings": []
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "opus",
+    "sample_fmt": "fltp",
+    "sample_rate": "48000",
+    "channels": 1,
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "format": "OGG",
+    "subtype": "OPUS",
+    "sr": 24000,
+    "ch": 1,
+    "frames": 2177
+   },
+   "size_bytes": 1185,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      4354
+     ],
+     "exact": false,
+     "note": "length differs by 2354",
+     "max_abs_diff_prefix": 2.214470624923706,
+     "got_peak": 1.7481588125228882,
+     "got_distinct": 4354,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      4354
+     ],
+     "exact": false,
+     "note": "length differs by 2354",
+     "max_abs_diff_prefix": 2.214470624923706,
+     "got_peak": 1.7481588125228882,
+     "got_distinct": 4354,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2177
+     ],
+     "exact": false,
+     "note": "length differs by 177",
+     "max_abs_diff_prefix": 2.244318723678589,
+     "got_peak": 1.7481588125228882,
+     "got_distinct": 2177,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2177
+     ],
+     "exact": false,
+     "note": "length differs by 177",
+     "max_abs_diff_prefix": 2.244318723678589,
+     "got_peak": 1.7481588125228882,
+     "got_distinct": 2177,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2177
+     ],
+     "exact": false,
+     "note": "length differs by 177",
+     "max_abs_diff_prefix": 2.244318723678589,
+     "got_peak": 1.7481588125228882,
+     "got_distinct": 2177,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      4354
+     ],
+     "exact": false,
+     "note": "length differs by 2354",
+     "max_abs_diff_prefix": 2.214470624923706,
+     "got_peak": 1.7481588125228882,
+     "got_distinct": 4354,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "ffmpeg-cli",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "opus",
+    "sample_fmt": "fltp",
+    "sample_rate": "48000",
+    "channels": 1,
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "format": "OGG",
+    "subtype": "OPUS",
+    "sr": 24000,
+    "ch": 1,
+    "frames": 2177
+   },
+   "size_bytes": 1181,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      4354
+     ],
+     "exact": false,
+     "note": "length differs by 2354",
+     "max_abs_diff_prefix": 2.0776243209838867,
+     "got_peak": 1.4126372337341309,
+     "got_distinct": 4354,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      4354
+     ],
+     "exact": false,
+     "note": "length differs by 2354",
+     "max_abs_diff_prefix": 2.0776243209838867,
+     "got_peak": 1.4126372337341309,
+     "got_distinct": 4354,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2177
+     ],
+     "exact": false,
+     "note": "length differs by 177",
+     "max_abs_diff_prefix": 2.1134324073791504,
+     "got_peak": 1.4126372337341309,
+     "got_distinct": 2176,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2177
+     ],
+     "exact": false,
+     "note": "length differs by 177",
+     "max_abs_diff_prefix": 2.1134324073791504,
+     "got_peak": 1.4126372337341309,
+     "got_distinct": 2176,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2177
+     ],
+     "exact": false,
+     "note": "length differs by 177",
+     "max_abs_diff_prefix": 2.1134324073791504,
+     "got_peak": 1.4126372337341309,
+     "got_distinct": 2176,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      4354
+     ],
+     "exact": false,
+     "note": "length differs by 2354",
+     "max_abs_diff_prefix": 2.0776243209838867,
+     "got_peak": 1.4126372337341309,
+     "got_distinct": 4354,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "ffmpeg-cli",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "opus",
+    "sample_fmt": "fltp",
+    "sample_rate": "48000",
+    "channels": 1,
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "format": "OGG",
+    "subtype": "OPUS",
+    "sr": 24000,
+    "ch": 1,
+    "frames": 2613
+   },
+   "size_bytes": 1322,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      5226
+     ],
+     "exact": false,
+     "note": "length differs by 2826",
+     "max_abs_diff_prefix": 6.482292652130127,
+     "got_peak": 4.54794454574585,
+     "got_distinct": 5225,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      5226
+     ],
+     "exact": false,
+     "note": "length differs by 2826",
+     "max_abs_diff_prefix": 6.482292652130127,
+     "got_peak": 4.54794454574585,
+     "got_distinct": 5225,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2613
+     ],
+     "exact": false,
+     "note": "length differs by 213",
+     "max_abs_diff_prefix": 6.483098030090332,
+     "got_peak": 4.547944068908691,
+     "got_distinct": 2613,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2613
+     ],
+     "exact": false,
+     "note": "length differs by 213",
+     "max_abs_diff_prefix": 6.483098030090332,
+     "got_peak": 4.547944068908691,
+     "got_distinct": 2613,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2613
+     ],
+     "exact": false,
+     "note": "length differs by 213",
+     "max_abs_diff_prefix": 6.483098030090332,
+     "got_peak": 4.547944068908691,
+     "got_distinct": 2613,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      5226
+     ],
+     "exact": false,
+     "note": "length differs by 2826",
+     "max_abs_diff_prefix": 6.482292652130127,
+     "got_peak": 4.54794454574585,
+     "got_distinct": 5225,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "opus",
+   "ext": "opus",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "opus",
+    "sample_fmt": "fltp",
+    "sample_rate": "48000",
+    "channels": 2,
+    "format_name": "ogg"
+   },
+   "sf_info": {
+    "format": "OGG",
+    "subtype": "OPUS",
+    "sr": 24000,
+    "ch": 2,
+    "frames": 2177
+   },
+   "size_bytes": 1547,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      4354
+     ],
+     "exact": false,
+     "note": "length differs by 2354",
+     "max_abs_diff_prefix": 2.3537790775299072,
+     "got_peak": 1.8079171180725098,
+     "got_distinct": 8708,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      4354
+     ],
+     "exact": false,
+     "note": "length differs by 2354",
+     "max_abs_diff_prefix": 2.3537790775299072,
+     "got_peak": 1.8079171180725098,
+     "got_distinct": 8708,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2177
+     ],
+     "exact": false,
+     "note": "length differs by 177",
+     "max_abs_diff_prefix": 2.3859565258026123,
+     "got_peak": 1.8079171180725098,
+     "got_distinct": 4354,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2177
+     ],
+     "exact": false,
+     "note": "length differs by 177",
+     "max_abs_diff_prefix": 2.3859565258026123,
+     "got_peak": 1.8079171180725098,
+     "got_distinct": 4354,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2177
+     ],
+     "exact": false,
+     "note": "length differs by 177",
+     "max_abs_diff_prefix": 2.3859565258026123,
+     "got_peak": 1.8079171180725098,
+     "got_distinct": 4354,
+     "sr_out": 24000,
+     "sr_preserved": false,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      4354
+     ],
+     "exact": false,
+     "note": "length differs by 2354",
+     "max_abs_diff_prefix": 2.3537790775299072,
+     "got_peak": 1.8079171180725098,
+     "got_distinct": 8708,
+     "sr_out": 48000,
+     "sr_preserved": false,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "32000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 854,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393296658992767,
+     "got_peak": 1.5571460723876953,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393296658992767,
+     "got_peak": 1.5571460723876953,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393295168876648,
+     "got_peak": 1.557146430015564,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393295168876648,
+     "got_peak": 1.557146430015564,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393295168876648,
+     "got_peak": 1.5571465492248535,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393296658992767,
+     "got_peak": 1.5571460723876953,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "32000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 854,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686840772628784,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686840772628784,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686842560768127,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686842560768127,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686842560768127,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686840772628784,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "32000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 958,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212104082107544,
+     "got_peak": 4.879705905914307,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212104082107544,
+     "got_peak": 4.879705905914307,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212100028991699,
+     "got_peak": 4.879706859588623,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212100028991699,
+     "got_peak": 4.879706859588623,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212100028991699,
+     "got_peak": 4.879706859588623,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212104082107544,
+     "got_peak": 4.879705905914307,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "64000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 1480,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388891816139221,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388891816139221,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388900756835938,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388900756835938,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388900756835938,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388891816139221,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "torchaudio.save",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "32000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 854,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393296658992767,
+     "got_peak": 1.5571460723876953,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393296658992767,
+     "got_peak": 1.5571460723876953,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393295168876648,
+     "got_peak": 1.557146430015564,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393295168876648,
+     "got_peak": 1.557146430015564,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393295168876648,
+     "got_peak": 1.5571465492248535,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393296658992767,
+     "got_peak": 1.5571460723876953,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "torchaudio.save",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "32000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 854,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686840772628784,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686840772628784,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686842560768127,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686842560768127,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686842560768127,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686840772628784,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "torchaudio.save",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "32000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 958,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212104082107544,
+     "got_peak": 4.879705905914307,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212104082107544,
+     "got_peak": 4.879705905914307,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212100028991699,
+     "got_peak": 4.879706859588623,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212100028991699,
+     "got_peak": 4.879706859588623,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212100028991699,
+     "got_peak": 4.879706859588623,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212104082107544,
+     "got_peak": 4.879705905914307,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "torchaudio.save",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "64000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 1480,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388891816139221,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388891816139221,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388900756835938,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388900756835938,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388900756835938,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388891816139221,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "soundfile.write",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "79829",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 1564,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.9967378377914429,
+     "got_peak": 1.6479779481887817,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.9967378377914429,
+     "got_peak": 1.6479779481887817,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.9967380464076996,
+     "got_peak": 1.6479781866073608,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.9967380464076996,
+     "got_peak": 1.6479781866073608,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.9967380464076996,
+     "got_peak": 1.6479781866073608,
+     "got_distinct": 1999,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 0.9967378377914429,
+     "got_peak": 1.6479779481887817,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "soundfile.write",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "78451",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 1537,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.0743048787117004,
+     "got_peak": 1.5313098430633545,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.0743048787117004,
+     "got_peak": 1.5313098430633545,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.0743050575256348,
+     "got_peak": 1.5313098430633545,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.0743050575256348,
+     "got_peak": 1.5313098430633545,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.0743050575256348,
+     "got_peak": 1.5313098430633545,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.0743048787117004,
+     "got_peak": 1.5313098430633545,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "soundfile.write",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "85531",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 1955,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.2115631103515625,
+     "got_peak": 5.268135070800781,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.2115631103515625,
+     "got_peak": 5.268135070800781,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.2115631103515625,
+     "got_peak": 5.2681355476379395,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.2115631103515625,
+     "got_peak": 5.2681355476379395,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.2115631103515625,
+     "got_peak": 5.2681355476379395,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 3.2115631103515625,
+     "got_peak": 5.268135070800781,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "soundfile.write",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "113159",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 2217,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.191900908946991,
+     "got_peak": 1.7806122303009033,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.191900908946991,
+     "got_peak": 1.7806122303009033,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.191900908946991,
+     "got_peak": 1.7806122303009033,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.191900908946991,
+     "got_peak": 1.7806122303009033,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.191900908946991,
+     "got_peak": 1.7806122303009033,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.191900908946991,
+     "got_peak": 1.7806122303009033,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "32000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 854,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393296658992767,
+     "got_peak": 1.5571460723876953,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393296658992767,
+     "got_peak": 1.5571460723876953,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393295168876648,
+     "got_peak": 1.557146430015564,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393295168876648,
+     "got_peak": 1.557146430015564,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393295168876648,
+     "got_peak": 1.5571465492248535,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.2393296658992767,
+     "got_peak": 1.5571460723876953,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "ffmpeg-cli",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "32000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2000
+   },
+   "size_bytes": 854,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686840772628784,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686840772628784,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686842560768127,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686842560768127,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686842560768127,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.4686840772628784,
+     "got_peak": 1.3075666427612305,
+     "got_distinct": 2000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "ffmpeg-cli",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "32000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 1,
+    "frames": 2400
+   },
+   "size_bytes": 958,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212104082107544,
+     "got_peak": 4.879705905914307,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212104082107544,
+     "got_peak": 4.879705905914307,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212100028991699,
+     "got_peak": 4.879706859588623,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212100028991699,
+     "got_peak": 4.879706859588623,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212100028991699,
+     "got_peak": 4.879706859588623,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2400
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 4.212104082107544,
+     "got_peak": 4.879705905914307,
+     "got_distinct": 2400,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "mp3",
+   "ext": "mp3",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "mp3",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "64000",
+    "format_name": "mp3"
+   },
+   "sf_info": {
+    "format": "MP3",
+    "subtype": "MPEG_LAYER_III",
+    "sr": 22050,
+    "ch": 2,
+    "frames": 2000
+   },
+   "size_bytes": 1480,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388891816139221,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388891816139221,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388900756835938,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f64)": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388900756835938,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388900756835938,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2000
+     ],
+     "exact": false,
+     "allclose_bitwise": false,
+     "max_abs_diff": 1.3388891816139221,
+     "got_peak": 1.7627232074737549,
+     "got_distinct": 4000,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "69416",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__q16.m4a': Format not recognised."
+   },
+   "size_bytes": 2009,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.3845837116241455,
+     "got_peak": 1.5821795463562012,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.3845837116241455,
+     "got_peak": 1.5821795463562012,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__q16.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__q16.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2006
+     ],
+     "exact": false,
+     "note": "length differs by 6",
+     "max_abs_diff_prefix": 1.342437744140625,
+     "got_peak": 1.0,
+     "got_distinct": 1883,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.3845837116241455,
+     "got_peak": 1.5821795463562012,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "69941",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__f32.m4a': Format not recognised."
+   },
+   "size_bytes": 2018,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.6706924438476562,
+     "got_peak": 1.4849441051483154,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.6706924438476562,
+     "got_peak": 1.4849441051483154,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__f32.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__f32.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2006
+     ],
+     "exact": false,
+     "note": "length differs by 6",
+     "max_abs_diff_prefix": 1.2620160579681396,
+     "got_peak": 1.0,
+     "got_distinct": 1912,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.6706924438476562,
+     "got_peak": 1.4849441051483154,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "62801",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__oor.m4a': Format not recognised."
+   },
+   "size_bytes": 2042,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      3072
+     ],
+     "exact": false,
+     "note": "length differs by 672",
+     "max_abs_diff_prefix": 3.65010666847229,
+     "got_peak": 5.00807523727417,
+     "got_distinct": 2625,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      3072
+     ],
+     "exact": false,
+     "note": "length differs by 672",
+     "max_abs_diff_prefix": 3.65010666847229,
+     "got_peak": 5.00807523727417,
+     "got_distinct": 2625,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__oor.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__oor.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2403
+     ],
+     "exact": false,
+     "note": "length differs by 3",
+     "max_abs_diff_prefix": 3.612180471420288,
+     "got_peak": 1.0,
+     "got_distinct": 1993,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      3072
+     ],
+     "exact": false,
+     "note": "length differs by 672",
+     "max_abs_diff_prefix": 3.65010666847229,
+     "got_peak": 5.00807523727417,
+     "got_distinct": 2625,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "torchcodec.AudioEncoder",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "96541",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__q16_stereo.m4a': Format not recognised."
+   },
+   "size_bytes": 2474,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.8012604713439941,
+     "got_peak": 1.7457069158554077,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.8012604713439941,
+     "got_peak": 1.7457069158554077,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__q16_stereo.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__q16_stereo.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2006
+     ],
+     "exact": false,
+     "note": "length differs by 6",
+     "max_abs_diff_prefix": 1.924835205078125,
+     "got_peak": 1.0,
+     "got_distinct": 3676,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.8012604713439941,
+     "got_peak": 1.7457069158554077,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "torchaudio.save",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "69416",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__q16.m4a': Format not recognised."
+   },
+   "size_bytes": 2009,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.3845837116241455,
+     "got_peak": 1.5821795463562012,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.3845837116241455,
+     "got_peak": 1.5821795463562012,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__q16.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__q16.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2006
+     ],
+     "exact": false,
+     "note": "length differs by 6",
+     "max_abs_diff_prefix": 1.342437744140625,
+     "got_peak": 1.0,
+     "got_distinct": 1883,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.3845837116241455,
+     "got_peak": 1.5821795463562012,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "torchaudio.save",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "69941",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__f32.m4a': Format not recognised."
+   },
+   "size_bytes": 2018,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.6706924438476562,
+     "got_peak": 1.4849441051483154,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.6706924438476562,
+     "got_peak": 1.4849441051483154,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__f32.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__f32.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2006
+     ],
+     "exact": false,
+     "note": "length differs by 6",
+     "max_abs_diff_prefix": 1.2620160579681396,
+     "got_peak": 1.0,
+     "got_distinct": 1912,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.6706924438476562,
+     "got_peak": 1.4849441051483154,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "torchaudio.save",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "62801",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__oor.m4a': Format not recognised."
+   },
+   "size_bytes": 2042,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      3072
+     ],
+     "exact": false,
+     "note": "length differs by 672",
+     "max_abs_diff_prefix": 3.65010666847229,
+     "got_peak": 5.00807523727417,
+     "got_distinct": 2625,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      3072
+     ],
+     "exact": false,
+     "note": "length differs by 672",
+     "max_abs_diff_prefix": 3.65010666847229,
+     "got_peak": 5.00807523727417,
+     "got_distinct": 2625,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__oor.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__oor.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2403
+     ],
+     "exact": false,
+     "note": "length differs by 3",
+     "max_abs_diff_prefix": 3.612180471420288,
+     "got_peak": 1.0,
+     "got_distinct": 1993,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      3072
+     ],
+     "exact": false,
+     "note": "length differs by 672",
+     "max_abs_diff_prefix": 3.65010666847229,
+     "got_peak": 5.00807523727417,
+     "got_distinct": 2625,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "torchaudio.save",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [
+    "UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."
+   ],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "96541",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__q16_stereo.m4a': Format not recognised."
+   },
+   "size_bytes": 2474,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.8012604713439941,
+     "got_peak": 1.7457069158554077,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.8012604713439941,
+     "got_peak": 1.7457069158554077,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__q16_stereo.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__q16_stereo.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2006
+     ],
+     "exact": false,
+     "note": "length differs by 6",
+     "max_abs_diff_prefix": 1.924835205078125,
+     "got_peak": 1.0,
+     "got_distinct": 3676,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.8012604713439941,
+     "got_peak": 1.7457069158554077,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "soundfile.write",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "NotImplementedError: libsndfile has no writer for this container",
+   "write_warnings": []
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "soundfile.write",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "NotImplementedError: libsndfile has no writer for this container",
+   "write_warnings": []
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "soundfile.write",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "FAIL",
+   "write_error": "NotImplementedError: libsndfile has no writer for this container",
+   "write_warnings": []
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "soundfile.write",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "FAIL",
+   "write_error": "NotImplementedError: libsndfile has no writer for this container",
+   "write_warnings": []
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "69416",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__q16.m4a': Format not recognised."
+   },
+   "size_bytes": 2009,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.3845837116241455,
+     "got_peak": 1.5821795463562012,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.3845837116241455,
+     "got_peak": 1.5821795463562012,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__q16.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__q16.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2006
+     ],
+     "exact": false,
+     "note": "length differs by 6",
+     "max_abs_diff_prefix": 1.342437744140625,
+     "got_peak": 1.0,
+     "got_distinct": 1883,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.3845837116241455,
+     "got_peak": 1.5821795463562012,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "ffmpeg-cli",
+   "signal": "f32",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "69941",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__f32.m4a': Format not recognised."
+   },
+   "size_bytes": 2018,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.6706924438476562,
+     "got_peak": 1.4849441051483154,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.6706924438476562,
+     "got_peak": 1.4849441051483154,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__f32.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__f32.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2006
+     ],
+     "exact": false,
+     "note": "length differs by 6",
+     "max_abs_diff_prefix": 1.2620160579681396,
+     "got_peak": 1.0,
+     "got_distinct": 1912,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2000
+     ],
+     "got_shape": [
+      1,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.6706924438476562,
+     "got_peak": 1.4849441051483154,
+     "got_distinct": 2048,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "ffmpeg-cli",
+   "signal": "oor",
+   "sr_in": 22050,
+   "ch_in": 1,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 1,
+    "bit_rate": "62801",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__oor.m4a': Format not recognised."
+   },
+   "size_bytes": 2042,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      3072
+     ],
+     "exact": false,
+     "note": "length differs by 672",
+     "max_abs_diff_prefix": 3.65010666847229,
+     "got_peak": 5.00807523727417,
+     "got_distinct": 2625,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      3072
+     ],
+     "exact": false,
+     "note": "length differs by 672",
+     "max_abs_diff_prefix": 3.65010666847229,
+     "got_peak": 5.00807523727417,
+     "got_distinct": 2625,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__oor.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__oor.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      2403
+     ],
+     "exact": false,
+     "note": "length differs by 3",
+     "max_abs_diff_prefix": 3.612180471420288,
+     "got_peak": 1.0,
+     "got_distinct": 1993,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      1,
+      2400
+     ],
+     "got_shape": [
+      1,
+      3072
+     ],
+     "exact": false,
+     "note": "length differs by 672",
+     "max_abs_diff_prefix": 3.65010666847229,
+     "got_peak": 5.00807523727417,
+     "got_distinct": 2625,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  },
+  {
+   "target": "m4a_aac",
+   "ext": "m4a",
+   "encoder": "ffmpeg-cli",
+   "signal": "q16_stereo",
+   "sr_in": 22050,
+   "ch_in": 2,
+   "write": "ok",
+   "write_warnings": [],
+   "probe": {
+    "codec_name": "aac",
+    "sample_fmt": "fltp",
+    "sample_rate": "22050",
+    "channels": 2,
+    "bit_rate": "96541",
+    "format_name": "mov,mp4,m4a,3gp,3g2,mj2"
+   },
+   "sf_info": {
+    "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__q16_stereo.m4a': Format not recognised."
+   },
+   "size_bytes": 2474,
+   "decode": {
+    "torchcodec.AudioDecoder": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.8012604713439941,
+     "got_peak": 1.7457069158554077,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "torchaudio.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.8012604713439941,
+     "got_peak": 1.7457069158554077,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": []
+    },
+    "soundfile.read(f32)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__q16_stereo.m4a': Format not recognised."
+    },
+    "soundfile.read(f64)": {
+     "error": "LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__q16_stereo.m4a': Format not recognised."
+    },
+    "librosa.load": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2006
+     ],
+     "exact": false,
+     "note": "length differs by 6",
+     "max_abs_diff_prefix": 1.924835205078125,
+     "got_peak": 1.0,
+     "got_distinct": 3676,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float32",
+     "warnings": [
+      "UserWarning: PySoundFile failed. Trying audioread instead.",
+      "FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in librosa version 1.0."
+     ]
+    },
+    "ffmpeg-cli": {
+     "ref_shape": [
+      2,
+      2000
+     ],
+     "got_shape": [
+      2,
+      2048
+     ],
+     "exact": false,
+     "note": "length differs by 48",
+     "max_abs_diff_prefix": 1.8012604713439941,
+     "got_peak": 1.7457069158554077,
+     "got_distinct": 4096,
+     "sr_out": 22050,
+     "sr_preserved": true,
+     "read_dtype": "float64->float32",
+     "warnings": []
+    }
+   }
+  }
+ ]
+}

--- a/specs/20260819-120600-io-invariants/raw/matrix_tables.txt
+++ b/specs/20260819-120600-io-invariants/raw/matrix_tables.txt
@@ -1,0 +1,301 @@
+==================================================================================================================================
+### ROUND-TRIP: signal=q16   (EXACT = bit-identical float32; else max |diff|; ERR = decoder failed)
+==================================================================================================================================
+target       encoder                  torchcodec.A torchaudio.l soundfile.re soundfile.re librosa.load   ffmpeg-cli
+wav_pcm16    torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm16    torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm16    soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm16    ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+wav_pcm24    torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm24    torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm24    soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm24    ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+wav_pcm32    torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm32    torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm32    soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm32    ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+wav_float32  torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float32  torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float32  soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float32  ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+wav_float64  torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float64  torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float64  soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float64  ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+flac_16      torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_16      torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_16      soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_16      ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+flac_24      torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_24      torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_24      soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_24      ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+ogg_vorbis   torchcodec.AudioEncoder        EXACT        EXACT         ERR          ERR         EXACT        EXACT 
+ogg_vorbis   torchaudio.save                EXACT        EXACT         ERR          ERR         EXACT        EXACT 
+ogg_vorbis   soundfile.write               8.8e-01      8.8e-01      8.8e-01      8.8e-01      8.8e-01      8.8e-01
+ogg_vorbis   ffmpeg-cli               WRITE FAILED
+----------------------------------------------------------------------------------------------------------------------------------
+opus         torchcodec.AudioEncoder  WRITE FAILED
+opus         torchaudio.save          WRITE FAILED
+opus         soundfile.write          WRITE FAILED
+opus         ffmpeg-cli                    2.2e+00      2.2e+00      2.2e+00      2.2e+00      2.2e+00      2.2e+00
+----------------------------------------------------------------------------------------------------------------------------------
+mp3          torchcodec.AudioEncoder       1.2e+00      1.2e+00      1.2e+00      1.2e+00      1.2e+00      1.2e+00
+mp3          torchaudio.save               1.2e+00      1.2e+00      1.2e+00      1.2e+00      1.2e+00      1.2e+00
+mp3          soundfile.write               1.0e+00      1.0e+00      1.0e+00      1.0e+00      1.0e+00      1.0e+00
+mp3          ffmpeg-cli                    1.2e+00      1.2e+00      1.2e+00      1.2e+00      1.2e+00      1.2e+00
+----------------------------------------------------------------------------------------------------------------------------------
+m4a_aac      torchcodec.AudioEncoder       1.4e+00      1.4e+00        ERR          ERR        1.3e+00      1.4e+00
+m4a_aac      torchaudio.save               1.4e+00      1.4e+00        ERR          ERR        1.3e+00      1.4e+00
+m4a_aac      soundfile.write          WRITE FAILED
+m4a_aac      ffmpeg-cli                    1.4e+00      1.4e+00        ERR          ERR        1.3e+00      1.4e+00
+----------------------------------------------------------------------------------------------------------------------------------
+==================================================================================================================================
+### ROUND-TRIP: signal=f32   (EXACT = bit-identical float32; else max |diff|; ERR = decoder failed)
+==================================================================================================================================
+target       encoder                  torchcodec.A torchaudio.l soundfile.re soundfile.re librosa.load   ffmpeg-cli
+wav_pcm16    torchcodec.AudioEncoder       1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+wav_pcm16    torchaudio.save               1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+wav_pcm16    soundfile.write               3.0e-05      3.0e-05      3.0e-05      3.0e-05      3.0e-05      3.0e-05
+wav_pcm16    ffmpeg-cli                    1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+----------------------------------------------------------------------------------------------------------------------------------
+wav_pcm24    torchcodec.AudioEncoder       1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+wav_pcm24    torchaudio.save               1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+wav_pcm24    soundfile.write               1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07
+wav_pcm24    ffmpeg-cli                    1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07
+----------------------------------------------------------------------------------------------------------------------------------
+wav_pcm32    torchcodec.AudioEncoder       1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+wav_pcm32    torchaudio.save               1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+wav_pcm32    soundfile.write               2.3e-10      2.3e-10      2.3e-10      2.3e-10      2.3e-10      2.3e-10
+wav_pcm32    ffmpeg-cli                    2.3e-10      2.3e-10      2.3e-10      2.3e-10      2.3e-10      2.3e-10
+----------------------------------------------------------------------------------------------------------------------------------
+wav_float32  torchcodec.AudioEncoder       1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+wav_float32  torchaudio.save               1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+wav_float32  soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float32  ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+wav_float64  torchcodec.AudioEncoder       1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+wav_float64  torchaudio.save               1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+wav_float64  soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float64  ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+flac_16      torchcodec.AudioEncoder       1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07
+flac_16      torchaudio.save               1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07
+flac_16      soundfile.write               1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+flac_16      ffmpeg-cli                    1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05      1.5e-05
+----------------------------------------------------------------------------------------------------------------------------------
+flac_24      torchcodec.AudioEncoder       1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07
+flac_24      torchaudio.save               1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07
+flac_24      soundfile.write               6.0e-08      6.0e-08      6.0e-08      6.0e-08      6.0e-08      6.0e-08
+flac_24      ffmpeg-cli                    1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07      1.2e-07
+----------------------------------------------------------------------------------------------------------------------------------
+ogg_vorbis   torchcodec.AudioEncoder       1.2e-07      1.2e-07        ERR          ERR        1.5e-05      1.2e-07
+ogg_vorbis   torchaudio.save               1.2e-07      1.2e-07        ERR          ERR        1.5e-05      1.2e-07
+ogg_vorbis   soundfile.write               7.6e-01      7.6e-01      7.6e-01      7.6e-01      7.6e-01      7.6e-01
+ogg_vorbis   ffmpeg-cli               WRITE FAILED
+----------------------------------------------------------------------------------------------------------------------------------
+opus         torchcodec.AudioEncoder  WRITE FAILED
+opus         torchaudio.save          WRITE FAILED
+opus         soundfile.write          WRITE FAILED
+opus         ffmpeg-cli                    2.1e+00      2.1e+00      2.1e+00      2.1e+00      2.1e+00      2.1e+00
+----------------------------------------------------------------------------------------------------------------------------------
+mp3          torchcodec.AudioEncoder       1.5e+00      1.5e+00      1.5e+00      1.5e+00      1.5e+00      1.5e+00
+mp3          torchaudio.save               1.5e+00      1.5e+00      1.5e+00      1.5e+00      1.5e+00      1.5e+00
+mp3          soundfile.write               1.1e+00      1.1e+00      1.1e+00      1.1e+00      1.1e+00      1.1e+00
+mp3          ffmpeg-cli                    1.5e+00      1.5e+00      1.5e+00      1.5e+00      1.5e+00      1.5e+00
+----------------------------------------------------------------------------------------------------------------------------------
+m4a_aac      torchcodec.AudioEncoder       1.7e+00      1.7e+00        ERR          ERR        1.3e+00      1.7e+00
+m4a_aac      torchaudio.save               1.7e+00      1.7e+00        ERR          ERR        1.3e+00      1.7e+00
+m4a_aac      soundfile.write          WRITE FAILED
+m4a_aac      ffmpeg-cli                    1.7e+00      1.7e+00        ERR          ERR        1.3e+00      1.7e+00
+----------------------------------------------------------------------------------------------------------------------------------
+==================================================================================================================================
+### ROUND-TRIP: signal=q16_stereo   (EXACT = bit-identical float32; else max |diff|; ERR = decoder failed)
+==================================================================================================================================
+target       encoder                  torchcodec.A torchaudio.l soundfile.re soundfile.re librosa.load   ffmpeg-cli
+wav_pcm16    torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm16    torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm16    soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm16    ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+wav_pcm24    torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm24    torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm24    soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm24    ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+wav_pcm32    torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm32    torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm32    soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_pcm32    ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+wav_float32  torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float32  torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float32  soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float32  ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+wav_float64  torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float64  torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float64  soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+wav_float64  ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+flac_16      torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_16      torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_16      soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_16      ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+flac_24      torchcodec.AudioEncoder        EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_24      torchaudio.save                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_24      soundfile.write                EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+flac_24      ffmpeg-cli                     EXACT        EXACT        EXACT        EXACT        EXACT        EXACT 
+----------------------------------------------------------------------------------------------------------------------------------
+ogg_vorbis   torchcodec.AudioEncoder        EXACT        EXACT         ERR          ERR         EXACT        EXACT 
+ogg_vorbis   torchaudio.save                EXACT        EXACT         ERR          ERR         EXACT        EXACT 
+ogg_vorbis   soundfile.write               1.7e+00      1.7e+00      1.7e+00      1.7e+00      1.7e+00      1.7e+00
+ogg_vorbis   ffmpeg-cli                    9.7e-01      9.7e-01      9.5e-01      9.5e-01      9.5e-01      9.7e-01
+----------------------------------------------------------------------------------------------------------------------------------
+opus         torchcodec.AudioEncoder  WRITE FAILED
+opus         torchaudio.save          WRITE FAILED
+opus         soundfile.write          WRITE FAILED
+opus         ffmpeg-cli                    2.4e+00      2.4e+00      2.4e+00      2.4e+00      2.4e+00      2.4e+00
+----------------------------------------------------------------------------------------------------------------------------------
+mp3          torchcodec.AudioEncoder       1.3e+00      1.3e+00      1.3e+00      1.3e+00      1.3e+00      1.3e+00
+mp3          torchaudio.save               1.3e+00      1.3e+00      1.3e+00      1.3e+00      1.3e+00      1.3e+00
+mp3          soundfile.write               1.2e+00      1.2e+00      1.2e+00      1.2e+00      1.2e+00      1.2e+00
+mp3          ffmpeg-cli                    1.3e+00      1.3e+00      1.3e+00      1.3e+00      1.3e+00      1.3e+00
+----------------------------------------------------------------------------------------------------------------------------------
+m4a_aac      torchcodec.AudioEncoder       1.8e+00      1.8e+00        ERR          ERR        1.9e+00      1.8e+00
+m4a_aac      torchaudio.save               1.8e+00      1.8e+00        ERR          ERR        1.9e+00      1.8e+00
+m4a_aac      soundfile.write          WRITE FAILED
+m4a_aac      ffmpeg-cli                    1.8e+00      1.8e+00        ERR          ERR        1.9e+00      1.8e+00
+----------------------------------------------------------------------------------------------------------------------------------
+
+==================================================================================================================================
+### OUT-OF-RANGE (signal peak 3.0, tail = flat 1.5).  peak = |max| read back; distinct = unique values; W = warnings at write
+==================================================================================================================================
+target       encoder                  wr   W     torchcodec.dec   soundfile.read       ffmpeg-cli
+wav_pcm16    torchcodec.AudioEncoder  ok   0    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+wav_pcm16    torchaudio.save          ok   3    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+wav_pcm16    soundfile.write          ok   0    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+wav_pcm16    ffmpeg-cli               ok   0    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+----------------------------------------------------------------------------------------------------------------------------------
+wav_pcm24    torchcodec.AudioEncoder  ok   0    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+wav_pcm24    torchaudio.save          ok   3    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+wav_pcm24    soundfile.write          ok   0    pk=1.0000 n=652  pk=1.0000 n=652  pk=1.0000 n=652
+wav_pcm24    ffmpeg-cli               ok   0    pk=1.0000 n=652  pk=1.0000 n=652  pk=1.0000 n=652
+----------------------------------------------------------------------------------------------------------------------------------
+wav_pcm32    torchcodec.AudioEncoder  ok   0    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+wav_pcm32    torchaudio.save          ok   3    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+wav_pcm32    soundfile.write          ok   0    pk=1.0000 n=652  pk=1.0000 n=652  pk=1.0000 n=652
+wav_pcm32    ffmpeg-cli               ok   0    pk=1.0000 n=652  pk=1.0000 n=652  pk=1.0000 n=652
+----------------------------------------------------------------------------------------------------------------------------------
+wav_float32  torchcodec.AudioEncoder  ok   0    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+wav_float32  torchaudio.save          ok   3    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+wav_float32  soundfile.write          ok   0   pk=2.9985 n=2001 pk=2.9985 n=2001 pk=2.9985 n=2001
+wav_float32  ffmpeg-cli               ok   0   pk=2.9985 n=2001 pk=2.9985 n=2001 pk=2.9985 n=2001
+----------------------------------------------------------------------------------------------------------------------------------
+wav_float64  torchcodec.AudioEncoder  ok   0    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+wav_float64  torchaudio.save          ok   3    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+wav_float64  soundfile.write          ok   0   pk=2.9985 n=2001 pk=2.9985 n=2001 pk=2.9985 n=2001
+wav_float64  ffmpeg-cli               ok   0   pk=2.9985 n=2001 pk=2.9985 n=2001 pk=2.9985 n=2001
+----------------------------------------------------------------------------------------------------------------------------------
+flac_16      torchcodec.AudioEncoder  ok   0    pk=1.0000 n=652  pk=1.0000 n=652  pk=1.0000 n=652
+flac_16      torchaudio.save          ok   2    pk=1.0000 n=652  pk=1.0000 n=652  pk=1.0000 n=652
+flac_16      soundfile.write          ok   0    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+flac_16      ffmpeg-cli               ok   0    pk=1.0000 n=651  pk=1.0000 n=651  pk=1.0000 n=651
+----------------------------------------------------------------------------------------------------------------------------------
+flac_24      torchcodec.AudioEncoder  ok   0    pk=1.0000 n=652  pk=1.0000 n=652  pk=1.0000 n=652
+flac_24      torchaudio.save          ok   2    pk=1.0000 n=652  pk=1.0000 n=652  pk=1.0000 n=652
+flac_24      soundfile.write          ok   0    pk=1.0000 n=652  pk=1.0000 n=652  pk=1.0000 n=652
+flac_24      ffmpeg-cli               ok   0    pk=1.0000 n=652  pk=1.0000 n=652  pk=1.0000 n=652
+----------------------------------------------------------------------------------------------------------------------------------
+ogg_vorbis   torchcodec.AudioEncoder  ok   0    pk=1.0000 n=652              ERR  pk=1.0000 n=652
+ogg_vorbis   torchaudio.save          ok   1    pk=1.0000 n=652              ERR  pk=1.0000 n=652
+ogg_vorbis   soundfile.write          ok   0   pk=3.5540 n=2688 pk=3.5540 n=2400 pk=3.5540 n=2688
+ogg_vorbis   ffmpeg-cli               FAIL
+----------------------------------------------------------------------------------------------------------------------------------
+opus         torchcodec.AudioEncoder  FAIL
+opus         torchaudio.save          FAIL
+opus         soundfile.write          FAIL
+opus         ffmpeg-cli               ok   0   pk=4.5479 n=5225 pk=4.5479 n=2613 pk=4.5479 n=5225
+----------------------------------------------------------------------------------------------------------------------------------
+mp3          torchcodec.AudioEncoder  ok   0   pk=4.8797 n=2400 pk=4.8797 n=2400 pk=4.8797 n=2400
+mp3          torchaudio.save          ok   1   pk=4.8797 n=2400 pk=4.8797 n=2400 pk=4.8797 n=2400
+mp3          soundfile.write          ok   0   pk=5.2681 n=2400 pk=5.2681 n=2400 pk=5.2681 n=2400
+mp3          ffmpeg-cli               ok   0   pk=4.8797 n=2400 pk=4.8797 n=2400 pk=4.8797 n=2400
+----------------------------------------------------------------------------------------------------------------------------------
+m4a_aac      torchcodec.AudioEncoder  ok   0   pk=5.0081 n=2625              ERR pk=5.0081 n=2625
+m4a_aac      torchaudio.save          ok   1   pk=5.0081 n=2625              ERR pk=5.0081 n=2625
+m4a_aac      soundfile.write          FAIL
+m4a_aac      ffmpeg-cli               ok   0   pk=5.0081 n=2625              ERR pk=5.0081 n=2625
+----------------------------------------------------------------------------------------------------------------------------------
+
+### SAMPLE RATE / CHANNEL preservation (signal=q16_stereo unless noted)
+wav_pcm16    torchcodec.AudioEncoder  sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_pcm16    torchaudio.save          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_pcm16    soundfile.write          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_pcm16    ffmpeg-cli               sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_pcm24    torchcodec.AudioEncoder  sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_pcm24    torchaudio.save          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_pcm24    soundfile.write          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_pcm24    ffmpeg-cli               sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_pcm32    torchcodec.AudioEncoder  sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_pcm32    torchaudio.save          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_pcm32    soundfile.write          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_pcm32    ffmpeg-cli               sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_float32  torchcodec.AudioEncoder  sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_float32  torchaudio.save          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_float32  soundfile.write          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_float32  ffmpeg-cli               sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_float64  torchcodec.AudioEncoder  sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_float64  torchaudio.save          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_float64  soundfile.write          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+wav_float64  ffmpeg-cli               sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+flac_16      torchcodec.AudioEncoder  sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+flac_16      torchaudio.save          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+flac_16      soundfile.write          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+flac_16      ffmpeg-cli               sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+flac_24      torchcodec.AudioEncoder  sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+flac_24      torchaudio.save          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+flac_24      soundfile.write          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+flac_24      ffmpeg-cli               sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+ogg_vorbis   torchcodec.AudioEncoder  sr_written=22050 sr_libsndfile=None ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+ogg_vorbis   torchaudio.save          sr_written=22050 sr_libsndfile=None ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+ogg_vorbis   soundfile.write          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2048] ref=[2, 2000]
+ogg_vorbis   ffmpeg-cli               sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 1024] ref=[2, 2000]
+opus         ffmpeg-cli               sr_written=48000 sr_libsndfile=24000 ch=2 tc_read_sr=48000 shape=[2, 4354] ref=[2, 2000]
+mp3          torchcodec.AudioEncoder  sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+mp3          torchaudio.save          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+mp3          soundfile.write          sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+mp3          ffmpeg-cli               sr_written=22050 sr_libsndfile=22050 ch=2 tc_read_sr=22050 shape=[2, 2000] ref=[2, 2000]
+m4a_aac      torchcodec.AudioEncoder  sr_written=22050 sr_libsndfile=None ch=2 tc_read_sr=22050 shape=[2, 2048] ref=[2, 2000]
+m4a_aac      torchaudio.save          sr_written=22050 sr_libsndfile=None ch=2 tc_read_sr=22050 shape=[2, 2048] ref=[2, 2000]
+m4a_aac      ffmpeg-cli               sr_written=22050 sr_libsndfile=None ch=2 tc_read_sr=22050 shape=[2, 2048] ref=[2, 2000]
+
+### decoder ERRORS
+ogg_vorbis   torchcodec.AudioEncoder  soundfile.read(f32)      LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__q16.ogg': Error : unknown error in flac decoder.
+ogg_vorbis   torchcodec.AudioEncoder  soundfile.read(f64)      LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchcodec_AudioEncoder__q16.ogg': Error : unknown error in flac decoder.
+ogg_vorbis   torchaudio.save          soundfile.read(f32)      LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__q16.ogg': Error : unknown error in flac decoder.
+ogg_vorbis   torchaudio.save          soundfile.read(f64)      LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/ogg_vorbis__torchaudio_save__q16.ogg': Error : unknown error in flac decoder.
+m4a_aac      torchcodec.AudioEncoder  soundfile.read(f32)      LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__q16.m4a': Format not recognised.
+m4a_aac      torchcodec.AudioEncoder  soundfile.read(f64)      LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchcodec_AudioEncoder__q16.m4a': Format not recognised.
+m4a_aac      torchaudio.save          soundfile.read(f32)      LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__q16.m4a': Format not recognised.
+m4a_aac      torchaudio.save          soundfile.read(f64)      LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__torchaudio_save__q16.m4a': Format not recognised.
+m4a_aac      ffmpeg-cli               soundfile.read(f32)      LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__q16.m4a': Format not recognised.
+m4a_aac      ffmpeg-cli               soundfile.read(f64)      LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work/m4a_aac__ffmpeg_cli__q16.m4a': Format not recognised.
+
+### any write-time warnings anywhere?
+[('wav_pcm16', 'torchaudio.save', 'q16', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_pcm16', 'torchaudio.save', 'f32', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_pcm16', 'torchaudio.save', 'oor', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_pcm16', 'torchaudio.save', 'q16_stereo', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_pcm24', 'torchaudio.save', 'q16', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_pcm24', 'torchaudio.save', 'f32', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_pcm24', 'torchaudio.save', 'oor', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_pcm24', 'torchaudio.save', 'q16_stereo', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_pcm32', 'torchaudio.save', 'q16', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_pcm32', 'torchaudio.save', 'f32', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_pcm32', 'torchaudio.save', 'oor', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_pcm32', 'torchaudio.save', 'q16_stereo', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_float32', 'torchaudio.save', 'q16', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_float32', 'torchaudio.save', 'f32', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_float32', 'torchaudio.save', 'oor', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_float32', 'torchaudio.save', 'q16_stereo', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_float64', 'torchaudio.save', 'q16', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_float64', 'torchaudio.save', 'f32', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_float64', 'torchaudio.save', 'oor', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('wav_float64', 'torchaudio.save', 'q16_stereo', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'encoding' parameter is not fully supported by TorchCodec AudioEncoder.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('flac_16', 'torchaudio.save', 'q16', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('flac_16', 'torchaudio.save', 'f32', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('flac_16', 'torchaudio.save', 'oor', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('flac_16', 'torchaudio.save', 'q16_stereo', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('flac_24', 'torchaudio.save', 'q16', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('flac_24', 'torchaudio.save', 'f32', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('flac_24', 'torchaudio.save', 'oor', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('flac_24', 'torchaudio.save', 'q16_stereo', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension.", "UserWarning: The 'bits_per_sample' parameter is not directly supported by TorchCodec AudioEncoder."]), ('ogg_vorbis', 'torchaudio.save', 'q16', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('ogg_vorbis', 'torchaudio.save', 'f32', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('ogg_vorbis', 'torchaudio.save', 'oor', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('ogg_vorbis', 'torchaudio.save', 'q16_stereo', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('opus', 'torchaudio.save', 'q16', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('opus', 'torchaudio.save', 'f32', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('opus', 'torchaudio.save', 'oor', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('opus', 'torchaudio.save', 'q16_stereo', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('mp3', 'torchaudio.save', 'q16', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('mp3', 'torchaudio.save', 'f32', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('mp3', 'torchaudio.save', 'oor', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('mp3', 'torchaudio.save', 'q16_stereo', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('m4a_aac', 'torchaudio.save', 'q16', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('m4a_aac', 'torchaudio.save', 'f32', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('m4a_aac', 'torchaudio.save', 'oor', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."]), ('m4a_aac', 'torchaudio.save', 'q16_stereo', ["UserWarning: The 'format' parameter is not used by TorchCodec AudioEncoder. Format is determined by the file extension."])]
+
+### decode-time warnings
+('librosa.load', "DeprecationWarning: 'aifc' is deprecated and slated for removal in Python 3.13")
+('librosa.load', "DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13")
+('librosa.load', "DeprecationWarning: 'sunau' is deprecated and slated for removal in Python 3.13")
+('librosa.load', 'FutureWarning: librosa.core.audio.__audioread_load\n\tDeprecated as of librosa version 0.10.0.\n\tIt will be removed in libr')
+('librosa.load', 'UserWarning: PySoundFile failed. Trying audioread instead.')

--- a/specs/20260819-120600-io-invariants/raw/probes_run.txt
+++ b/specs/20260819-120600-io-invariants/raw/probes_run.txt
@@ -1,0 +1,113 @@
+
+====================================================================================================
+## 1. float -> int16 conversion: rounding rule and scale factor per encoder
+====================================================================================================
+   input float         torchcodec   soundfile PCM_16   ffmpeg pcm_s16le
+   0.000000000                  0                  0                  0
+   1.000000000              32767              32767              32767
+  -1.000000000             -32768             -32768             -32768
+   0.500000000              16384              16384              16384
+   0.499984711              16383              16383              16383
+   0.000030518                  1                  1                  1
+   0.000045776                  2                  1                  2
+   0.000076294                  2                  2                  2
+  -0.000045776                 -2                 -2                 -2
+
+note: 1.0 -> 32767 means /32767-ish or clamped; -1.0 -> -32768 means /32768 scale.
+
+====================================================================================================
+## 2. torchcodec AudioEncoder: accepted input dtypes / shapes
+====================================================================================================
+  float32 (1,N)              OK  -> PCM_16 ch=1 frames=100
+  float64 (1,N)              ValueError: Expected float32 samples, got samples.dtype = torch.float64.
+  float16 (1,N)              ValueError: Expected float32 samples, got samples.dtype = torch.float16.
+  int16 (1,N)                ValueError: Expected float32 samples, got samples.dtype = torch.int16.
+  int32 (1,N)                ValueError: Expected float32 samples, got samples.dtype = torch.int32.
+  float32 1-D (N,)           OK  -> PCM_16 ch=1 frames=100
+  float32 (N,1) time-first   RuntimeError: validateSamples, /Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/Encoder.cpp:36, Trying to e
+  float32 non-contig         OK  -> PCM_16 ch=2 frames=100
+  numpy float32              ValueError: Expected samples to be a Tensor, got type(samples) = <class 'numpy.ndarray'>.
+
+====================================================================================================
+## 2b. soundfile.write accepted input dtypes (WAV/FLOAT)
+====================================================================================================
+  float32                    OK -> FLOAT
+  float64                    OK -> FLOAT
+  int16                      OK -> FLOAT
+  int32                      OK -> FLOAT
+  torch float32 tensor       OK -> FLOAT
+
+====================================================================================================
+## 3. torchcodec: which codec/container does each extension select? (no way to override)
+====================================================================================================
+  .wav    -> ffprobe ['pcm_s16le', 's16', 'N/A', 'wav']   |  WAV/PCM_16
+  .flac   -> ffprobe ['flac', 's32', '24', 'flac']   |  FLAC/PCM_24
+  .ogg    -> ffprobe ['flac', 's32', '24', 'ogg']   |  libsndfile: CANNOT READ
+  .oga    -> ffprobe ['flac', 's32', '24', 'ogg']   |  libsndfile: CANNOT READ
+  .opus   -> ffprobe ['opus', 'fltp', 'N/A', 'ogg']   |  OGG/OPUS
+  .mp3    -> ffprobe ['mp3', 'fltp', 'N/A', 'mp3']   |  MP3/MPEG_LAYER_III
+  .m4a    -> ffprobe ['aac', 'fltp', 'N/A', 'mov,mp4,m4a,3gp,3g2,mj2']   |  libsndfile: CANNOT READ
+  .mp4    -> ffprobe ['aac', 'fltp', 'N/A', 'mov,mp4,m4a,3gp,3g2,mj2']   |  libsndfile: CANNOT READ
+  .aac    -> ffprobe ['aac', 'fltp', 'N/A', 'aac']   |  libsndfile: CANNOT READ
+  .wv     -> ffprobe ['wavpack', 'fltp', '32', 'wv']   |  libsndfile: CANNOT READ
+  .caf    -> ffprobe ['pcm_s16be', 's16', 'N/A', 'caf']   |  CAF/PCM_16
+  .aiff   -> ffprobe ['pcm_s16be', 's16', 'N/A', 'aiff']   |  AIFF/PCM_16
+  .w64    -> ffprobe ['pcm_s16le', 's16', 'N/A', 'w64']   |  W64/PCM_16
+  .mka    -> RuntimeError: validateSampleRate, /Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/Enco
+  .webm   -> ffprobe ['opus', 'fltp', 'N/A', 'matroska,webm']   |  libsndfile: CANNOT READ
+
+====================================================================================================
+## 4. metadata preservation (title/comment) on WAV and FLAC
+====================================================================================================
+  soundfile.write+SoundFile attrs -> read back: ? | TAG:title=SENSELAB_TITLE TAG:comment=SENSELAB_COMMENT
+  ffmpeg -metadata -> read back: TAG:title=SENSELAB_TITLE TAG:comment=SENSELAB_COMMENT TAG:encoder=Lavf62.12.100
+  torchcodec: no metadata parameter exists. Tags written: TAG:encoder=Lavf62.12.100
+  AudioDecoder.metadata fields: ['begin_stream_seconds', 'begin_stream_seconds_from_header', 'bit_rate', 'codec', 'duration_seconds', 'duration_seconds_from_header', 'num_channels', 'sample_format', 'sample_rate', 'stream_index']
+  soundfile can read tags? sf.info has no tags; SoundFile.title -> SENSELAB_TITLE
+
+====================================================================================================
+## 5. audio extraction from a video container (mp4: h264 video + aac audio; mkv: vp9 + opus)
+====================================================================================================
+
+  --- mp4_h264_aac (15284 bytes)
+    torchcodec.AudioDecoder      OK shape=(1, 48128) sr=48000
+    torchaudio.load              OK shape=(1, 48128) sr=48000
+    soundfile.read               LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work2/vid_mp4_h264_aac.mp4': Format not recogni
+    librosa.load                 OK shape=(1, 48000) sr=48000
+    ffmpeg-cli                   OK 48128 samples
+
+  --- mkv_vp9_opus (16158 bytes)
+    torchcodec.AudioDecoder      OK shape=(1, 48000) sr=48000
+    torchaudio.load              OK shape=(1, 48000) sr=48000
+    soundfile.read               LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work2/vid_mkv_vp9_opus.mkv': Format not recogni
+    librosa.load                 OK shape=(1, 48000) sr=48000
+    ffmpeg-cli                   OK 48000 samples
+
+  --- mov_h264_pcm (101965 bytes)
+    torchcodec.AudioDecoder      OK shape=(1, 48000) sr=48000
+    torchaudio.load              OK shape=(1, 48000) sr=48000
+    soundfile.read               LibsndfileError: Error opening '/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work2/vid_mov_h264_pcm.mov': Format not recogni
+    librosa.load                 OK shape=(1, 48000) sr=48000
+    ffmpeg-cli                   OK 48000 samples
+
+====================================================================================================
+## 6. senselab Audio: save_to_file / load round-trip (uses torchcodec when available)
+====================================================================================================
+  in-range float32 (peak .9)   .wav   WAV/PCM_16                             exact=False maxdiff=1.526e-05 in_peak=0.8998 out_peak=0.8998 warns=0
+  in-range float32 (peak .9)   .flac  FLAC/PCM_24                            exact=False maxdiff=1.187e-07 in_peak=0.8998 out_peak=0.8998 warns=0
+  in-range float32 (peak .9)   .ogg   libsndfile CANNOT READ (LibsndfileError) exact=False maxdiff=1.187e-07 in_peak=0.8998 out_peak=0.8998 warns=0
+  16-bit exact grid            .wav   WAV/PCM_16                             exact=True  maxdiff=0.000e+00 in_peak=0.9999 out_peak=0.9999 warns=0
+  16-bit exact grid            .flac  FLAC/PCM_24                            exact=True  maxdiff=0.000e+00 in_peak=0.9999 out_peak=0.9999 warns=0
+  16-bit exact grid            .ogg   libsndfile CANNOT READ (LibsndfileError) exact=True  maxdiff=0.000e+00 in_peak=0.9999 out_peak=0.9999 warns=0
+  out-of-range (peak 3.0)      .wav   WAV/PCM_16                             exact=False maxdiff=2.000e+00 in_peak=3.0000 out_peak=1.0000 warns=0
+  out-of-range (peak 3.0)      .flac  FLAC/PCM_24                            exact=False maxdiff=2.000e+00 in_peak=3.0000 out_peak=1.0000 warns=0
+  out-of-range (peak 3.0)      .ogg   libsndfile CANNOT READ (LibsndfileError) exact=False maxdiff=2.000e+00 in_peak=3.0000 out_peak=1.0000 warns=0
+
+====================================================================================================
+## 7. AudioDecoder: implicit resample / channel-fold parameters (silent transform risk)
+====================================================================================================
+  AudioDecoder(**{}) -> shape=(2, 2000) sr=22050
+  AudioDecoder(**{'sample_rate': 16000}) -> shape=(2, 1452) sr=16000
+  AudioDecoder(**{'num_channels': 1}) -> shape=(1, 2000) sr=22050
+  AudioDecoder(**{'sample_rate': 16000, 'num_channels': 1}) -> shape=(1, 1452) sr=16000
+  soundfile equivalent: none (sf.read never resamples); librosa.load(sr=...) resamples; ffmpeg -ar resamples

--- a/specs/20260819-120600-io-invariants/raw/torchcodec_0.16.0_check.txt
+++ b/specs/20260819-120600-io-invariants/raw/torchcodec_0.16.0_check.txt
@@ -1,0 +1,152 @@
+torchcodec 0.16.0  torch 2.13.0  libsndfile 1.2.2
+
+== 1. encode API signature: is there any encoding / bit-depth control now?
+  AudioEncoder.__init__ (self, samples: torch.Tensor, *, sample_rate: int)
+  to_file              (self, dest: str | pathlib.Path, *, bit_rate: int | None = None, num_channels: int | None = None, sample_rate: int | None = None) -> None
+  AudioDecoder.__init__ (self, source: str | pathlib.Path | io.RawIOBase | _io.BufferedReader | bytes | torch.Tensor, *, stream_index: int | None = None, sample_rate: int | None = None, num_channels: int | None = None)
+
+== 2. does encode still silently clamp, and still choose PCM_16 for .wav?
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/check016.py", line 18, in <module>
+    AudioEncoder(samples=flat, sample_rate=SR).to_file(p); wmsg="no warning"
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/encoders/_audio_encoder.py", line 34, in __init__
+    load_core_libraries()
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/_internally_replaced_utils.py", line 145, in load_core_libraries
+    raise RuntimeError(
+RuntimeError: Could not load libtorchcodec. Likely causes:
+          1. FFmpeg is not properly installed in your environment. We support
+             versions 4, 5, 6, 7, 8, and 9, and we attempt to load libtorchcodec
+             for each of those versions. Errors for versions not installed on
+             your system are expected; only the error for your installed FFmpeg
+             version is relevant. On Windows, ensure you've installed the
+             "full-shared" version which ships DLLs.
+          2. The PyTorch version (2.13.0) is not compatible with
+             this version of TorchCodec. Refer to the version compatibility
+             table:
+             https://github.com/pytorch/torchcodec?tab=readme-ov-file#installing-torchcodec.
+          3. Another runtime dependency; see exceptions below.
+
+        The following exceptions were raised as we tried to load libtorchcodec:
+        
+[start of libtorchcodec loading traceback]
+FFmpeg version 9:
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1516, in load_library
+    ctypes.CDLL(path)
+  File "/Users/satra/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/ctypes/__init__.py", line 379, in __init__
+    self._handle = _dlopen(self._name, mode)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+OSError: dlopen(/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core9.dylib, 0x0006): Library not loaded: @rpath/libavutil.61.dylib
+  Referenced from: <C8B8D81C-B294-3F42-8C03-7B266A1D2EF9> /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core9.dylib
+  Reason: no LC_RPATH's found
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/_internally_replaced_utils.py", line 132, in load_core_libraries
+    torch.ops.load_library(core_library_path)
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1518, in load_library
+    raise OSError(f"Could not load this library: {path}") from e
+OSError: Could not load this library: /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core9.dylib
+
+FFmpeg version 8:
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1516, in load_library
+    ctypes.CDLL(path)
+  File "/Users/satra/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/ctypes/__init__.py", line 379, in __init__
+    self._handle = _dlopen(self._name, mode)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+OSError: dlopen(/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core8.dylib, 0x0006): Library not loaded: @rpath/libavutil.60.dylib
+  Referenced from: <CB795C10-4828-3C7F-8ED0-27B197D28AC0> /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core8.dylib
+  Reason: no LC_RPATH's found
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/_internally_replaced_utils.py", line 132, in load_core_libraries
+    torch.ops.load_library(core_library_path)
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1518, in load_library
+    raise OSError(f"Could not load this library: {path}") from e
+OSError: Could not load this library: /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core8.dylib
+
+FFmpeg version 7:
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1516, in load_library
+    ctypes.CDLL(path)
+  File "/Users/satra/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/ctypes/__init__.py", line 379, in __init__
+    self._handle = _dlopen(self._name, mode)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+OSError: dlopen(/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core7.dylib, 0x0006): Library not loaded: @rpath/libavutil.59.dylib
+  Referenced from: <CC95D1CF-5584-390E-A2E3-23EECA6BDEE4> /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core7.dylib
+  Reason: no LC_RPATH's found
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/_internally_replaced_utils.py", line 132, in load_core_libraries
+    torch.ops.load_library(core_library_path)
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1518, in load_library
+    raise OSError(f"Could not load this library: {path}") from e
+OSError: Could not load this library: /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core7.dylib
+
+FFmpeg version 6:
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1516, in load_library
+    ctypes.CDLL(path)
+  File "/Users/satra/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/ctypes/__init__.py", line 379, in __init__
+    self._handle = _dlopen(self._name, mode)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+OSError: dlopen(/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core6.dylib, 0x0006): Library not loaded: @rpath/libavutil.58.dylib
+  Referenced from: <A6181DB4-B946-3F4D-B351-F4D14B1E2B25> /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core6.dylib
+  Reason: no LC_RPATH's found
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/_internally_replaced_utils.py", line 132, in load_core_libraries
+    torch.ops.load_library(core_library_path)
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1518, in load_library
+    raise OSError(f"Could not load this library: {path}") from e
+OSError: Could not load this library: /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core6.dylib
+
+FFmpeg version 5:
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1516, in load_library
+    ctypes.CDLL(path)
+  File "/Users/satra/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/ctypes/__init__.py", line 379, in __init__
+    self._handle = _dlopen(self._name, mode)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+OSError: dlopen(/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core5.dylib, 0x0006): Library not loaded: @rpath/libavutil.57.dylib
+  Referenced from: <A069756C-0A2D-35BD-80C8-E43B38988D9A> /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core5.dylib
+  Reason: no LC_RPATH's found
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/_internally_replaced_utils.py", line 132, in load_core_libraries
+    torch.ops.load_library(core_library_path)
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1518, in load_library
+    raise OSError(f"Could not load this library: {path}") from e
+OSError: Could not load this library: /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core5.dylib
+
+FFmpeg version 4:
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1516, in load_library
+    ctypes.CDLL(path)
+  File "/Users/satra/.local/share/uv/python/cpython-3.12.0-macos-aarch64-none/lib/python3.12/ctypes/__init__.py", line 379, in __init__
+    self._handle = _dlopen(self._name, mode)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+OSError: dlopen(/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core4.dylib, 0x0006): Library not loaded: @rpath/libavutil.56.dylib
+  Referenced from: <45B5DCCD-B7EB-3AF9-A658-A3EEF69BAEE4> /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core4.dylib
+  Reason: no LC_RPATH's found
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/_internally_replaced_utils.py", line 132, in load_core_libraries
+    torch.ops.load_library(core_library_path)
+  File "/private/tmp/tcnew/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1518, in load_library
+    raise OSError(f"Could not load this library: {path}") from e
+OSError: Could not load this library: /private/tmp/tcnew/.venv/lib/python3.12/site-packages/torchcodec/libtorchcodec_core4.dylib
+[end of libtorchcodec loading traceback].

--- a/specs/20260819-120600-io-invariants/scripts/check_torchcodec_0.16.0.py
+++ b/specs/20260819-120600-io-invariants/scripts/check_torchcodec_0.16.0.py
@@ -1,0 +1,106 @@
+import inspect, os, subprocess, warnings
+import numpy as np, soundfile as sf, torch, torchcodec
+from torchcodec.decoders import AudioDecoder
+from torchcodec.encoders import AudioEncoder
+warnings.filterwarnings("error", category=UserWarning)   # make any warning loud
+W="/tmp/tcnew/w"; os.makedirs(W, exist_ok=True); SR=22050
+print(f"torchcodec {torchcodec.__version__}  torch {torch.__version__}  libsndfile {sf.__libsndfile_version__}")
+
+print("\n== 1. encode API signature: is there any encoding / bit-depth control now?")
+print("  AudioEncoder.__init__", inspect.signature(AudioEncoder.__init__))
+print("  to_file             ", inspect.signature(AudioEncoder.to_file))
+print("  AudioDecoder.__init__", inspect.signature(AudioDecoder.__init__))
+
+print("\n== 2. does encode still silently clamp, and still choose PCM_16 for .wav?")
+flat = torch.full((1,1000), 1.5)
+p=os.path.join(W,"flat.wav")
+try:
+    AudioEncoder(samples=flat, sample_rate=SR).to_file(p); wmsg="no warning"
+except UserWarning as e: wmsg=f"WARNED: {e}"
+back = AudioDecoder(p).get_all_samples().data
+print(f"  input flat 1.5 -> subtype={sf.info(p).subtype} peak={back.abs().max().item()} distinct={back.unique().numel()}  [{wmsg}]")
+
+print("\n== 3. extension -> codec map (spot check)")
+x=(torch.rand(1,2000)*0.5)
+for ext in ["wav","flac","ogg","wv","mp3"]:
+    q=os.path.join(W,f"e.{ext}")
+    if os.path.exists(q): os.remove(q)
+    try:
+        AudioEncoder(samples=x, sample_rate=SR).to_file(q)
+        pr=subprocess.run(["ffprobe","-v","error","-select_streams","a:0","-show_entries","stream=codec_name,sample_fmt","-of","default=nw=1:nk=1",q],capture_output=True,text=True).stdout.split()
+        try: si=f"{sf.info(q).format}/{sf.info(q).subtype}"
+        except Exception: si="libsndfile CANNOT READ"
+        print(f"  .{ext:<5} {'/'.join(pr):<22} {si}")
+    except Exception as e: print(f"  .{ext:<5} {type(e).__name__}: {str(e)[:70]}")
+
+print("\n== 4. float round-trip exactness through torchcodec .wav / .wv")
+z=(np.random.default_rng(3).uniform(-0.9,0.9,2000)).astype(np.float32)
+for ext in ["wav","wv"]:
+    q=os.path.join(W,f"r.{ext}")
+    AudioEncoder(samples=torch.from_numpy(z.reshape(1,-1)), sample_rate=SR).to_file(q)
+    a=AudioDecoder(q).get_all_samples().data.numpy()[0]
+    print(f"  .{ext:<4} exact={a.tobytes()==z.tobytes()} maxdiff={np.abs(a-z).max():.3e}")
+
+print("\n== 5. CHUNK == SLICE (each vs its own full decode, alignment searched +/-3000)")
+def align(full,ch,nom,win=3000):
+    n=ch.shape[-1]; best=(None,np.inf,False)
+    for d in range(-win,win+1):
+        s=nom+d
+        if s<0 or s+n>full.shape[-1]: continue
+        seg=full[:,s:s+n]
+        if seg.shape!=ch.shape: continue
+        v=float(np.max(np.abs(seg.astype(np.float64)-ch.astype(np.float64))))
+        if v<best[1]: best=(d,v,bool(seg.tobytes()==ch.astype(np.float32).tobytes()))
+    return best
+sig=(np.random.default_rng(23).integers(-32768,32768,SR*6)/32768.0).astype(np.float32)
+def ffw(p,x,sr,c):
+    subprocess.run(["ffmpeg","-hide_banner","-v","error","-y","-f","f32le","-ar",str(sr),"-ac","1","-i","-"]+c+[p],
+                   input=np.ascontiguousarray(x.astype("<f4")).tobytes(),check=True)
+F={}
+sf.write(os.path.join(W,"c16.wav"),sig,SR,format="WAV",subtype="PCM_16"); F["wav PCM_16"]=("c16.wav",SR)
+sf.write(os.path.join(W,"cf.wav"),sig,SR,format="WAV",subtype="FLOAT");  F["wav FLOAT32"]=("cf.wav",SR)
+sf.write(os.path.join(W,"c24.flac"),sig,SR,format="FLAC",subtype="PCM_24"); F["flac PCM_24"]=("c24.flac",SR)
+ffw(os.path.join(W,"c.mp3"),sig,SR,["-c:a","libmp3lame","-b:a","192k"]); F["mp3 192k"]=("c.mp3",SR)
+ffw(os.path.join(W,"c.m4a"),sig,SR,["-c:a","aac","-b:a","128k"]);        F["m4a aac"]=("c.m4a",SR)
+ffw(os.path.join(W,"c.opus"),sig,48000,["-c:a","libopus"]);              F["opus 48k"]=("c.opus",48000)
+for name,(f,fsr) in F.items():
+    p=os.path.join(W,f); full=AudioDecoder(p).get_all_samples().data.numpy()
+    cells=[]
+    for tag,a0,n0 in [("t=0",0,2048),("odd",5001,2048),("mid",44877,4096)]:
+        a=int(round(a0*fsr/SR)); n=int(round(n0*fsr/SR))
+        s=AudioDecoder(p).get_samples_played_in_range(start_seconds=a/fsr, stop_seconds=(a+n)/fsr)
+        ch=s.data.numpy(); d,m,ex=align(full,ch,a)
+        cells.append(f"{tag}: n={ch.shape[1]} off={d} d={m:.1e} {'EXACT' if ex else 'NO'}")
+    print(f"  {name:<13} full_n={full.shape[1]:<7} " + " | ".join(cells))
+
+print("\n== 6. contiguity: concat 2048-sample chunks vs full decode")
+for name,(f,fsr) in F.items():
+    p=os.path.join(W,f); full=AudioDecoder(p).get_all_samples().data.numpy()
+    parts=[]; a=0
+    while a<full.shape[1]:
+        n=min(2048, full.shape[1]-a)
+        parts.append(AudioDecoder(p).get_samples_played_in_range(start_seconds=a/fsr, stop_seconds=(a+n)/fsr).data.numpy()); a+=2048
+    cat=np.concatenate(parts,axis=1); k=min(cat.shape[1],full.shape[1])
+    print(f"  {name:<13} concat_n={cat.shape[1]:<7} full_n={full.shape[1]:<7} "
+          f"bitexact={cat.shape==full.shape and cat.tobytes()==full.tobytes()} lost={full.shape[1]-cat.shape[1]}")
+
+print("\n== 7. #1601/#1614 regression: chunked decode WITH resampling vs one go")
+p=os.path.join(W,"cf.wav")
+for target in [16000, 8000]:
+    full=AudioDecoder(p, sample_rate=target).get_all_samples().data.numpy()
+    parts=[]; t=0.0; dur=1.2
+    while t < 6.0:
+        s=AudioDecoder(p, sample_rate=target).get_samples_played_in_range(start_seconds=t, stop_seconds=min(t+dur,6.0))
+        parts.append(s.data.numpy()); t+=dur
+    cat=np.concatenate(parts,axis=1); k=min(cat.shape[1],full.shape[1])
+    print(f"  resample->{target}: full_n={full.shape[1]} chunked_n={cat.shape[1]} "
+          f"bitexact={cat.shape==full.shape and cat.tobytes()==full.tobytes()} maxdiff={np.abs(cat[:,:k]-full[:,:k]).max():.3e}")
+
+print("\n== 8. decode range-transparency (float WAV, peak 4.0) and amplitude convention")
+oor=np.concatenate([np.full(200,3.0),np.full(200,-4.0),np.linspace(-4,4,400)]).astype(np.float32)
+q=os.path.join(W,"oor.wav"); sf.write(q,oor,SR,format="WAV",subtype="FLOAT")
+a=AudioDecoder(q).get_all_samples().data.numpy()[0]
+print(f"  float WAV peak 4.0 -> read peak={np.abs(a).max():.5f} bitexact={a.tobytes()==oor.tobytes()}")
+ints=np.array([-32768,-32767,0,32767],dtype=np.int16); q2=os.path.join(W,"fs.wav")
+sf.write(q2,ints,SR,format="WAV",subtype="PCM_16")
+print("  int16 full-scale ->", AudioDecoder(q2).get_all_samples().data.numpy()[0].tolist(), "( /32768 convention expected )")

--- a/specs/20260819-120600-io-invariants/scripts/invariants.py
+++ b/specs/20260819-120600-io-invariants/scripts/invariants.py
@@ -1,0 +1,269 @@
+"""Priority experiments.
+
+A. Is decode source-independent?  dtype / amplitude convention / clamping / normalisation.
+B. Does a streamed or seeked chunk equal the corresponding slice of a full decode, bit-for-bit?
+"""
+
+import os
+import subprocess
+import sys
+import warnings
+
+import numpy as np
+import soundfile as sf
+import torch
+import torchaudio
+from torchcodec.decoders import AudioDecoder
+
+warnings.filterwarnings("ignore")
+W = "/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work3"
+os.makedirs(W, exist_ok=True)
+
+
+def hr(t):
+    print("\n" + "=" * 118 + f"\n## {t}\n" + "=" * 118)
+
+
+def ff_write(path, x, sr, codec):
+    subprocess.run(
+        ["ffmpeg", "-hide_banner", "-v", "error", "-y", "-f", "f32le", "-ar", str(sr), "-ac", str(x.shape[0]),
+         "-i", "-"] + codec + [path],
+        input=np.ascontiguousarray(x.T.astype("<f4")).tobytes(), check=True)
+
+
+# =====================================================================================
+# A. decode standardisation
+# =====================================================================================
+hr("A1. Amplitude convention: full-scale integer sources. Is int16 -32768 -> -1.0 and 32767 -> 32767/32768?")
+sr = 22050
+ints = np.array([-32768, -32767, -16384, 0, 16384, 32766, 32767], dtype=np.int16)
+p = os.path.join(W, "fs16.wav")
+sf.write(p, ints, sr, format="WAV", subtype="PCM_16")
+readers = {
+    "torchcodec.AudioDecoder": lambda q: AudioDecoder(q).get_all_samples().data.numpy(),
+    "torchaudio.load": lambda q: torchaudio.load(q)[0].numpy(),
+    "soundfile.read(f32)": lambda q: sf.read(q, dtype="float32", always_2d=True)[0].T,
+    "soundfile.read(f64)": lambda q: sf.read(q, dtype="float64", always_2d=True)[0].T,
+    "librosa.load": lambda q: np.atleast_2d(__import__("librosa").load(q, sr=None, mono=False)[0]),
+    "ffmpeg-cli(f64)": lambda q: np.frombuffer(
+        subprocess.run(["ffmpeg", "-v", "error", "-i", q, "-f", "f64le", "-"], capture_output=True,
+                       check=True).stdout, dtype="<f8").astype(np.float32).reshape(1, -1),
+}
+print(f"{'reader':<24} " + " ".join(f"{int(v):>12}" for v in ints))
+print(f"{'/32768 reference':<24} " + " ".join(f"{v / 32768:>12.8f}" for v in ints))
+for name, fn in readers.items():
+    try:
+        a = fn(p)[0]
+        print(f"{name:<24} " + " ".join(f"{v:>12.8f}" for v in a))
+    except Exception as e:
+        print(f"{name:<24} {type(e).__name__}: {e}")
+print(f"{'dtype returned':<24} " + ", ".join(f"{n}={fn(p).dtype}" for n, fn in readers.items() if n != 'ffmpeg-cli(f64)'))
+
+hr("A2. THE KEY TEST: float32 WAV with samples beyond +/-1 -- does decode clamp?")
+oor = np.concatenate([np.full(200, 3.0), np.full(200, -2.5), np.full(200, 1.5), np.linspace(-4, 4, 400)]).astype(np.float32)
+for sub, ffc in [("FLOAT", ["-c:a", "pcm_f32le"]), ("DOUBLE", ["-c:a", "pcm_f64le"])]:
+    p = os.path.join(W, f"oor_{sub}.wav")
+    sf.write(p, oor, sr, format="WAV", subtype=sub)
+    print(f"\n  source: WAV/{sub} written by soundfile, true peak = {np.abs(oor).max():.4f}")
+    for name, fn in readers.items():
+        try:
+            a = fn(p)[0]
+            print(f"    {name:<24} peak={np.abs(a).max():<10.5f} min={a.min():<10.5f} max={a.max():<10.5f} "
+                  f"clamped={'YES' if np.abs(a).max() <= 1.0001 else 'no':<4} "
+                  f"exact_vs_source={'YES' if a.shape == oor.shape and a.astype(np.float32).tobytes() == oor.tobytes() else 'no'}")
+        except Exception as e:
+            print(f"    {name:<24} {type(e).__name__}: {str(e)[:80]}")
+    p2 = os.path.join(W, f"oor_ff_{sub}.wav")
+    ff_write(p2, oor.reshape(1, -1), sr, ffc)
+    a = readers["torchcodec.AudioDecoder"](p2)[0]
+    print(f"    (same source written by ffmpeg) torchcodec peak={np.abs(a).max():.5f}")
+
+hr("A3. Does any decode path normalise? Two files differing only by a known gain of 0.1")
+base = (np.random.default_rng(7).uniform(-0.9, 0.9, 20000)).astype(np.float32)
+pairs = {}
+for tag, g in [("loud", 1.0), ("quiet", 0.1)]:
+    for fmt, sub, ext in [("WAV", "FLOAT", "wav"), ("WAV", "PCM_16", "wav"), ("FLAC", "PCM_24", "flac")]:
+        q = os.path.join(W, f"gain_{tag}_{fmt}_{sub}.{ext}")
+        sf.write(q, (base * g).astype(np.float32), sr, format=fmt, subtype=sub)
+        pairs[(tag, f"{fmt}/{sub}")] = q
+for fs in ["WAV/FLOAT", "WAV/PCM_16", "FLAC/PCM_24"]:
+    print(f"\n  {fs}: expected peak ratio quiet/loud = 0.1 exactly (no normalisation)")
+    for name, fn in readers.items():
+        try:
+            pl, pq = np.abs(fn(pairs[("loud", fs)])).max(), np.abs(fn(pairs[("quiet", fs)])).max()
+            rl, rq = float(np.sqrt((fn(pairs[("loud", fs)]) ** 2).mean())), float(np.sqrt((fn(pairs[("quiet", fs)]) ** 2).mean()))
+            print(f"    {name:<24} peak {pl:.6f}/{pq:.6f} ratio={pq / pl:.6f}   rms ratio={rq / rl:.6f}")
+        except Exception as e:
+            print(f"    {name:<24} {type(e).__name__}")
+
+hr("A4. Source-independence: identical audio in 8 containers, decoded by torchcodec. dtype / peak / RMS / length")
+ref = (np.random.default_rng(11).uniform(-0.8, 0.8, 22050 * 2)).astype(np.float32)
+srcs = {}
+sf.write(os.path.join(W, "s_pcm16.wav"), ref, sr, format="WAV", subtype="PCM_16"); srcs["wav PCM_16"] = "s_pcm16.wav"
+sf.write(os.path.join(W, "s_pcm24.wav"), ref, sr, format="WAV", subtype="PCM_24"); srcs["wav PCM_24"] = "s_pcm24.wav"
+sf.write(os.path.join(W, "s_pcm32.wav"), ref, sr, format="WAV", subtype="PCM_32"); srcs["wav PCM_32"] = "s_pcm32.wav"
+sf.write(os.path.join(W, "s_f32.wav"), ref, sr, format="WAV", subtype="FLOAT"); srcs["wav FLOAT32"] = "s_f32.wav"
+sf.write(os.path.join(W, "s_f64.wav"), ref, sr, format="WAV", subtype="DOUBLE"); srcs["wav FLOAT64"] = "s_f64.wav"
+sf.write(os.path.join(W, "s_16.flac"), ref, sr, format="FLAC", subtype="PCM_16"); srcs["flac 16"] = "s_16.flac"
+sf.write(os.path.join(W, "s_24.flac"), ref, sr, format="FLAC", subtype="PCM_24"); srcs["flac 24"] = "s_24.flac"
+ff_write(os.path.join(W, "s.mp3"), ref.reshape(1, -1), sr, ["-c:a", "libmp3lame", "-b:a", "192k"]); srcs["mp3 192k"] = "s.mp3"
+ff_write(os.path.join(W, "s.opus"), ref.reshape(1, -1), 48000, ["-c:a", "libopus"]); srcs["opus (48k src)"] = "s.opus"
+ff_write(os.path.join(W, "s.m4a"), ref.reshape(1, -1), sr, ["-c:a", "aac"]); srcs["m4a aac"] = "s.m4a"
+subprocess.run(["ffmpeg", "-hide_banner", "-v", "error", "-y", "-f", "lavfi", "-i",
+                "testsrc=size=160x120:rate=10:duration=2", "-f", "f32le", "-ar", str(sr), "-ac", "1", "-i", "-",
+                "-c:v", "libx264", "-pix_fmt", "yuv420p", "-c:a", "aac", os.path.join(W, "s.mp4")],
+               input=np.ascontiguousarray(ref.astype("<f4")).tobytes(), check=True)
+srcs["mp4 (video+aac)"] = "s.mp4"
+print(f"  reference: dtype={ref.dtype} n={ref.size} peak={np.abs(ref).max():.6f} rms={np.sqrt((ref**2).mean()):.6f}")
+print(f"\n  {'source':<18} {'dtype':<9} {'n':<8} {'sr':<7} {'peak':<10} {'rms':<10} {'peak/ref':<9} {'exact':<6}")
+for k, f in srcs.items():
+    q = os.path.join(W, f)
+    try:
+        d = AudioDecoder(q)
+        s = d.get_all_samples()
+        a = s.data.numpy()
+        ex = a.shape[1] == ref.size and a[0].tobytes() == ref.tobytes()
+        print(f"  {k:<18} {str(a.dtype):<9} {a.shape[1]:<8} {s.sample_rate:<7} {np.abs(a).max():<10.6f} "
+              f"{np.sqrt((a**2).mean()):<10.6f} {np.abs(a).max() / np.abs(ref).max():<9.5f} {str(ex):<6}")
+    except Exception as e:
+        print(f"  {k:<18} {type(e).__name__}: {str(e)[:70]}")
+
+# =====================================================================================
+# B. chunk == slice
+# =====================================================================================
+hr("B. CHUNK == SLICE.  full = decode whole file; chunk = decode [t0, t1). Compare bit-for-bit.")
+
+SR2 = 22050
+NS = SR2 * 6
+sig = (np.random.default_rng(23).integers(-32768, 32768, NS) / 32768.0).astype(np.float32)  # 16-bit-exact
+
+FILES = {}
+sf.write(os.path.join(W, "c_pcm16.wav"), sig, SR2, format="WAV", subtype="PCM_16"); FILES["wav PCM_16"] = "c_pcm16.wav"
+sf.write(os.path.join(W, "c_f32.wav"), sig, SR2, format="WAV", subtype="FLOAT"); FILES["wav FLOAT32"] = "c_f32.wav"
+sf.write(os.path.join(W, "c_24.flac"), sig, SR2, format="FLAC", subtype="PCM_24"); FILES["flac PCM_24"] = "c_24.flac"
+ff_write(os.path.join(W, "c.mp3"), sig.reshape(1, -1), SR2, ["-c:a", "libmp3lame", "-b:a", "192k"]); FILES["mp3 192k"] = "c.mp3"
+ff_write(os.path.join(W, "c.m4a"), sig.reshape(1, -1), SR2, ["-c:a", "aac", "-b:a", "128k"]); FILES["m4a aac"] = "c.m4a"
+ff_write(os.path.join(W, "c.opus"), sig.reshape(1, -1), 48000, ["-c:a", "libopus"]); FILES["opus 48k"] = "c.opus"
+
+# chunk requests: (start_sample, n_samples) at the file's own rate
+REQS = [("aligned 0", 0, 2048), ("odd offset", 5001, 2048), ("mid-file", SR2 * 2 + 777, 4096),
+        ("late", SR2 * 4, 8192)]
+
+
+def chunk_torchcodec(path, srate, a, n):
+    return AudioDecoder(path).get_samples_played_in_range(
+        start_seconds=a / srate, stop_seconds=(a + n) / srate).data.numpy()
+
+
+def chunk_torchaudio(path, srate, a, n):
+    return torchaudio.load(path, frame_offset=a, num_frames=n)[0].numpy()
+
+
+def chunk_soundfile(path, srate, a, n):
+    x, _ = sf.read(path, dtype="float32", start=a, frames=n, always_2d=True)
+    return x.T
+
+
+def chunk_librosa(path, srate, a, n):
+    import librosa
+    x, _ = librosa.load(path, sr=None, mono=False, offset=a / srate, duration=n / srate)
+    return np.atleast_2d(x)
+
+
+def chunk_ffmpeg(path, srate, a, n):
+    r = subprocess.run(["ffmpeg", "-v", "error", "-ss", f"{a / srate:.9f}", "-i", path, "-t", f"{n / srate:.9f}",
+                        "-f", "f32le", "-"], capture_output=True, check=True)
+    return np.frombuffer(r.stdout, dtype="<f4").reshape(1, -1)
+
+
+def chunk_senselab(path, srate, a, n):
+    sys.path.insert(0, "/Users/satra/software/sensein/senselab/src")
+    from senselab.audio.data_structures.audio import Audio
+    return Audio(filepath=path, offset_in_sec=a / srate, duration_in_sec=n / srate).waveform.numpy()
+
+
+CHUNKERS = {
+    "torchcodec range": chunk_torchcodec,
+    "torchaudio.load(off)": chunk_torchaudio,
+    "soundfile.read(start)": chunk_soundfile,
+    "librosa(offset)": chunk_librosa,
+    "ffmpeg -ss/-t": chunk_ffmpeg,
+    "senselab Audio(off)": chunk_senselab,
+}
+
+
+def best_align(full, ch, nominal, window=200):
+    """Return (best_offset_delta, max_abs_diff at that offset, exact_bool) over +/- window samples."""
+    n = ch.shape[-1]
+    best = (None, np.inf, False)
+    for d in range(-window, window + 1):
+        a = nominal + d
+        if a < 0 or a + n > full.shape[-1]:
+            continue
+        seg = full[:, a:a + n]
+        if seg.shape != ch.shape:
+            continue
+        m = float(np.max(np.abs(seg.astype(np.float64) - ch.astype(np.float64))))
+        if m < best[1]:
+            best = (d, m, bool(seg.tobytes() == ch.astype(np.float32).tobytes()))
+    return best
+
+
+for fname, f in FILES.items():
+    path = os.path.join(W, f)
+    fsr = sf.info(path).samplerate if not f.endswith((".m4a", ".opus")) else int(
+        subprocess.run(["ffprobe", "-v", "error", "-select_streams", "a:0", "-show_entries", "stream=sample_rate",
+                        "-of", "default=nw=1:nk=1", path], capture_output=True, text=True).stdout.strip())
+    full = AudioDecoder(path).get_all_samples().data.numpy()
+    print(f"\n  --- {fname}   (file sr={fsr}, full decode n={full.shape[1]}, input n={NS})")
+    print(f"      {'chunker':<22} {'request':<12} {'got_n':<7} {'nominal_off_delta':<18} {'max|diff|':<12} {'bitexact'}")
+    for tag, a, n in REQS:
+        aa = int(round(a * fsr / SR2))
+        nn = int(round(n * fsr / SR2))
+        for cname, cfn in CHUNKERS.items():
+            try:
+                ch = cfn(path, fsr, aa, nn)
+                if ch.shape[0] != full.shape[0]:
+                    print(f"      {cname:<22} {tag:<12} channel mismatch {ch.shape} vs {full.shape}")
+                    continue
+                d, m, ex = best_align(full, ch, aa)
+                print(f"      {cname:<22} {tag:<12} {ch.shape[1]:<7} {str(d):<18} {m:<12.3e} {ex}")
+            except Exception as e:
+                print(f"      {cname:<22} {tag:<12} {type(e).__name__}: {str(e)[:60]}")
+
+hr("B2. Contiguity: do consecutive chunks concatenate back to the full decode exactly?")
+for fname, f in [("wav PCM_16", "c_pcm16.wav"), ("wav FLOAT32", "c_f32.wav"), ("flac PCM_24", "c_24.flac"),
+                 ("mp3 192k", "c.mp3"), ("m4a aac", "c.m4a")]:
+    path = os.path.join(W, f)
+    full = AudioDecoder(path).get_all_samples().data.numpy()
+    CH = 2048
+    for cname, cfn in [("torchcodec range", chunk_torchcodec), ("soundfile.read(start)", chunk_soundfile),
+                       ("torchaudio.load(off)", chunk_torchaudio)]:
+        try:
+            parts = []
+            a = 0
+            while a < full.shape[1]:
+                parts.append(cfn(path, SR2, a, min(CH, full.shape[1] - a)))
+                a += CH
+            cat = np.concatenate(parts, axis=1)
+            n = min(cat.shape[1], full.shape[1])
+            ex = cat.shape == full.shape and cat.astype(np.float32).tobytes() == full.tobytes()
+            m = float(np.max(np.abs(cat[:, :n].astype(np.float64) - full[:, :n].astype(np.float64))))
+            nmis = int(np.sum(cat[:, :n] != full[:, :n]))
+            print(f"  {fname:<14} {cname:<22} concat_n={cat.shape[1]:<8} full_n={full.shape[1]:<8} "
+                  f"bitexact={str(ex):<6} max|diff|={m:.3e} mismatched_samples={nmis}")
+        except Exception as e:
+            print(f"  {fname:<14} {cname:<22} {type(e).__name__}: {str(e)[:70]}")
+
+hr("B3. senselab Audio.from_stream (soundfile blocks) vs full decode")
+sys.path.insert(0, "/Users/satra/software/sensein/senselab/src")
+from senselab.audio.data_structures.audio import Audio  # noqa: E402
+
+for fname, f in [("wav PCM_16", "c_pcm16.wav"), ("wav FLOAT32", "c_f32.wav"), ("flac PCM_24", "c_24.flac")]:
+    path = os.path.join(W, f)
+    full = Audio(filepath=path).waveform.numpy()
+    cat = np.concatenate([c.waveform.numpy() for c in Audio.from_stream(path, chunk_duration_in_sec=0.25)], axis=1)
+    n = min(cat.shape[1], full.shape[1])
+    print(f"  {fname:<14} stream_n={cat.shape[1]:<8} full_n={full.shape[1]:<8} "
+          f"bitexact={cat.shape == full.shape and cat.tobytes() == full.tobytes()} "
+          f"max|diff|={np.max(np.abs(cat[:, :n] - full[:, :n])):.3e}")

--- a/specs/20260819-120600-io-invariants/scripts/invariants2.py
+++ b/specs/20260819-120600-io-invariants/scripts/invariants2.py
@@ -1,0 +1,201 @@
+"""Focused follow-up:
+  (a) same-library baselines for chunk==slice (previous run mixed decoders into one baseline);
+  (b) wide-window alignment search for mp3/aac to characterise the offset exactly;
+  (c) does torchcodec's AudioSamples.pts_seconds let a caller recover the true position?
+  (d) ffmpeg accurate seek (-ss AFTER -i) vs fast seek (-ss BEFORE -i).
+"""
+
+import os
+import subprocess
+import sys
+import warnings
+
+import numpy as np
+import soundfile as sf
+import torchaudio
+from torchcodec.decoders import AudioDecoder
+
+warnings.filterwarnings("ignore")
+W = "/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work3"
+SR = 22050
+
+
+def hr(t):
+    print("\n" + "=" * 118 + f"\n## {t}\n" + "=" * 118)
+
+
+FILES = {
+    "wav PCM_16": ("c_pcm16.wav", SR),
+    "wav FLOAT32": ("c_f32.wav", SR),
+    "flac PCM_24": ("c_24.flac", SR),
+    "mp3 192k": ("c.mp3", SR),
+    "m4a aac": ("c.m4a", SR),
+    "opus 48k": ("c.opus", 48000),
+}
+
+
+def full_tc(p):
+    return AudioDecoder(p).get_all_samples().data.numpy()
+
+
+def full_ta(p):
+    return torchaudio.load(p)[0].numpy()
+
+
+def full_sf(p):
+    return sf.read(p, dtype="float32", always_2d=True)[0].T
+
+
+def full_ff(p):
+    r = subprocess.run(["ffmpeg", "-v", "error", "-i", p, "-f", "f32le", "-"], capture_output=True, check=True)
+    ch = int(subprocess.run(["ffprobe", "-v", "error", "-select_streams", "a:0", "-show_entries",
+                             "stream=channels", "-of", "default=nw=1:nk=1", p],
+                            capture_output=True, text=True).stdout.strip())
+    return np.frombuffer(r.stdout, dtype="<f4").reshape(-1, ch).T
+
+
+def ch_tc(p, sr, a, n):
+    return AudioDecoder(p).get_samples_played_in_range(
+        start_seconds=a / sr, stop_seconds=(a + n) / sr).data.numpy()
+
+
+def ch_ta(p, sr, a, n):
+    return torchaudio.load(p, frame_offset=a, num_frames=n)[0].numpy()
+
+
+def ch_sf(p, sr, a, n):
+    return sf.read(p, dtype="float32", start=a, frames=n, always_2d=True)[0].T
+
+
+def ch_ff_fast(p, sr, a, n):
+    r = subprocess.run(["ffmpeg", "-v", "error", "-ss", f"{a / sr:.9f}", "-i", p, "-t", f"{n / sr:.9f}",
+                        "-f", "f32le", "-"], capture_output=True, check=True)
+    return np.frombuffer(r.stdout, dtype="<f4").reshape(1, -1)
+
+
+def ch_ff_accurate(p, sr, a, n):
+    r = subprocess.run(["ffmpeg", "-v", "error", "-i", p, "-ss", f"{a / sr:.9f}", "-t", f"{n / sr:.9f}",
+                        "-f", "f32le", "-"], capture_output=True, check=True)
+    return np.frombuffer(r.stdout, dtype="<f4").reshape(1, -1)
+
+
+PAIRS = [
+    ("torchcodec", full_tc, ch_tc),
+    ("torchaudio(=tc)", full_ta, ch_ta),
+    ("soundfile", full_sf, ch_sf),
+    ("ffmpeg -ss BEFORE -i", full_ff, ch_ff_fast),
+    ("ffmpeg -ss AFTER -i", full_ff, ch_ff_accurate),
+]
+
+REQS = [("start 0", 0, 2048), ("odd 5001", 5001, 2048), ("mid", 44100 + 777, 4096)]
+
+
+def align(full, ch, nominal, window=4000):
+    n = ch.shape[-1]
+    best = (None, np.inf, False)
+    for d in range(-window, window + 1):
+        a = nominal + d
+        if a < 0 or a + n > full.shape[-1]:
+            continue
+        seg = full[:, a:a + n]
+        m = float(np.max(np.abs(seg.astype(np.float64) - ch.astype(np.float64))))
+        if m < best[1]:
+            best = (d, m, bool(seg.tobytes() == ch.astype(np.float32).tobytes()))
+    return best
+
+
+hr("B4. chunk == slice, EACH LIBRARY AGAINST ITS OWN FULL DECODE, alignment searched over +/-4000 samples")
+print("   'off' = how far the returned chunk actually sits from where it was requested (samples).")
+for fname, (f, fsr) in FILES.items():
+    p = os.path.join(W, f)
+    print(f"\n  --- {fname} (sr={fsr})")
+    for lname, ffull, fch in PAIRS:
+        try:
+            full = ffull(p)
+        except Exception as e:
+            print(f"      {lname:<22} full decode failed: {type(e).__name__}")
+            continue
+        out = [f"full_n={full.shape[1]}"]
+        for tag, a0, n0 in REQS:
+            a = int(round(a0 * fsr / SR))
+            n = int(round(n0 * fsr / SR))
+            try:
+                ch = fch(p, fsr, a, n)
+                d, m, ex = align(full, ch, a)
+                out.append(f"{tag}: n={ch.shape[1]} off={d} diff={m:.2e} {'EXACT' if ex else '-'}")
+            except Exception as e:
+                out.append(f"{tag}: {type(e).__name__}")
+        print(f"      {lname:<22} " + " | ".join(out))
+
+hr("B5. Does AudioSamples.pts_seconds report the true start of the returned chunk?")
+for fname, (f, fsr) in FILES.items():
+    p = os.path.join(W, f)
+    full = full_tc(p)
+    print(f"\n  --- {fname}")
+    for tag, a0, n0 in REQS:
+        a = int(round(a0 * fsr / SR))
+        n = int(round(n0 * fsr / SR))
+        try:
+            s = AudioDecoder(p).get_samples_played_in_range(start_seconds=a / fsr, stop_seconds=(a + n) / fsr)
+            ch = s.data.numpy()
+            pts_samp = s.pts_seconds * fsr
+            d_req, m_req, ex_req = align(full, ch, a)
+            d_pts, m_pts, ex_pts = align(full, ch, int(round(pts_samp)))
+            print(f"      {tag:<10} requested_start={a:<7} pts_seconds={s.pts_seconds:.9f} "
+                  f"(= sample {pts_samp:.1f})  n={ch.shape[1]:<5} "
+                  f"align_vs_requested off={d_req} diff={m_req:.2e}  "
+                  f"align_vs_pts off={d_pts} diff={m_pts:.2e} exact={ex_pts}")
+        except Exception as e:
+            print(f"      {tag:<10} {type(e).__name__}: {str(e)[:80]}")
+
+hr("B6. mp3: what exactly does the range API drop? sweep chunk starts, report returned length")
+p = os.path.join(W, "c.mp3")
+full = full_tc(p)
+print(f"  full decode n={full.shape[1]}; input was {SR*6}")
+for a in [0, 1, 100, 576, 1105, 1106, 2048, 5001, 22050]:
+    n = 2048
+    s = AudioDecoder(p).get_samples_played_in_range(start_seconds=a / SR, stop_seconds=(a + n) / SR)
+    ch = s.data.numpy()
+    d, m, ex = align(full, ch, a, 4000)
+    print(f"    request start={a:<7} n_req={n} -> n_got={ch.shape[1]:<6} pts={s.pts_seconds:.9f} "
+          f"(sample {s.pts_seconds*SR:.1f})  best_off_vs_requested={d} diff={m:.2e} exact={ex}")
+
+hr("B7. Cross-library agreement on a FULL decode of the same file (decoder identity, not chunking)")
+for fname, (f, fsr) in FILES.items():
+    p = os.path.join(W, f)
+    dec = {}
+    for lname, ffull, _ in PAIRS[:4]:
+        try:
+            dec[lname] = ffull(p)
+        except Exception as e:
+            dec[lname] = None
+    base = dec.get("torchcodec")
+    row = []
+    for lname, a in dec.items():
+        if a is None:
+            row.append(f"{lname}=ERR")
+        elif base is None:
+            row.append(f"{lname}=n/a")
+        elif a.shape == base.shape:
+            row.append(f"{lname}: n={a.shape[1]} {'EXACT' if a.tobytes() == base.tobytes() else f'diff={np.abs(a-base).max():.2e}'}")
+        else:
+            row.append(f"{lname}: n={a.shape[1]} (len differs by {a.shape[1]-base.shape[1]})")
+    print(f"  {fname:<14} " + " | ".join(row))
+
+hr("B8. senselab Audio: does its offset/duration path inherit the mp3 defect? (uses torchcodec range)")
+sys.path.insert(0, "/Users/satra/software/sensein/senselab/src")
+from senselab.audio.data_structures.audio import Audio  # noqa: E402
+
+for fname, (f, fsr) in FILES.items():
+    p = os.path.join(W, f)
+    full = Audio(filepath=p).waveform.numpy()
+    for tag, a0, n0 in [("odd 5001", 5001, 2048)]:
+        a = int(round(a0 * fsr / SR))
+        n = int(round(n0 * fsr / SR))
+        try:
+            ch = Audio(filepath=p, offset_in_sec=a / fsr, duration_in_sec=n / fsr).waveform.numpy()
+            d, m, ex = align(full, ch, a, 4000)
+            print(f"  {fname:<14} full_n={full.shape[1]:<8} chunk_n={ch.shape[1]:<6} "
+                  f"off_from_requested={d} max|diff|={m:.3e} bitexact={ex}")
+        except Exception as e:
+            print(f"  {fname:<14} {type(e).__name__}: {str(e)[:70]}")

--- a/specs/20260819-120600-io-invariants/scripts/invariants3.py
+++ b/specs/20260819-120600-io-invariants/scripts/invariants3.py
@@ -1,0 +1,92 @@
+"""Closing two decode-side gaps:
+  C. PER-SEGMENT normalisation: a file whose halves differ by 60 dB. If any path normalised
+     per segment, the quiet chunk would come back boosted relative to its slice.
+  D. Frame-boundary dependence of seeked chunks for mp3 / aac / opus: sweep the offset across
+     a codec frame and report where chunk != slice and by how much.
+"""
+import os, subprocess, warnings
+import numpy as np, soundfile as sf, torchaudio
+from torchcodec.decoders import AudioDecoder
+warnings.filterwarnings("ignore")
+W = "/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work5"; os.makedirs(W, exist_ok=True)
+SR = 22050
+
+def hr(t): print("\n" + "=" * 112 + f"\n## {t}\n" + "=" * 112)
+
+def ffw(p, x, sr, codec):
+    subprocess.run(["ffmpeg","-hide_banner","-v","error","-y","-f","f32le","-ar",str(sr),"-ac","1","-i","-"]
+                   + codec + [p], input=np.ascontiguousarray(x.astype("<f4")).tobytes(), check=True)
+
+# ---- C. per-segment normalisation ----
+hr("C. Per-segment normalisation test: loud half (peak 0.9) then quiet half (peak 0.0009, -60 dB)")
+n = SR * 3
+rng = np.random.default_rng(41)
+loud  = rng.uniform(-0.9, 0.9, n).astype(np.float32)
+quiet = (rng.uniform(-0.9, 0.9, n) * 1e-3).astype(np.float32)
+sig = np.concatenate([loud, quiet]).astype(np.float32)
+print(f"  file: loud-half peak={np.abs(loud).max():.6f}  quiet-half peak={np.abs(quiet).max():.9f}  ratio={np.abs(quiet).max()/np.abs(loud).max():.3e}")
+
+files = {}
+sf.write(os.path.join(W,"d_f32.wav"), sig, SR, format="WAV", subtype="FLOAT"); files["wav FLOAT32"]=("d_f32.wav",SR)
+sf.write(os.path.join(W,"d_p16.wav"), sig, SR, format="WAV", subtype="PCM_16"); files["wav PCM_16"]=("d_p16.wav",SR)
+sf.write(os.path.join(W,"d_24.flac"), sig, SR, format="FLAC", subtype="PCM_24"); files["flac PCM_24"]=("d_24.flac",SR)
+ffw(os.path.join(W,"d.mp3"), sig, SR, ["-c:a","libmp3lame","-b:a","192k"]); files["mp3 192k"]=("d.mp3",SR)
+ffw(os.path.join(W,"d.m4a"), sig, SR, ["-c:a","aac","-b:a","128k"]);        files["m4a aac"]=("d.m4a",SR)
+ffw(os.path.join(W,"d.opus"), sig, 48000, ["-c:a","libopus"]);              files["opus 48k"]=("d.opus",48000)
+
+READERS = {
+  "torchcodec": (lambda p: AudioDecoder(p).get_all_samples().data.numpy(),
+                 lambda p,sr,a,nn: AudioDecoder(p).get_samples_played_in_range(start_seconds=a/sr, stop_seconds=(a+nn)/sr).data.numpy()),
+  "torchaudio": (lambda p: torchaudio.load(p)[0].numpy(),
+                 lambda p,sr,a,nn: torchaudio.load(p, frame_offset=a, num_frames=nn)[0].numpy()),
+  "soundfile":  (lambda p: sf.read(p, dtype="float32", always_2d=True)[0].T,
+                 lambda p,sr,a,nn: sf.read(p, dtype="float32", start=a, frames=nn, always_2d=True)[0].T),
+  "ffmpeg -ss after -i": (
+      lambda p: np.frombuffer(subprocess.run(["ffmpeg","-v","error","-i",p,"-f","f32le","-"],capture_output=True,check=True).stdout,dtype="<f4").reshape(1,-1),
+      lambda p,sr,a,nn: np.frombuffer(subprocess.run(["ffmpeg","-v","error","-i",p,"-ss",f"{a/sr:.9f}","-t",f"{nn/sr:.9f}","-f","f32le","-"],capture_output=True,check=True).stdout,dtype="<f4").reshape(1,-1)),
+}
+print(f"\n  {'format':<13} {'reader':<20} {'quiet-chunk peak':<18} {'slice peak':<14} {'chunk/slice':<13} {'bitexact'}")
+for fname,(f,fsr) in files.items():
+    p = os.path.join(W,f)
+    a = int(round(n * fsr/SR)); nn = int(round(SR*1.0 * fsr/SR))
+    for rname,(rfull,rch) in READERS.items():
+        try:
+            full = rfull(p); ch = rch(p,fsr,a,nn)
+            sl = full[:, a:a+ch.shape[1]]
+            pk_c, pk_s = float(np.abs(ch).max()), float(np.abs(sl).max())
+            ex = sl.shape==ch.shape and sl.tobytes()==ch.astype(np.float32).tobytes()
+            print(f"  {fname:<13} {rname:<20} {pk_c:<18.9f} {pk_s:<14.9f} {pk_c/pk_s if pk_s else float('nan'):<13.6f} {ex}")
+        except Exception as e:
+            print(f"  {fname:<13} {rname:<20} {type(e).__name__}: {str(e)[:50]}")
+
+# ---- D. frame-boundary sweep ----
+hr("D. Frame-boundary dependence: sweep seek offset over one codec frame, chunk vs own-full-decode slice")
+def align(full, ch, nominal, window=3000):
+    m0 = ch.shape[-1]; best=(None,np.inf,False)
+    for d in range(-window,window+1):
+        s=nominal+d
+        if s<0 or s+m0>full.shape[-1]: continue
+        seg=full[:, s:s+m0]
+        if seg.shape!=ch.shape: continue
+        v=float(np.max(np.abs(seg.astype(np.float64)-ch.astype(np.float64))))
+        if v<best[1]: best=(d,v,bool(seg.tobytes()==ch.astype(np.float32).tobytes()))
+    return best
+
+# frame sizes: mp3=1152, aac=1024, opus=960 @48k
+for fname,(f,fsr,frame) in {"mp3 192k":("d.mp3",SR,1152), "m4a aac":("d.m4a",SR,1024), "opus 48k":("d.opus",48000,960)}.items():
+    p=os.path.join(W,f)
+    print(f"\n  --- {fname} (frame={frame} samples).  base offset = 1.0 s, then +0..frame in steps")
+    for rname,(rfull,rch) in READERS.items():
+        try: full=rfull(p)
+        except Exception as e:
+            print(f"      {rname:<20} full decode {type(e).__name__}"); continue
+        base=int(round(SR*1.0*fsr/SR)); nn=2048
+        offs=[base+k for k in [0,1,frame//4,frame//2,frame-1,frame,frame+1,2*frame]]
+        cells=[]
+        for a in offs:
+            try:
+                ch=rch(p,fsr,a,nn); d,m,ex=align(full,ch,a)
+                cells.append(f"+{a-base}:n={ch.shape[1]},off={d},d={m:.1e}{'!' if not ex else ''}")
+            except Exception as e: cells.append(f"+{a-base}:{type(e).__name__}")
+        print(f"      {rname:<20} " + "  ".join(cells))
+print("\n  ('!' marks a chunk that is NOT bit-identical to the slice of that same library's full decode)")

--- a/specs/20260819-120600-io-invariants/scripts/matrix.py
+++ b/specs/20260819-120600-io-invariants/scripts/matrix.py
@@ -1,0 +1,353 @@
+"""Audio I/O path matrix: encode paths x decode paths x formats x signals.
+
+Read-only w.r.t. the senselab repo; writes only into its own tmp dir.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import warnings
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import soundfile as sf
+import torch
+
+TMP = os.environ.get("IOAUDIT_TMP", "/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work")
+os.makedirs(TMP, exist_ok=True)
+
+SR = 22050
+
+# ---------------------------------------------------------------- versions
+import librosa  # noqa: E402
+import torchaudio  # noqa: E402
+import torchcodec  # noqa: E402
+from torchcodec.decoders import AudioDecoder  # noqa: E402
+from torchcodec.encoders import AudioEncoder  # noqa: E402
+
+VERSIONS = {
+    "python": sys.version.split()[0],
+    "numpy": np.__version__,
+    "torch": torch.__version__,
+    "torchaudio": torchaudio.__version__,
+    "torchcodec": torchcodec.__version__,
+    "soundfile": sf.__version__,
+    "libsndfile": sf.__libsndfile_version__,
+    "librosa": librosa.__version__,
+    "ffmpeg": subprocess.run(["ffmpeg", "-version"], capture_output=True, text=True).stdout.split("\n")[0],
+}
+
+# ---------------------------------------------------------------- signals
+rng = np.random.default_rng(0)
+
+
+def _q16(n: int) -> np.ndarray:
+    """Values exactly representable as PCM_16 under the /32768 convention."""
+    k = rng.integers(-32768, 32768, size=n).astype(np.int64)
+    return (k.astype(np.float64) / 32768.0).astype(np.float32)
+
+
+def _f32(n: int) -> np.ndarray:
+    return rng.uniform(-0.9, 0.9, size=n).astype(np.float32)
+
+
+N = 2000
+
+SIGNALS: Dict[str, np.ndarray] = {
+    # mono, exactly representable in 16-bit
+    "q16": _q16(N).reshape(1, -1),
+    # mono, arbitrary float32 in range
+    "f32": _f32(N).reshape(1, -1),
+    # mono, out of range: peak 3.0 plus a flat DC block at 1.5
+    "oor": np.concatenate([_f32(N) * (3.0 / 0.9), np.full(400, 1.5, dtype=np.float32)]).reshape(1, -1),
+    # stereo, exactly representable in 16-bit, channels differ
+    "q16_stereo": np.stack([_q16(N), _q16(N)]),
+}
+
+# ---------------------------------------------------------------- targets
+TARGETS: List[Dict[str, Any]] = [
+    dict(
+        id="wav_pcm16",
+        ext="wav",
+        sf=("WAV", "PCM_16"),
+        ffmpeg=["-c:a", "pcm_s16le"],
+        ta=dict(format="wav", encoding="PCM_S", bits_per_sample=16),
+    ),
+    dict(
+        id="wav_pcm24",
+        ext="wav",
+        sf=("WAV", "PCM_24"),
+        ffmpeg=["-c:a", "pcm_s24le"],
+        ta=dict(format="wav", encoding="PCM_S", bits_per_sample=24),
+    ),
+    dict(
+        id="wav_pcm32",
+        ext="wav",
+        sf=("WAV", "PCM_32"),
+        ffmpeg=["-c:a", "pcm_s32le"],
+        ta=dict(format="wav", encoding="PCM_S", bits_per_sample=32),
+    ),
+    dict(
+        id="wav_float32",
+        ext="wav",
+        sf=("WAV", "FLOAT"),
+        ffmpeg=["-c:a", "pcm_f32le"],
+        ta=dict(format="wav", encoding="PCM_F", bits_per_sample=32),
+    ),
+    dict(
+        id="wav_float64",
+        ext="wav",
+        sf=("WAV", "DOUBLE"),
+        ffmpeg=["-c:a", "pcm_f64le"],
+        ta=dict(format="wav", encoding="PCM_F", bits_per_sample=64),
+    ),
+    dict(
+        id="flac_16",
+        ext="flac",
+        sf=("FLAC", "PCM_16"),
+        ffmpeg=["-c:a", "flac", "-sample_fmt", "s16"],
+        ta=dict(format="flac", bits_per_sample=16),
+    ),
+    dict(
+        id="flac_24",
+        ext="flac",
+        sf=("FLAC", "PCM_24"),
+        ffmpeg=["-c:a", "flac", "-sample_fmt", "s32", "-bits_per_raw_sample", "24"],
+        ta=dict(format="flac", bits_per_sample=24),
+    ),
+    dict(
+        id="ogg_vorbis",
+        ext="ogg",
+        sf=("OGG", "VORBIS"),
+        ffmpeg=["-c:a", "vorbis", "-strict", "-2"],
+        ta=dict(format="ogg"),
+    ),
+    dict(
+        id="opus",
+        ext="opus",
+        sf=("OGG", "OPUS"),
+        ffmpeg=["-c:a", "libopus"],
+        ta=dict(format="opus"),
+    ),
+    dict(
+        id="mp3",
+        ext="mp3",
+        sf=("MP3", "MPEG_LAYER_III"),
+        ffmpeg=["-c:a", "libmp3lame"],
+        ta=dict(format="mp3"),
+    ),
+    dict(
+        id="m4a_aac",
+        ext="m4a",
+        sf=None,
+        ffmpeg=["-c:a", "aac"],
+        ta=dict(format="m4a"),
+    ),
+]
+
+LOSSY = {"ogg_vorbis", "opus", "mp3", "m4a_aac"}
+
+
+# ---------------------------------------------------------------- encoders
+def enc_torchcodec(path: str, x: np.ndarray, sr: int, t: Dict) -> None:
+    AudioEncoder(samples=torch.from_numpy(x), sample_rate=sr).to_file(path)
+
+
+def enc_torchaudio(path: str, x: np.ndarray, sr: int, t: Dict) -> None:
+    kw = dict(t["ta"])
+    torchaudio.save(uri=path, src=torch.from_numpy(x), sample_rate=sr, channels_first=True, **kw)
+
+
+def enc_soundfile(path: str, x: np.ndarray, sr: int, t: Dict) -> None:
+    if t["sf"] is None:
+        raise NotImplementedError("libsndfile has no writer for this container")
+    fmt, sub = t["sf"]
+    sf.write(path, x.T, sr, format=fmt, subtype=sub)
+
+
+def enc_ffmpeg(path: str, x: np.ndarray, sr: int, t: Dict) -> None:
+    raw = np.ascontiguousarray(x.T.astype("<f4")).tobytes()
+    cmd = (
+        ["ffmpeg", "-hide_banner", "-nostdin", "-y", "-f", "f32le", "-ar", str(sr), "-ac", str(x.shape[0]), "-i", "-"]
+        + t["ffmpeg"]
+        + [path]
+    )
+    p = subprocess.run(cmd, input=raw, capture_output=True)
+    if p.returncode != 0:
+        raise RuntimeError(p.stderr.decode()[-600:])
+    enc_ffmpeg.last_stderr = p.stderr.decode()  # type: ignore[attr-defined]
+
+
+ENCODERS = {
+    "torchcodec.AudioEncoder": enc_torchcodec,
+    "torchaudio.save": enc_torchaudio,
+    "soundfile.write": enc_soundfile,
+    "ffmpeg-cli": enc_ffmpeg,
+}
+
+
+# ---------------------------------------------------------------- decoders
+def dec_torchcodec(path: str) -> Dict[str, Any]:
+    d = AudioDecoder(path)
+    s = d.get_all_samples()
+    a = s.data.numpy()
+    return dict(data=a, sr=int(s.sample_rate), dtype=str(a.dtype))
+
+
+def dec_torchaudio(path: str) -> Dict[str, Any]:
+    a, sr = torchaudio.load(path)
+    return dict(data=a.numpy(), sr=int(sr), dtype=str(a.numpy().dtype))
+
+
+def dec_soundfile_f32(path: str) -> Dict[str, Any]:
+    a, sr = sf.read(path, dtype="float32", always_2d=True)
+    return dict(data=a.T, sr=int(sr), dtype="float32")
+
+
+def dec_soundfile_f64(path: str) -> Dict[str, Any]:
+    a, sr = sf.read(path, dtype="float64", always_2d=True)
+    return dict(data=a.T.astype(np.float32), sr=int(sr), dtype="float64->float32")
+
+
+def dec_librosa(path: str) -> Dict[str, Any]:
+    a, sr = librosa.load(path, sr=None, mono=False)
+    a = np.atleast_2d(a)
+    return dict(data=a, sr=int(sr), dtype=str(a.dtype))
+
+
+def _ffprobe(path: str) -> Dict[str, Any]:
+    p = subprocess.run(
+        [
+            "ffprobe",
+            "-hide_banner",
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=codec_name,sample_fmt,sample_rate,channels,bits_per_raw_sample,bit_rate",
+            "-show_entries",
+            "format=format_name",
+            "-of",
+            "json",
+            path,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    try:
+        j = json.loads(p.stdout)
+        st = j.get("streams", [{}])[0]
+        st["format_name"] = j.get("format", {}).get("format_name")
+        return st
+    except Exception:
+        return {"error": p.stderr[-300:]}
+
+
+def dec_ffmpeg(path: str) -> Dict[str, Any]:
+    info = _ffprobe(path)
+    ch = int(info.get("channels", 1) or 1)
+    sr = int(info.get("sample_rate", SR) or SR)
+    p = subprocess.run(
+        ["ffmpeg", "-hide_banner", "-nostdin", "-v", "error", "-i", path, "-f", "f64le", "-c:a", "pcm_f64le", "-"],
+        capture_output=True,
+    )
+    if p.returncode != 0:
+        raise RuntimeError(p.stderr.decode()[-400:])
+    a = np.frombuffer(p.stdout, dtype="<f8").reshape(-1, ch).T.astype(np.float32)
+    return dict(data=a, sr=sr, dtype="float64->float32")
+
+
+DECODERS = {
+    "torchcodec.AudioDecoder": dec_torchcodec,
+    "torchaudio.load": dec_torchaudio,
+    "soundfile.read(f32)": dec_soundfile_f32,
+    "soundfile.read(f64)": dec_soundfile_f64,
+    "librosa.load": dec_librosa,
+    "ffmpeg-cli": dec_ffmpeg,
+}
+
+
+# ---------------------------------------------------------------- compare
+def compare(ref: np.ndarray, got: np.ndarray) -> Dict[str, Any]:
+    out: Dict[str, Any] = dict(ref_shape=list(ref.shape), got_shape=list(got.shape))
+    if ref.shape != got.shape:
+        n = min(ref.shape[-1], got.shape[-1])
+        if ref.shape[0] != got.shape[0]:
+            out["exact"] = False
+            out["note"] = "channel count differs"
+            return out
+        # lossy codecs pad/delay: compare the common prefix only, plus best-offset
+        r, g = ref[:, :n], got[:, :n]
+        out["exact"] = False
+        out["note"] = f"length differs by {got.shape[-1] - ref.shape[-1]}"
+        out["max_abs_diff_prefix"] = float(np.max(np.abs(r - g))) if n else None
+        out["got_peak"] = float(np.max(np.abs(got))) if got.size else None
+        out["got_distinct"] = int(np.unique(got).size) if got.size else 0
+        return out
+    d = np.abs(ref.astype(np.float64) - got.astype(np.float64))
+    out["exact"] = bool(ref.tobytes() == got.astype(np.float32).tobytes())
+    out["allclose_bitwise"] = bool(np.array_equal(ref, got.astype(np.float32)))
+    out["max_abs_diff"] = float(d.max()) if d.size else 0.0
+    out["got_peak"] = float(np.max(np.abs(got))) if got.size else None
+    out["got_distinct"] = int(np.unique(got).size) if got.size else 0
+    return out
+
+
+# ---------------------------------------------------------------- run
+results: List[Dict[str, Any]] = []
+
+for t in TARGETS:
+    for enc_name, enc in ENCODERS.items():
+        for sig_name, x in SIGNALS.items():
+            path = os.path.join(TMP, f"{t['id']}__{enc_name.replace('.', '_').replace('-', '_')}__{sig_name}.{t['ext']}")
+            if os.path.exists(path):
+                os.remove(path)
+            rec: Dict[str, Any] = dict(
+                target=t["id"], ext=t["ext"], encoder=enc_name, signal=sig_name, sr_in=SR, ch_in=int(x.shape[0])
+            )
+            with warnings.catch_warnings(record=True) as wl:
+                warnings.simplefilter("always")
+                try:
+                    enc(path, x, SR, t)
+                    rec["write"] = "ok"
+                except Exception as e:  # noqa: BLE001
+                    rec["write"] = "FAIL"
+                    rec["write_error"] = f"{type(e).__name__}: {e}"[:400]
+                rec["write_warnings"] = [f"{w.category.__name__}: {str(w.message)[:200]}" for w in wl]
+            if rec["write"] == "ok":
+                rec["probe"] = _ffprobe(path)
+                try:
+                    i = sf.info(path)
+                    rec["sf_info"] = dict(format=i.format, subtype=i.subtype, sr=i.samplerate, ch=i.channels, frames=i.frames)
+                except Exception as e:  # noqa: BLE001
+                    rec["sf_info"] = {"error": f"{type(e).__name__}: {e}"[:200]}
+                rec["size_bytes"] = os.path.getsize(path)
+                rec["decode"] = {}
+                for dec_name, dec in DECODERS.items():
+                    with warnings.catch_warnings(record=True) as wl:
+                        warnings.simplefilter("always")
+                        try:
+                            r = dec(path)
+                            c = compare(x, r["data"])
+                            c["sr_out"] = r["sr"]
+                            c["sr_preserved"] = r["sr"] == SR
+                            c["read_dtype"] = r["dtype"]
+                            c["warnings"] = [f"{w.category.__name__}: {str(w.message)[:150]}" for w in wl]
+                            rec["decode"][dec_name] = c
+                        except Exception as e:  # noqa: BLE001
+                            rec["decode"][dec_name] = {"error": f"{type(e).__name__}: {e}"[:300]}
+            results.append(rec)
+            print(
+                f"{t['id']:<12} {enc_name:<24} {sig_name:<11} {rec['write']:<5} "
+                f"{rec.get('sf_info', {}).get('subtype') or rec.get('probe', {}).get('codec_name', '')}",
+                flush=True,
+            )
+
+out_path = os.path.join(os.path.dirname(TMP), "matrix.json")
+with open(out_path, "w") as f:
+    json.dump({"versions": VERSIONS, "sr": SR, "results": results}, f, indent=1)
+print("wrote", out_path)

--- a/specs/20260819-120600-io-invariants/scripts/probes.py
+++ b/specs/20260819-120600-io-invariants/scripts/probes.py
@@ -1,0 +1,219 @@
+import json
+import os
+import subprocess
+import warnings
+
+import numpy as np
+import soundfile as sf
+import torch
+import torchaudio
+from torchcodec.decoders import AudioDecoder
+from torchcodec.encoders import AudioEncoder
+
+W = "/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/work2"
+os.makedirs(W, exist_ok=True)
+SR = 22050
+
+
+def hr(t):
+    print("\n" + "=" * 100 + f"\n## {t}\n" + "=" * 100)
+
+
+# ---------------------------------------------------------------- 1. rounding
+hr("1. float -> int16 conversion: rounding rule and scale factor per encoder")
+# values chosen to expose truncation vs round-to-nearest and 32767 vs 32768 scaling
+vals = np.array([0.0, 1.0, -1.0, 0.5, 0.4999847, 1.0 / 32768, 1.5 / 32768, 2.5 / 32768, -1.5 / 32768], dtype=np.float32)
+x = vals.reshape(1, -1)
+rows = {}
+for name, fn in [
+    ("torchcodec", lambda p: AudioEncoder(samples=torch.from_numpy(x), sample_rate=SR).to_file(p)),
+    ("soundfile PCM_16", lambda p: sf.write(p, x.T, SR, format="WAV", subtype="PCM_16")),
+    ("ffmpeg pcm_s16le", lambda p: subprocess.run(
+        ["ffmpeg", "-hide_banner", "-v", "error", "-y", "-f", "f32le", "-ar", str(SR), "-ac", "1", "-i", "-",
+         "-c:a", "pcm_s16le", p], input=np.ascontiguousarray(x.T.astype("<f4")).tobytes(), check=True)),
+]:
+    p = os.path.join(W, f"round_{name.split()[0]}.wav")
+    fn(p)
+    raw, _ = sf.read(p, dtype="int16")
+    rows[name] = raw
+print(f"{'input float':>14} " + " ".join(f"{k:>18}" for k in rows))
+for i, v in enumerate(vals):
+    print(f"{v:>14.9f} " + " ".join(f"{int(rows[k][i]):>18}" for k in rows))
+print("\nnote: 1.0 -> 32767 means /32767-ish or clamped; -1.0 -> -32768 means /32768 scale.")
+
+# ---------------------------------------------------------------- 2. input dtypes
+hr("2. torchcodec AudioEncoder: accepted input dtypes / shapes")
+cases = {
+    "float32 (1,N)": torch.rand(1, 100, dtype=torch.float32) * 0.5,
+    "float64 (1,N)": torch.rand(1, 100, dtype=torch.float64) * 0.5,
+    "float16 (1,N)": (torch.rand(1, 100) * 0.5).to(torch.float16),
+    "int16 (1,N)": (torch.rand(1, 100) * 1000).to(torch.int16),
+    "int32 (1,N)": (torch.rand(1, 100) * 1000).to(torch.int32),
+    "float32 1-D (N,)": torch.rand(100, dtype=torch.float32) * 0.5,
+    "float32 (N,1) time-first": torch.rand(100, 1, dtype=torch.float32) * 0.5,
+    "float32 non-contig": (torch.rand(2, 200, dtype=torch.float32) * 0.5)[:, ::2],
+    "numpy float32": np.random.rand(1, 100).astype(np.float32),
+}
+for k, v in cases.items():
+    p = os.path.join(W, "dt.wav")
+    try:
+        AudioEncoder(samples=v, sample_rate=SR).to_file(p)
+        i = sf.info(p)
+        print(f"  {k:<26} OK  -> {i.subtype} ch={i.channels} frames={i.frames}")
+    except Exception as e:
+        print(f"  {k:<26} {type(e).__name__}: {str(e)[:130]}")
+
+hr("2b. soundfile.write accepted input dtypes (WAV/FLOAT)")
+for k, v in {
+    "float32": np.random.rand(100, 1).astype(np.float32),
+    "float64": np.random.rand(100, 1),
+    "int16": (np.random.rand(100, 1) * 1000).astype(np.int16),
+    "int32": (np.random.rand(100, 1) * 1000).astype(np.int32),
+    "torch float32 tensor": torch.rand(100, 1),
+}.items():
+    p = os.path.join(W, "dt2.wav")
+    try:
+        sf.write(p, v, SR, format="WAV", subtype="FLOAT")
+        print(f"  {k:<26} OK -> {sf.info(p).subtype}")
+    except Exception as e:
+        print(f"  {k:<26} {type(e).__name__}: {str(e)[:130]}")
+
+# ---------------------------------------------------------------- 3. extension -> codec
+hr("3. torchcodec: which codec/container does each extension select? (no way to override)")
+x2 = (torch.rand(1, 2000, dtype=torch.float32) * 0.5)
+for ext in ["wav", "flac", "ogg", "oga", "opus", "mp3", "m4a", "mp4", "aac", "wv", "caf", "aiff", "w64", "mka", "webm"]:
+    p = os.path.join(W, f"ext.{ext}")
+    if os.path.exists(p):
+        os.remove(p)
+    try:
+        AudioEncoder(samples=x2, sample_rate=48000 if ext in ("opus", "webm") else SR).to_file(p)
+        pr = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "a:0", "-show_entries",
+             "stream=codec_name,sample_fmt,bits_per_raw_sample", "-show_entries", "format=format_name",
+             "-of", "default=nw=1:nk=1", p], capture_output=True, text=True).stdout.split()
+        try:
+            si = sf.info(p)
+            sfs = f"{si.format}/{si.subtype}"
+        except Exception:
+            sfs = "libsndfile: CANNOT READ"
+        print(f"  .{ext:<6} -> ffprobe {pr}   |  {sfs}")
+    except Exception as e:
+        print(f"  .{ext:<6} -> {type(e).__name__}: {str(e)[:110]}")
+
+# ---------------------------------------------------------------- 4. metadata
+hr("4. metadata preservation (title/comment) on WAV and FLAC")
+sig = np.random.rand(1000, 1).astype(np.float32) * 0.5
+# soundfile: set via SoundFile attributes
+p_sf = os.path.join(W, "meta_sf.flac")
+with sf.SoundFile(p_sf, "w", SR, 1, format="FLAC", subtype="PCM_24") as f:
+    f.title = "SENSELAB_TITLE"
+    f.comment = "SENSELAB_COMMENT"
+    f.write(sig)
+print("  soundfile.write+SoundFile attrs -> read back:", sf.info(p_sf).__dict__.get("title", "?"), "|",
+      subprocess.run(["ffprobe", "-v", "error", "-show_entries", "format_tags", "-of", "default=nw=1", p_sf],
+                     capture_output=True, text=True).stdout.strip().replace("\n", " "))
+p_ff = os.path.join(W, "meta_ff.flac")
+subprocess.run(["ffmpeg", "-hide_banner", "-v", "error", "-y", "-f", "f32le", "-ar", str(SR), "-ac", "1", "-i", "-",
+                "-c:a", "flac", "-metadata", "title=SENSELAB_TITLE", "-metadata", "comment=SENSELAB_COMMENT", p_ff],
+               input=sig.tobytes(), check=True)
+print("  ffmpeg -metadata -> read back:",
+      subprocess.run(["ffprobe", "-v", "error", "-show_entries", "format_tags", "-of", "default=nw=1", p_ff],
+                     capture_output=True, text=True).stdout.strip().replace("\n", " "))
+p_tc = os.path.join(W, "meta_tc.flac")
+AudioEncoder(samples=torch.from_numpy(sig.T.copy()), sample_rate=SR).to_file(p_tc)
+print("  torchcodec: no metadata parameter exists. Tags written:",
+      subprocess.run(["ffprobe", "-v", "error", "-show_entries", "format_tags", "-of", "default=nw=1", p_tc],
+                     capture_output=True, text=True).stdout.strip().replace("\n", " ") or "(none)")
+# does a decode path expose tags at all?
+print("  AudioDecoder.metadata fields:", [a for a in dir(AudioDecoder(p_ff).metadata) if not a.startswith('_')])
+print("  soundfile can read tags?", "sf.info has no tags;", "SoundFile.title ->",
+      sf.SoundFile(p_ff).title if hasattr(sf.SoundFile(p_ff), "title") else "n/a")
+
+# ---------------------------------------------------------------- 5. video containers
+hr("5. audio extraction from a video container (mp4: h264 video + aac audio; mkv: vp9 + opus)")
+vids = {}
+for name, args in {
+    "mp4_h264_aac": ["-c:v", "libx264", "-pix_fmt", "yuv420p", "-c:a", "aac"],
+    "mkv_vp9_opus": ["-c:v", "libvpx-vp9", "-c:a", "libopus"],
+    "mov_h264_pcm": ["-c:v", "libx264", "-pix_fmt", "yuv420p", "-c:a", "pcm_s16le"],
+}.items():
+    ext = name.split("_")[0]
+    p = os.path.join(W, f"vid_{name}.{ext}")
+    r = subprocess.run(
+        ["ffmpeg", "-hide_banner", "-v", "error", "-y",
+         "-f", "lavfi", "-i", "testsrc=size=160x120:rate=10:duration=1",
+         "-f", "lavfi", "-i", "sine=frequency=440:sample_rate=48000:duration=1"] + args + [p],
+        capture_output=True, text=True)
+    vids[name] = p if r.returncode == 0 else None
+    if r.returncode != 0:
+        print(f"  {name}: could not build fixture: {r.stderr[-200:]}")
+
+for name, p in vids.items():
+    if not p:
+        continue
+    print(f"\n  --- {name} ({os.path.getsize(p)} bytes)")
+    try:
+        d = AudioDecoder(p)
+        s = d.get_all_samples()
+        print(f"    torchcodec.AudioDecoder      OK shape={tuple(s.data.shape)} sr={s.sample_rate}")
+    except Exception as e:
+        print(f"    torchcodec.AudioDecoder      {type(e).__name__}: {str(e)[:110]}")
+    try:
+        a, sr = torchaudio.load(p)
+        print(f"    torchaudio.load              OK shape={tuple(a.shape)} sr={sr}")
+    except Exception as e:
+        print(f"    torchaudio.load              {type(e).__name__}: {str(e)[:110]}")
+    try:
+        a, sr = sf.read(p)
+        print(f"    soundfile.read               OK shape={a.shape} sr={sr}")
+    except Exception as e:
+        print(f"    soundfile.read               {type(e).__name__}: {str(e)[:110]}")
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            import librosa
+            a, sr = librosa.load(p, sr=None, mono=False)
+        print(f"    librosa.load                 OK shape={np.atleast_2d(a).shape} sr={sr}")
+    except Exception as e:
+        print(f"    librosa.load                 {type(e).__name__}: {str(e)[:110]}")
+    r = subprocess.run(["ffmpeg", "-v", "error", "-i", p, "-f", "f32le", "-"], capture_output=True)
+    print(f"    ffmpeg-cli                   {'OK ' + str(len(r.stdout) // 4) + ' samples' if r.returncode == 0 else 'FAIL'}")
+
+# ---------------------------------------------------------------- 6. senselab end-to-end
+hr("6. senselab Audio: save_to_file / load round-trip (uses torchcodec when available)")
+import sys
+sys.path.insert(0, "/Users/satra/software/sensein/senselab/src")
+from senselab.audio.data_structures.audio import Audio  # noqa: E402
+
+for sig_name, arr in {
+    "in-range float32 (peak .9)": (np.random.default_rng(1).uniform(-0.9, 0.9, 2000)).astype(np.float32),
+    "16-bit exact grid": (np.random.default_rng(2).integers(-32768, 32768, 2000) / 32768.0).astype(np.float32),
+    "out-of-range (peak 3.0)": (np.concatenate([np.full(500, 1.5), np.full(500, -3.0), np.full(1000, 0.25)])).astype(np.float32),
+}.items():
+    for ext in ["wav", "flac", "ogg"]:
+        a = Audio(waveform=arr, sampling_rate=SR)
+        p = os.path.join(W, f"sl_{ext}.{ext}")
+        with warnings.catch_warnings(record=True) as wl:
+            warnings.simplefilter("always")
+            a.save_to_file(p, encoding="PCM_F", bits_per_sample=32)
+            nw = [str(w.message)[:60] for w in wl]
+        b = Audio(filepath=p)
+        got = b.waveform.numpy()[0]
+        ref = arr
+        n = min(len(got), len(ref))
+        exact = got.shape == ref.shape and ref.tobytes() == got.tobytes()
+        try:
+            sub = f"{sf.info(p).format}/{sf.info(p).subtype}"
+        except Exception as e:
+            sub = f"libsndfile CANNOT READ ({type(e).__name__})"
+        print(f"  {sig_name:<28} .{ext:<5} {sub:<38} exact={exact!s:<5} "
+              f"maxdiff={np.max(np.abs(ref[:n] - got[:n])):.3e} in_peak={np.max(np.abs(ref)):.4f} "
+              f"out_peak={np.max(np.abs(got)):.4f} warns={len(nw)}")
+
+hr("7. AudioDecoder: implicit resample / channel-fold parameters (silent transform risk)")
+p = os.path.join(W, "res.wav")
+sf.write(p, np.random.rand(2000, 2).astype(np.float32) * 0.5, 22050, format="WAV", subtype="FLOAT")
+for kw in [{}, {"sample_rate": 16000}, {"num_channels": 1}, {"sample_rate": 16000, "num_channels": 1}]:
+    s = AudioDecoder(p, **kw).get_all_samples()
+    print(f"  AudioDecoder(**{kw}) -> shape={tuple(s.data.shape)} sr={s.sample_rate}")
+print("  soundfile equivalent: none (sf.read never resamples); librosa.load(sr=...) resamples; ffmpeg -ar resamples")

--- a/specs/20260819-120600-io-invariants/scripts/summarize.py
+++ b/specs/20260819-120600-io-invariants/scripts/summarize.py
@@ -1,0 +1,120 @@
+import json
+from collections import OrderedDict
+
+d = json.load(open("/Users/satra/.claude/jobs/295c3f8a/tmp/io-audit/matrix.json"))
+R = d["results"]
+
+ENC = ["torchcodec.AudioEncoder", "torchaudio.save", "soundfile.write", "ffmpeg-cli"]
+DEC = ["torchcodec.AudioDecoder", "torchaudio.load", "soundfile.read(f32)", "soundfile.read(f64)", "librosa.load", "ffmpeg-cli"]
+TGT = OrderedDict()
+for r in R:
+    TGT.setdefault(r["target"], None)
+
+
+def get(t, e, s):
+    for r in R:
+        if r["target"] == t and r["encoder"] == e and r["signal"] == s:
+            return r
+    return None
+
+
+def cell(c):
+    if c is None:
+        return "  -   "
+    if "error" in c:
+        return " ERR  "
+    if c.get("exact"):
+        return "EXACT "
+    m = c.get("max_abs_diff", c.get("max_abs_diff_prefix"))
+    if m is None:
+        return " n/a  "
+    if m == 0.0:
+        return "  0e0 "
+    return f"{m:6.1e}"
+
+
+for sig in ["q16", "f32", "q16_stereo"]:
+    print("=" * 130)
+    print(f"### ROUND-TRIP: signal={sig}   (EXACT = bit-identical float32; else max |diff|; ERR = decoder failed)")
+    print("=" * 130)
+    hdr = f"{'target':<12} {'encoder':<24} " + " ".join(f"{x[:12]:>12}" for x in DEC)
+    print(hdr)
+    for t in TGT:
+        for e in ENC:
+            r = get(t, e, sig)
+            if r is None:
+                continue
+            if r["write"] != "ok":
+                print(f"{t:<12} {e:<24} WRITE FAILED")
+                continue
+            row = " ".join(f"{cell(r['decode'].get(dn)):>12}" for dn in DEC)
+            print(f"{t:<12} {e:<24} {row}")
+        print("-" * 130)
+
+print()
+print("=" * 130)
+print("### OUT-OF-RANGE (signal peak 3.0, tail = flat 1.5).  peak = |max| read back; distinct = unique values; W = warnings at write")
+print("=" * 130)
+print(f"{'target':<12} {'encoder':<24} {'wr':<4} {'W':<3} " + " ".join(f"{x[:14]:>16}" for x in ["torchcodec.dec", "soundfile.read", "ffmpeg-cli"]))
+for t in TGT:
+    for e in ENC:
+        r = get(t, e, "oor")
+        if r is None:
+            continue
+        if r["write"] != "ok":
+            print(f"{t:<12} {e:<24} FAIL")
+            continue
+        nw = len(r.get("write_warnings", []))
+        parts = []
+        for dn in ["torchcodec.AudioDecoder", "soundfile.read(f32)", "ffmpeg-cli"]:
+            c = r["decode"].get(dn, {})
+            if "error" in c:
+                parts.append(f"{'ERR':>16}")
+            else:
+                parts.append(f"{'pk=' + format(c.get('got_peak') or 0, '.4f') + ' n=' + str(c.get('got_distinct')):>16}")
+        print(f"{t:<12} {e:<24} {'ok':<4} {nw:<3} " + " ".join(parts))
+    print("-" * 130)
+
+print()
+print("### SAMPLE RATE / CHANNEL preservation (signal=q16_stereo unless noted)")
+for t in TGT:
+    for e in ENC:
+        r = get(t, e, "q16_stereo")
+        if r is None or r["write"] != "ok":
+            continue
+        c = r["decode"].get("torchcodec.AudioDecoder", {})
+        sfi = r.get("sf_info", {})
+        print(
+            f"{t:<12} {e:<24} sr_written={r.get('probe',{}).get('sample_rate')} "
+            f"sr_libsndfile={sfi.get('sr')} ch={r.get('probe',{}).get('channels')} "
+            f"tc_read_sr={c.get('sr_out')} shape={c.get('got_shape')} ref={c.get('ref_shape')}"
+        )
+
+print()
+print("### decoder ERRORS")
+seen = set()
+for r in R:
+    if r["write"] != "ok":
+        continue
+    for dn, c in r.get("decode", {}).items():
+        if "error" in c:
+            k = (r["target"], r["encoder"], dn, c["error"][:80])
+            if k[:3] in seen:
+                continue
+            seen.add(k[:3])
+            print(f"{r['target']:<12} {r['encoder']:<24} {dn:<24} {c['error'][:180]}")
+
+print()
+print("### any write-time warnings anywhere?")
+any_w = [(r["target"], r["encoder"], r["signal"], r["write_warnings"]) for r in R if r.get("write_warnings")]
+print(any_w if any_w else "NONE — no encoder emitted a Python warning in any cell, including out-of-range")
+
+print()
+print("### decode-time warnings")
+dw = set()
+for r in R:
+    for dn, c in r.get("decode", {}).items():
+        for w in c.get("warnings", []):
+            dw.add((dn, w[:120]))
+for x in sorted(dw):
+    print(x)

--- a/specs/20260819-120600-io-invariants/torchcodec-issue-draft.md
+++ b/specs/20260819-120600-io-invariants/torchcodec-issue-draft.md
@@ -1,0 +1,193 @@
+# DRAFTS — not filed. Proposed issues for `meta-pytorch/torchcodec`
+
+**Do not file without a final duplicate check.** Note the repo is `meta-pytorch/torchcodec`.
+
+**The silent-clamping issue is already settled and must NOT be re-filed.**
+[#1576](https://github.com/meta-pytorch/torchcodec/issues/1576) reported exactly our clamping
+behaviour and was closed `not_planned` within six hours: the maintainer's position is that range
+validation is the caller's job because it costs an extra `O(n)` pass. Re-filing it would be a
+duplicate of a deliberate decision. See `upstream.md` for the verbatim exchange.
+
+What *is* unreported, and worth filing, is below: **Draft A** (an MP3 correctness bug, the
+stronger of the two) and **Draft B** (the encoding-parameter feature request, which no issue or PR
+has ever raised — `bits_per_sample` returns zero search results).
+
+Measured on torchcodec **0.11.1** *and independently reproduced on **0.16.0*** (torch 2.13.0,
+FFmpeg 8.1, Python 3.12, macOS arm64) unless noted.
+
+---
+
+# Draft A — `get_all_samples()` and `get_samples_played_in_range()` disagree by 1105 samples on MP3
+
+## Summary
+
+For an MP3 file, `AudioDecoder`'s two entry points index the same stream on two different
+timelines. `get_all_samples()` returns 1105 extra leading samples of decoder pre-roll that
+`get_samples_played_in_range()` excludes. Consequently, for an MP3:
+
+- index `i` of a full decode is presentation sample `i − 1105`;
+- concatenating consecutive ranges over the whole file yields **1105 fewer samples** than
+  `get_all_samples()`;
+- a request with `start_seconds` below sample 1105 **silently short-reads**, returning
+  `n − (1105 − start)` samples with no warning.
+
+The sample *values* are correct once aligned, so this is purely an indexing inconsistency. It is
+also a **constant** shift, independent of where the seek lands relative to a frame boundary, which
+makes it straightforward to reason about and to fix.
+
+Why it matters: any analysis that windows a file via `get_samples_played_in_range` and compares
+against a whole-file analysis of the same file is misaligned by 1105 samples — 50.1 ms at
+22.05 kHz. In our case a windowed level measurement of a quiet passage read **9.9x too loud**,
+because the shifted window straddled a loud/quiet transition.
+
+## Reproducer
+
+```python
+import subprocess
+import numpy as np, soundfile as sf
+from torchcodec.decoders import AudioDecoder
+
+SR = 22050
+sig = (np.random.default_rng(23).integers(-32768, 32768, SR * 6) / 32768.0).astype(np.float32)
+subprocess.run(["ffmpeg","-hide_banner","-v","error","-y","-f","f32le","-ar",str(SR),
+                "-ac","1","-i","-","-c:a","libmp3lame","-b:a","192k","c.mp3"],
+               input=sig.tobytes(), check=True)
+
+full = AudioDecoder("c.mp3").get_all_samples().data.numpy()
+print(full.shape)                                    # (1, 132300)
+
+# a window in the middle
+a, n = 5001, 2048
+s = AudioDecoder("c.mp3").get_samples_played_in_range(
+        start_seconds=a / SR, stop_seconds=(a + n) / SR)
+ch = s.data.numpy()
+
+print(np.abs(full[:, a:a+n] - ch).max())             # 1.8   <- not the requested window
+print(np.abs(full[:, a-1105:a-1105+n] - ch).max())   # 0.0   <- shifted by exactly 1105
+print(s.pts_seconds * SR)                            # 5001.0 (the request WAS honoured on the
+                                                     #         container timeline)
+
+# at the start, a silent short read
+s0 = AudioDecoder("c.mp3").get_samples_played_in_range(start_seconds=0.0, stop_seconds=n / SR)
+print(s0.data.shape[-1], s0.pts_seconds * SR)        # 943  1105.0   (asked for 2048)
+
+# and the whole file, chunked, loses 1105 samples
+parts, t = [], 0
+while t < full.shape[1]:
+    m = min(2048, full.shape[1] - t)
+    parts.append(AudioDecoder("c.mp3").get_samples_played_in_range(
+        start_seconds=t / SR, stop_seconds=(t + m) / SR).data.numpy())
+    t += 2048
+print(np.concatenate(parts, axis=1).shape[-1])       # 131195  vs  132300
+```
+
+1105 = 576 + 529, the standard MPEG MDCT + LAME encoder delay.
+
+## Expected vs. actual
+
+| | expected | actual |
+|---|---|---|
+| `get_all_samples()` vs. concatenated ranges | same samples, same count | ranges total 1105 fewer |
+| `full[a:a+n]` vs. `range(a/sr, (a+n)/sr)` | identical | shifted by 1105 |
+| `range(0, n/sr)` | `n` samples, or a documented reason for fewer | `n − 1105` samples, silently |
+
+WAV, FLAC, Opus and AAC are all exact at every offset tested, so MP3 (and, per
+[#1610](https://github.com/meta-pytorch/torchcodec/issues/1610), MPEG/MPG) look like the affected
+family. This is adjacent to
+[#1601](https://github.com/meta-pytorch/torchcodec/issues/1601) and
+[#1614](https://github.com/meta-pytorch/torchcodec/pull/1614) — #1614 established the principle
+that "decoding in chunks should return identical samples to decoding in one go" and fixed it for
+the resampling case; this is the same principle failing for MP3 pre-roll.
+
+## The ask
+
+Make the two entry points agree — either by having `get_all_samples()` drop the pre-roll (so both
+start at the first presented sample), or by having the range API address the same timeline
+`get_all_samples()` exposes. Failing that, document the offset and stop silently short-reading
+below sample 1105. Note that `AudioSamples.pts_seconds` already reports the true position
+correctly, so the information needed for a fix — or for a caller-side workaround — is present.
+
+## Also reproduced on 0.16.0
+
+Identical numbers: `off = −1105` at every offset, 943-sample short read at `t=0`, 1105 samples
+lost over a chunked full pass.
+
+---
+
+# Draft B — no way to select a sample format / bit depth when encoding
+
+## Summary
+
+`AudioEncoder` chooses the output sample format from the file extension alone, and for every
+lossless target it selects an integer format:
+
+| extension | codec / `sample_fmt` |
+|---|---|
+| `.wav`, `.w64` | `pcm_s16le` / s16 |
+| `.caf`, `.aiff`, `.au` | `pcm_s16be` / s16 |
+| `.flac` | `flac` / s32, 24 bits_per_raw_sample |
+| `.ogg`, `.oga` | `flac` in Ogg / s32, 24 |
+| `.wv` | `wavpack` / **fltp** |
+
+There is no argument that changes this: `to_file` takes only `bit_rate`, `num_channels` and
+`sample_rate`, and `bit_rate` is bits-per-second for lossy codecs, not PCM bit depth. So a caller
+cannot request `pcm_f32le`, `pcm_s24le` or `pcm_s32le`, all of which FFmpeg supports.
+
+Combined with the settled decision in #1576 that range validation is the caller's job, this leaves
+callers with float data outside `[-1, 1]` no correct target at all: the check is theirs to make,
+but the format that would carry the data is not expressible. Writing a float WAV is a normal
+requirement for measurement and research pipelines, where intermediate signals routinely exceed
+unity (enhancement, source separation, spectral inversion, gain staging).
+
+## Reproducer
+
+```python
+import numpy as np, soundfile as sf, torch
+from torchcodec.decoders import AudioDecoder
+from torchcodec.encoders import AudioEncoder
+
+z = (np.random.rand(1000).astype(np.float32) * 6 - 3)          # peak ~3.0
+AudioEncoder(samples=torch.from_numpy(z[None]), sample_rate=16000).to_file("x.wav")
+print(sf.info("x.wav").subtype)                                 # PCM_16  (not requestable)
+print(AudioDecoder("x.wav").get_all_samples().data.abs().max())  # 1.0     (was 3.0)
+
+# both alternatives can express it, and both round-trip bit-exactly:
+sf.write("y.wav", z, 16000, format="WAV", subtype="FLOAT")
+assert sf.read("y.wav", dtype="float32")[0].tobytes() == z.tobytes()
+# ffmpeg -f f32le -ar 16000 -ac 1 -i - -c:a pcm_f32le y2.wav   -- likewise bit-exact
+```
+
+`AudioDecoder` reads such a file back **correctly and unclamped** — peak 4.0 stays 4.0, bit-exact
+— so the capability gap is only on the write side.
+
+## The ask
+
+1. A `sample_format=` (or `encoding=` / `bits_per_sample=`, mirroring the `torchaudio.save`
+   signature this replaced) on `to_file` / `to_tensor` / `to_file_like`. FFmpeg already exposes
+   the formats, so this is plumbing rather than new capability.
+2. Failing that, **document the extension → sample-format mapping.** Neither the `AudioEncoder`
+   API reference nor the encoding tutorial states that `.wav` means 16-bit integer, so a caller
+   has no way to learn that a float write is lossy other than by inspecting the output.
+3. Consider defaulting `.wav` to `pcm_f32le` when the input is float32 and the container supports
+   it — this would make the documented `[-1, 1]` contract and the default behaviour consistent.
+
+Context: `torchaudio.save` has forwarded to `AudioEncoder` since 2.9 and warns that `encoding` and
+`bits_per_sample` are unsupported, so for code migrating off torchaudio this is a capability
+regression. Searching this repo, `bits_per_sample` returns **zero** results and no issue or PR in
+the `AudioEncoder` history requests sample-format control, so as far as I can tell this has simply
+never been raised.
+
+## Two smaller observations, same root cause
+
+- **`.ogg` produces Ogg-FLAC, not Ogg-Vorbis** (`ffprobe`: `codec_name=flac`, container `ogg`).
+  Lossless, so arguably better than asked for, but libsndfile refuses it —
+  `soundfile.read` fails with `unknown error in flac decoder` — so a file written as `.ogg` cannot
+  be read by a large part of the Python audio ecosystem. `.oga` behaves the same way.
+- **`.wv` is the only float-preserving target**, and it round-trips out-of-range data bit-exactly
+  (peak 4.0 in, 4.0 out). That the one float-capable option is undocumented and reachable only by
+  guessing an extension is itself the argument for making the format choice explicit.
+
+## Environment
+
+torchcodec 0.11.1 and 0.16.0; torch 2.11.0 / 2.13.0; torchaudio 2.11.0; FFmpeg 8.1;
+libsndfile 1.2.2 via soundfile 0.13.1; Python 3.12.0; numpy 2.4.4; macOS arm64.

--- a/specs/20260819-120600-io-invariants/upstream.md
+++ b/specs/20260819-120600-io-invariants/upstream.md
@@ -1,0 +1,139 @@
+# Part 1 — upstream status
+
+Searched via the GitHub API. **Note the repository moved**: it is
+`meta-pytorch/torchcodec`, not `pytorch/torchcodec` (the latter 422s on search). The C++ error
+paths emitted by the installed wheel confirm it —
+`/Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/Encoder.cpp`.
+
+## The silent clamping is acknowledged, intended, and closed as `not_planned`
+
+**[meta-pytorch/torchcodec#1576](https://github.com/meta-pytorch/torchcodec/issues/1576) —
+"AudioEncoder silently clips out-of-range float32 samples instead of rejecting or warning"**
+Opened 2026-07-30 by `John6666cat`, closed 2026-07-30 (~6 hours later), state reason
+`not_planned`. The report is essentially identical to ours: the constructor validates tensor
+type, dimensions, dtype and sample rate but not the documented value range, so out-of-range
+float32 is accepted and silently clipped, and "for sufficiently large input values, almost the
+entire encoded waveform becomes full-scale PCM. The operation succeeds, but most amplitude
+information is lost."
+
+The maintainer's reply is the whole answer, verbatim:
+
+> **NicolasHug:** Hi @John6666cat , we leave it up to the user to validate their input. We are
+> usually quite defensive about user input, but in such a case it would significantly affect
+> performance: checking the input is another `O(n)` check that most users would not want to pay.
+> I don't think there's an easy way to validate the input on the fly as they're being encoded,
+> since the encoding happens within FFmpeg.
+
+The reporter accepted and closed it. So:
+
+- **acknowledged?** Yes, explicitly, by the maintainer.
+- **intended?** Yes — declined on `O(n)` performance grounds, not deferred.
+- **documented?** The *contract* is: `AudioEncoder` documents that samples must be float32 in
+  `[-1, 1]`, and `torchaudio.save`'s docstring repeats it ("Must be a 1D or 2D tensor with
+  float32 values in the range [-1, 1]"). What is **not** documented is the consequence of
+  violating it — nothing states that violation means silent clipping, and nothing documents that
+  `.wav` means `pcm_s16le`.
+- **will it change?** No. This is the settled upstream position.
+
+**Consequence for senselab: the range check cannot be delegated below senselab, ever.** Upstream
+has declined to do it, for a stated and reasonable reason. That is precisely the case for putting
+the resolution and range policy in `Audio.save_to_file` plus a senselab-free
+`portable_audio_io`, which is what PR #570 does.
+
+## A bit-depth / encoding parameter is *unreported*
+
+Searched `bits_per_sample` (**0 results**), `encoding parameter audio in:title` (0 results),
+`sample_fmt`, `pcm_s24le`/`pcm_f32le`, `bit depth` (7 results, all video/HDR/pixel-format), and
+every issue and PR with `AudioEncoder` in the title (11 results — `#692` public API, `#698` use
+`AudioStreamOptions`, `#700` user-defined encoded sample rate, `#701` rename, `#717` docs, `#754`
+file-like, `#836` FFmpeg 5 on Windows, `#850`/`#852` `pathlib.Path`, `#1411`/`#1478`/`#1480`
+refactors, `#1576` above).
+
+**Nobody has asked for PCM subtype / encoding control.** So ask #3 in the issue draft is novel,
+and worth filing on its own — separately from #1576, which is closed and settled.
+
+Also relevant, still **open**:
+**[pytorch/audio#4211](https://github.com/pytorch/audio/issues/4211) — "torchaudio.save silently
+saturates PCM-scale int16 input after the TorchCodec migration"** (opened 2026-07-30, no
+comments). `torchaudio.save` casts `int16` to `float32` **without rescaling**, so int16 `26212`
+becomes float `26212.0` and everything saturates. A wrapper-level bug distinct from #1576, and a
+live hazard for any code that still hands `torchaudio.save` integer PCM.
+
+## The chunking / seeking area is under active repair — this is the important part
+
+Our Invariant 4 work landed in the middle of an open upstream workstream. Chronologically:
+
+| ref | state | what |
+|---|---|---|
+| [#1448](https://github.com/meta-pytorch/torchcodec/issues/1448) | closed | `get_samples_played_in_range` decodes from the start up to `start_seconds` rather than seeking, so a window near the end of a long file costs a full decode. Reporter notes `soundfile.seek + read` is effectively constant-time. |
+| [#1449](https://github.com/meta-pytorch/torchcodec/pull/1449) | closed | "Fix and speed-up AudioDecoder seeking logic" |
+| [#1601](https://github.com/meta-pytorch/torchcodec/issues/1601) | closed/completed, **but reporter still reproducing** | `AudioDecoder` intermittently drops 1 sample in the final fractional-second chunk, ~1 in 3 runs. Reporter states it appears only after 0.14.0. Maintainer after the first fix: *"working on it. It's not trivial"*. |
+| [#1610](https://github.com/meta-pytorch/torchcodec/issues/1610) | closed/completed | `get_samples_played_in_range` **fails outright** on MPEG/MPG audio with `start_seconds > 0` |
+| [#1614](https://github.com/meta-pytorch/torchcodec/pull/1614) | **merged** 2026-08-12 | "Fix audio resampling: decoding in chunks should return identical samples to decoding in one go" — *"a resampled stream in consecutive chunks must return exactly the same samples as decoding it in one go … we must align the input and output 'grid' for the resampler … we enforce that through preroll + skipping some samples."* Adds `test_resample_chunked_matches_full`. |
+| [#1645](https://github.com/meta-pytorch/torchcodec/issues/1645) | closed | `get_samples_played_in_range()` fails to seek in SWF audio |
+
+**No open or closed issue matches the MP3 −1105-sample offset we measured** (searched `mp3 seek`,
+`priming`/`pre-roll`/`delay samples`, `get_samples_played_in_range`, `get_all_samples mismatch`).
+That specific defect appears unreported, and it reproduces on 0.16.0 — see below. It is the
+better candidate for a new issue than the clamping, which is settled.
+
+## Version comparison: 0.11.1 (pinned here) vs 0.16.0 (current)
+
+Measured in an isolated venv, torchcodec 0.16.0 + torch 2.13.0 + FFmpeg 8.1. (The 0.16.0 macOS
+wheel needs `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib` — its dylibs ship with no `LC_RPATH`
+and fail to load otherwise. Worth knowing before anyone upgrades.) Raw output:
+`raw/torchcodec_0.16.0_check.txt`.
+
+| behaviour | 0.11.1 | 0.16.0 |
+|---|---|---|
+| `AudioEncoder` signature | `(samples, *, sample_rate)` / `to_file(dest, *, bit_rate, num_channels, sample_rate)` | **identical — no encoding control added** |
+| flat 1.5 → `.wav` | PCM_16, 1 distinct value, **no warning** | PCM_16, 1 distinct value, **no warning** |
+| `.wav` / `.flac` / `.ogg` / `.wv` | `pcm_s16le` / 24-bit flac / **Ogg-FLAC** / `wavpack fltp` | **unchanged** |
+| float32 round-trip via `.wav` | inexact, 1.53e−05 | inexact, 1.53e−05 |
+| float32 round-trip via `.wv` | **bit-exact** | **bit-exact** |
+| chunk == slice, wav / flac / opus | EXACT | EXACT |
+| chunk == slice, **mp3** | **off = −1105**, short read 943 at t=0 | **off = −1105**, short read 943 at t=0 — **not fixed** |
+| mp3 chunk contiguity | loses exactly 1105 samples | loses exactly 1105 samples |
+| decode range-transparency (float WAV peak 4.0) | bit-exact, unclamped | bit-exact, unclamped |
+| amplitude convention | `/32768` | `/32768` |
+| **chunked decode with resampling vs one go** | **BROKEN: max diff 2.0e−01 at 16 kHz, 9.96e−01 at 8 kHz** | **bit-exact at both** (PR #1614) |
+| **m4a chunk contiguity** | bit-exact | **NOT bit-exact**: 256 samples differ from index 132160, max diff 9.9e−01 (tail of the file) |
+
+Two conclusions from this table, both actionable:
+
+1. **The pinned 0.11.1 has a serious latent hazard: `AudioDecoder(path, sample_rate=N)` read in
+   chunks does not equal the same file read in one go — max abs difference 0.20 at 16 kHz and
+   0.996 at 8 kHz.** Order-unity, not rounding. senselab does **not** currently trip it: all
+   three `AudioDecoder(...)` call sites (`audio.py:144`, `audio.py:204`,
+   `video/data_structures/video.py:186`) decode at the native rate and resample separately. But
+   this forecloses the obvious optimisation of letting the decoder resample, on 0.11.1, and it is
+   exactly the kind of thing someone adds later as a speedup. PR #1614 fixes it in 0.16.0.
+2. **Upgrading is not a free win.** 0.16.0 fixes the resampling-chunk bug but leaves the MP3
+   −1105 shift untouched and introduces an AAC tail discrepancy of order 1.0 that 0.11.1 did not
+   have — consistent with #1601 still being open in substance. Whichever version is pinned, the
+   MP3 offset guard is required, and chunked AAC needs its own check.
+
+## `torchaudio` I/O deprecation timeline
+
+Verified directly against the installed 2.11.0 rather than from release notes:
+
+- `torchaudio.load` / `torchaudio.save` **exist**, and are thin wrappers over torchcodec.
+  `torchaudio/_torchcodec.py` does `from torchcodec.decoders import AudioDecoder` (line 82) and
+  `from torchcodec.encoders import AudioEncoder` (line 246), each guarded to raise `ImportError`
+  with *"TorchCodec is required for load_with_torchcodec"* / `save_with_torchcodec`.
+- `torchaudio.info`, `torchaudio.list_audio_backends`, `torchaudio.io`, `torchaudio.backend`,
+  `torchaudio.AudioMetaData` — **all absent** (`hasattr` → `False` for every one).
+- The `save` docstring states the migration landed in **2.9** and that `format`, `encoding`,
+  `bits_per_sample`, `buffer_size` and `backend` "are ignored and accepted only for backwards
+  compatibility"; `load`'s says the same of `normalize`, `buffer_size` and `backend`. Both
+  recommend porting to torchcodec directly.
+- Relevant PRs, both closed: pytorch/audio#3975 "Add save_with_torchcodec, modify save()'s
+  warnings" and #4039 "Let `torchaudio.load()` and `torchaudio.save()` rely on
+  `load_with_torchcodec()` and `save_with_torchcodec()`"; also #4089 "Clarify load and save
+  behavior".
+
+**I did not find an authoritative announced removal version for `torchaudio.load`/`save`
+themselves.** What is established is stronger than a timeline for our purposes: they are already
+not an independent implementation. A senselab "torchaudio fallback" for encode or decode cannot
+work when torchcodec is missing, because that is the exact condition under which torchaudio's own
+I/O raises `ImportError`. The real fallbacks are `soundfile`, `ffmpeg`, and `scipy.io.wavfile`.


### PR DESCRIPTION
Moves the I/O audit out of `~/Downloads` and into the tree, with its raw measurements and reproduction scripts, so the invariants behind the write policy are reviewable and re-runnable.

## What it establishes

**Range checking cannot be delegated below senselab.** `meta-pytorch/torchcodec#1576` — "AudioEncoder silently clips out-of-range float32 samples" — was filed 2026-07-30 and closed six hours later as `not_planned`: *"we leave it up to the user to validate their input… checking the input is another O(n) check that most users would not want to pay."* Acknowledged, intended, settled. This is the justification for #570 existing at all, and the reason not to re-file.

**Decode holds all four invariants.** Source-independent (`float32` from 11 containers, the `/32768` convention bit-identical across six readers); range-transparent on read (float WAV at peak 4.0 returns 4.0 bit-exact — the exact asymmetry with the write path); and **nothing normalises at any scope** — halves 60 dB apart give a chunk/slice peak ratio of exactly `1.000000`. That last one was the risk worth checking: a per-segment normalisation would have silently invalidated every windowed measurement in the analysis workflow.

**One confirmed defect.** `get_samples_played_in_range` returns mp3 content ~1105 samples (50.1 ms) early while reporting a `pts_seconds` equal to the requested start — the misalignment certifies itself as correct. 9.93x on a window straddling an amplitude step, where `soundfile`, `torchaudio` and `ffmpeg -i … -ss` all return `1.000000`. mp3 only; wav/flac/m4a/opus report exactly `0.000000`. Latent for the workflow (which reads WAV), real for mp3 input. Fixed separately.

**Two constraints worth knowing before anyone reaches for them.** The pinned torchcodec 0.11.1 gets *chunked resampling* wrong (max abs difference 0.996 at 8 kHz — order unity), fixed in 0.16.0 by #1614; but 0.16.0 introduces an AAC tail discrepancy 0.11.1 lacks. Upgrading is not a free win, and the invariants want tests rather than a version pin. Separately, `torchaudio` 2.11 **is** torchcodec — `_torchcodec.py` raises `ImportError` without it and `info`/`list_audio_backends`/`io`/`backend` are gone — so the `TORCHCODEC_AVAILABLE ? … : torchaudio.save` branch has no second branch. Real fallbacks are soundfile, ffmpeg, scipy.

## Corrections applied to the agent's draft

Its recommendation argued to keep `encoding`/`bits_per_sample`, which #570 removed. The substance matched what shipped — resolve above the backend, refuse the unsatisfiable — so the section now describes the `subtype` + `out_of_range` interface that actually exists and why the pair was replaced. The six no-subtype `sf.write` sites it flagged were measured against `triage` and are already routed through the layer; annotated as resolved rather than left as open work.

Docs and measurements only — no source changes, so nothing here can affect behaviour.