### PR TITLE
A hand-maintained document was living in pdoc's output directory

### DIFF
--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -33,6 +33,7 @@ jobs:
       run: |
         APP_MODULE_NAME=$(ls -1 src | sort | head -1)
         uv run pdoc src/"$APP_MODULE_NAME" -o docs -t docs_style/pdoc-theme --docformat google --favicon https://readthedocs.org/favicon.ico
+        uv run python scripts/generate-compat-matrix.py
         touch docs/.nojekyll
     - name: Deploy preview
       uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -45,6 +45,7 @@ jobs:
         APP_MODULE_NAME=$(ls -1 src | sort | head -1)
         echo "APP_MODULE_NAME: $APP_MODULE_NAME"
         uv run pdoc src/"$APP_MODULE_NAME" -o docs -t docs_style/pdoc-theme --docformat google --favicon https://readthedocs.org/favicon.ico
+        uv run python scripts/generate-compat-matrix.py
         touch docs/.nojekyll
       shell: bash
     - name: Determine if deployment is needed

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,5 +1,8 @@
 # Senselab Compatibility Matrix
 
+Hand-maintained. The per-function dependency table is generated from `COMPATIBILITY_MATRIX`
+into `docs/function-dependencies.md` by the docs build (`scripts/generate-compat-matrix.py`).
+
 Minimum and maximum tested versions of senselab dependencies across Python versions.
 Lower bounds verified by pinning each package to its minimum in an isolated venv.
 Upper bounds verified by running the full test suite (490+ tests passing).

--- a/scripts/generate-compat-matrix.py
+++ b/scripts/generate-compat-matrix.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-"""Generate docs/compatibility-matrix.md from the compatibility module."""
+"""Generate the per-function dependency table from the compatibility module.
+
+The path is ``senselab.utils.compatibility.GENERATED_DOC``. It is deliberately not
+``docs/compatibility-matrix.md``, which is a hand-maintained document this script must not touch.
+"""
 
 from pathlib import Path
 
-from senselab.utils.compatibility import generate_matrix_markdown
+from senselab.utils.compatibility import GENERATED_DOC, generate_matrix_markdown
 
-output = Path(__file__).parent.parent / "docs" / "compatibility-matrix.md"
+output = Path(__file__).parent.parent / GENERATED_DOC
 output.parent.mkdir(parents=True, exist_ok=True)
 output.write_text(generate_matrix_markdown())
 print(f"Generated {output}")

--- a/specs/20260819-131500-compat-matrix-generator/design.md
+++ b/specs/20260819-131500-compat-matrix-generator/design.md
@@ -1,0 +1,59 @@
+# The generator was overwriting a different document
+
+## What was wrong
+
+`scripts/generate-compat-matrix.py` wrote `generate_matrix_markdown()` to
+`docs/compatibility-matrix.md`. The file at that path is not what the generator produces.
+
+| | tracked `docs/compatibility-matrix.md` | `generate_matrix_markdown()` |
+|---|---|---|
+| lines | 78 | 143 |
+| bytes | 4536 | 15962 |
+| subject | Python support; per-package min/max version bounds | one row per public function: required deps, GPU, isolated venv |
+| provenance | hand-maintained; lower bounds verified by pinning each package to its minimum in an isolated venv, upper bounds by running the suite | derived from `COMPATIBILITY_MATRIX` |
+
+They share a filename and nothing else. Running the script replaced a document recording
+measurements no generator can reproduce — "lower bounds verified by pinning" is the result of
+having done that work — with an unrelated table.
+
+The divergence was diagnosed in `specs/20260818-093000-drop-pre-4x-pyannote/decision.md`, which
+declined to run the generator for exactly this reason and recorded it as "a separate defect,
+unfiled here". This files it.
+
+## How it happened
+
+`specs/20260419-133236-test-classification-deps` created the path as generated output (its T004,
+T024 and T037 all treat it as such). Later work — the diarization backends plan, then the pyannote
+4.x change — edited the committed file by hand to register new backends and bump
+`pyannote-audio >=4.0`. Both were reasonable against the file as it then read. Neither noticed that
+a generator claimed the same path, because nothing failed: the script is not run in CI, and the
+only symptom is destruction at the moment someone runs it.
+
+## Fix
+
+The generated table moves to `docs/function-dependencies.md`, named for what it contains, with its
+H1 retitled to match. The path is one constant, `compatibility.GENERATED_DOC`, imported by the
+script rather than repeated in it. `docs/compatibility-matrix.md` stays hand-maintained and is
+written by nothing.
+
+`src/tests/utils/compatibility_doc_test.py` holds three checks: the committed generated document
+equals what the generator produces (so regenerating is a no-op and the table cannot drift from the
+matrix it describes); the generator's target is not the hand-maintained path, and its output does
+not equal that file's contents; and the script imports the constant rather than carrying its own
+literal.
+
+The first check is the one that matters — it converts "someone must remember to regenerate" into a
+test failure. It also means a change to `COMPATIBILITY_MATRIX` that forgets the doc now fails CI
+with the command to run.
+
+## Rejected
+
+**Fold the hand-maintained content into the generator.** The version bounds are measurements, not
+facts derivable from `COMPATIBILITY_MATRIX`: "verified by pinning each package to its minimum in an
+isolated venv" is a record of work performed on a host. A generator would have to invent them.
+
+**Delete the generator.** The per-function table is useful and is genuinely derived; the defect was
+its destination, not its existence.
+
+**Leave the script and document the hazard.** A comment does not prevent the next person from
+running a script named `generate-compat-matrix.py` to generate the compatibility matrix.

--- a/specs/20260819-131500-compat-matrix-generator/design.md
+++ b/specs/20260819-131500-compat-matrix-generator/design.md
@@ -20,6 +20,22 @@ The divergence was diagnosed in `specs/20260818-093000-drop-pre-4x-pyannote/deci
 declined to run the generator for exactly this reason and recorded it as "a separate defect,
 unfiled here". This files it.
 
+## The second half, found when CI failed
+
+The first fix pointed the generator at `docs/function-dependencies.md` and asserted the committed
+copy matched it. CI failed: **the file was missing.** `docs/` is gitignored — `.gitignore:192`,
+under the comment `# pdoc documentation` — because it is pdoc's output directory, written by
+`pdoc src/senselab -o docs` in both `docs.yaml` and `docs-preview.yaml`.
+
+That is the rest of the explanation for why the collision survived. `docs/compatibility-matrix.md`
+was tracked only because someone force-added it past the ignore rule, so:
+
+- it never appeared in `git status`, and an accidental overwrite showed up as nothing at all;
+- it lived in a directory a CI job writes to, alongside generated HTML;
+- and a generator aimed at the same directory looked, from the outside, entirely reasonable.
+
+A hand-maintained document inside build output cannot be defended by naming; it has to be moved.
+
 ## How it happened
 
 `specs/20260419-133236-test-classification-deps` created the path as generated output (its T004,
@@ -31,20 +47,34 @@ only symptom is destruction at the moment someone runs it.
 
 ## Fix
 
-The generated table moves to `docs/function-dependencies.md`, named for what it contains, with its
-H1 retitled to match. The path is one constant, `compatibility.GENERATED_DOC`, imported by the
-script rather than repeated in it. `docs/compatibility-matrix.md` stays hand-maintained and is
-written by nothing.
+The two documents are separated by kind, not just by name.
 
-`src/tests/utils/compatibility_doc_test.py` holds three checks: the committed generated document
-equals what the generator produces (so regenerating is a no-op and the table cannot drift from the
-matrix it describes); the generator's target is not the hand-maintained path, and its output does
-not equal that file's contents; and the script imports the constant rather than carrying its own
-literal.
+**The hand-maintained one moves out of build output** to `COMPATIBILITY.md` at the repo root, beside
+`README.md`, `SECURITY.md` and `CHANGELOG.md`. It is tracked, visible in `git status`, and no build
+writes to its directory. It gained two lines naming its generated counterpart, so a reader who wants
+the per-function view knows where it is.
 
-The first check is the one that matters — it converts "someone must remember to regenerate" into a
-test failure. It also means a change to `COMPATIBILITY_MATRIX` that forgets the doc now fails CI
-with the command to run.
+**The generated one stays in `docs/` and is not committed.** It is derived from
+`COMPATIBILITY_MATRIX` on every docs build, so a committed copy could only ever be a stale duplicate
+of what the build already produces. Both `docs.yaml` and `docs-preview.yaml` now run the generator
+immediately after pdoc, which is what puts the table on the published site. The path is one constant,
+`compatibility.GENERATED_DOC`, imported by the script rather than repeated in it.
+
+`src/tests/utils/compatibility_doc_test.py` holds four checks:
+
+1. `COMPATIBILITY.md` exists, is tracked, and is **not** under any gitignore rule. This is the check
+   that would have caught the original defect, and it fails if anyone moves a hand-maintained
+   document back into build output.
+2. `GENERATED_DOC` is neither the hand-maintained path nor the old shared one, **is** ignored, and
+   its content differs from the hand-maintained document.
+3. Both docs workflows invoke the generator — since the table is no longer committed, the build is
+   the only thing that can produce it, and a workflow publishing `docs/` without it would ship a
+   site missing the table.
+4. The script imports the path constant rather than carrying its own literal.
+
+Regenerating is no longer something anyone must remember, because nothing is committed to go stale.
+That is a stronger guarantee than the idempotence check the first attempt reached for — which could
+not have worked anyway, since the file it wanted to compare cannot be committed.
 
 ## Rejected
 
@@ -57,3 +87,12 @@ its destination, not its existence.
 
 **Leave the script and document the hazard.** A comment does not prevent the next person from
 running a script named `generate-compat-matrix.py` to generate the compatibility matrix.
+
+**Force-add the generated table past the ignore rule**, as the hand-maintained file had been. That is
+the practice that hid this defect; repeating it for a second file in the same directory would be
+choosing the same trap knowingly.
+
+**Keep the hand-maintained document at `docs/compatibility-matrix.md` and only redirect the
+generator.** This was the first attempt, and CI rejected it. It leaves a hand-maintained file inside
+pdoc's output directory, invisible to `git status` and adjacent to generated HTML — so the next
+collision is as quiet as this one was.

--- a/src/senselab/utils/compatibility.py
+++ b/src/senselab/utils/compatibility.py
@@ -381,10 +381,15 @@ def get_matrix() -> dict[str, CompatibilityEntry]:
     return COMPATIBILITY_MATRIX
 
 
+# Repo-relative path of the document ``generate_matrix_markdown`` produces. The hand-maintained
+# ``docs/compatibility-matrix.md`` is a different document and is not written by any generator.
+GENERATED_DOC = "docs/function-dependencies.md"
+
+
 def generate_matrix_markdown() -> str:
-    """Generate a markdown table from the compatibility matrix."""
+    """Return the per-function dependency table as markdown, for ``GENERATED_DOC``."""
     lines = [
-        "# Senselab Compatibility Matrix",
+        "# Senselab Function Dependencies",
         "",
         "| Function | Required Deps | Dep Versions | GPU | Isolated | Python | Torch |",
         "|----------|--------------|-------------|-----|----------|--------|-------|",

--- a/src/tests/utils/compatibility_doc_test.py
+++ b/src/tests/utils/compatibility_doc_test.py
@@ -1,40 +1,83 @@
-"""The generated dependency table and the hand-maintained compatibility matrix are two documents.
+"""The hand-maintained compatibility document must be tracked, and outside the docs build output.
 
-They were one path. ``scripts/generate-compat-matrix.py`` wrote its per-function table over
-``docs/compatibility-matrix.md``, which is a hand-maintained Python/dependency-version document,
-so running the generator replaced one document with an unrelated one.
+Two documents once shared one path. ``scripts/generate-compat-matrix.py`` wrote its per-function
+table over ``docs/compatibility-matrix.md``, a hand-maintained Python/dependency-version document.
+The reason nobody noticed is the second half of the defect: ``docs/`` is pdoc's output directory and
+is gitignored, so the hand-maintained file was invisible to ``git status`` and lived where a build
+writes.
 
 Reasoning: ``specs/20260819-131500-compat-matrix-generator/design.md``.
 """
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 from senselab.utils.compatibility import GENERATED_DOC, generate_matrix_markdown
+
+# The hand-maintained document: version bounds verified by pinning, which no generator can derive.
+HAND_MAINTAINED_DOC = "COMPATIBILITY.md"
 
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
 
-def test_the_generated_document_in_the_tree_is_what_the_generator_produces() -> None:
-    """Regenerating must be a no-op, so the table cannot drift from the matrix it describes."""
-    committed = _repo_root() / GENERATED_DOC
-    assert committed.is_file(), f"{GENERATED_DOC} is missing; run scripts/generate-compat-matrix.py"
-    assert committed.read_text() == generate_matrix_markdown(), (
-        f"{GENERATED_DOC} is stale. Run `uv run python scripts/generate-compat-matrix.py` "
-        "and commit the result -- do not hand-edit it."
+def _is_ignored(path: str) -> bool:
+    """Reports whether git ignores ``path``.
+
+    Args:
+        path: Repo-relative path.
+
+    Returns:
+        True when a gitignore rule covers it.
+    """
+    return (
+        subprocess.run(
+            ["git", "check-ignore", "-q", path],
+            cwd=_repo_root(),
+            capture_output=True,
+        ).returncode
+        == 0
     )
 
 
-def test_the_generator_does_not_write_over_the_hand_maintained_matrix() -> None:
-    """The version matrix records bounds verified by pinning, which no generator can reproduce."""
-    assert GENERATED_DOC != "docs/compatibility-matrix.md"
+def test_the_hand_maintained_document_exists_and_is_tracked() -> None:
+    """A document only a human can write must be under version control, not build output."""
+    doc = _repo_root() / HAND_MAINTAINED_DOC
+    assert doc.is_file(), f"{HAND_MAINTAINED_DOC} is missing"
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", HAND_MAINTAINED_DOC],
+        cwd=_repo_root(),
+        capture_output=True,
+    )
+    assert tracked.returncode == 0, f"{HAND_MAINTAINED_DOC} is not tracked by git"
+    assert not _is_ignored(HAND_MAINTAINED_DOC), (
+        f"{HAND_MAINTAINED_DOC} sits under a gitignore rule. It is hand-maintained, so it must not "
+        "live in a directory a build writes to -- that is how the generator overwrote it unnoticed."
+    )
 
-    hand_maintained = _repo_root() / "docs" / "compatibility-matrix.md"
-    if hand_maintained.is_file():
-        assert hand_maintained.read_text() != generate_matrix_markdown()
+
+def test_the_generated_table_goes_to_build_output_not_over_the_hand_maintained_document() -> None:
+    """The generated table is derived, so it is rebuilt rather than committed."""
+    assert GENERATED_DOC != HAND_MAINTAINED_DOC
+    assert GENERATED_DOC != "docs/compatibility-matrix.md"
+    assert _is_ignored(GENERATED_DOC), (
+        f"{GENERATED_DOC} is not ignored. It is regenerated from COMPATIBILITY_MATRIX on every "
+        "docs build, so committing it would let a stale copy outlive the matrix it describes."
+    )
+    assert generate_matrix_markdown() != (_repo_root() / HAND_MAINTAINED_DOC).read_text()
+
+
+def test_the_docs_build_runs_the_generator() -> None:
+    """Since the table is not committed, the build is the only thing that can produce it."""
+    for workflow in ("docs.yaml", "docs-preview.yaml"):
+        text = (_repo_root() / ".github" / "workflows" / workflow).read_text()
+        assert "generate-compat-matrix.py" in text, (
+            f"{workflow} publishes docs/ but never generates {GENERATED_DOC}, so the table would "
+            "be absent from the published site."
+        )
 
 
 def test_the_script_writes_where_the_module_says() -> None:

--- a/src/tests/utils/compatibility_doc_test.py
+++ b/src/tests/utils/compatibility_doc_test.py
@@ -1,0 +1,44 @@
+"""The generated dependency table and the hand-maintained compatibility matrix are two documents.
+
+They were one path. ``scripts/generate-compat-matrix.py`` wrote its per-function table over
+``docs/compatibility-matrix.md``, which is a hand-maintained Python/dependency-version document,
+so running the generator replaced one document with an unrelated one.
+
+Reasoning: ``specs/20260819-131500-compat-matrix-generator/design.md``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from senselab.utils.compatibility import GENERATED_DOC, generate_matrix_markdown
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def test_the_generated_document_in_the_tree_is_what_the_generator_produces() -> None:
+    """Regenerating must be a no-op, so the table cannot drift from the matrix it describes."""
+    committed = _repo_root() / GENERATED_DOC
+    assert committed.is_file(), f"{GENERATED_DOC} is missing; run scripts/generate-compat-matrix.py"
+    assert committed.read_text() == generate_matrix_markdown(), (
+        f"{GENERATED_DOC} is stale. Run `uv run python scripts/generate-compat-matrix.py` "
+        "and commit the result -- do not hand-edit it."
+    )
+
+
+def test_the_generator_does_not_write_over_the_hand_maintained_matrix() -> None:
+    """The version matrix records bounds verified by pinning, which no generator can reproduce."""
+    assert GENERATED_DOC != "docs/compatibility-matrix.md"
+
+    hand_maintained = _repo_root() / "docs" / "compatibility-matrix.md"
+    if hand_maintained.is_file():
+        assert hand_maintained.read_text() != generate_matrix_markdown()
+
+
+def test_the_script_writes_where_the_module_says() -> None:
+    """One source of truth for the path, so the script and the test cannot disagree."""
+    script = (_repo_root() / "scripts" / "generate-compat-matrix.py").read_text()
+    assert "GENERATED_DOC" in script, "the script should import the path, not repeat the literal"
+    assert '"docs" / "compatibility-matrix.md"' not in script


### PR DESCRIPTION
`scripts/generate-compat-matrix.py` wrote `generate_matrix_markdown()` to `docs/compatibility-matrix.md`. The file at that path is not what the generator produces — they share a filename and nothing else.

| | tracked `docs/compatibility-matrix.md` | `generate_matrix_markdown()` |
|---|---|---|
| lines | 78 | 143 |
| subject | Python support; per-package min/max bounds | one row per public function: deps, GPU, isolated venv |
| provenance | hand-maintained; **lower bounds verified by pinning each package to its minimum in an isolated venv** | derived from `COMPATIBILITY_MATRIX` |

Running the script replaced a document recording measurements no generator can reproduce with an unrelated table.

## CI found the second half, and it is the more interesting one

My first fix redirected the generator and asserted the committed copy matched it. **CI failed: the file was missing.** `docs/` is gitignored — `.gitignore:192`, under the comment `# pdoc documentation` — because it is pdoc's output directory, written by `pdoc src/senselab -o docs` in both docs workflows.

So `docs/compatibility-matrix.md` was tracked only because someone force-added it past the ignore rule. That is the rest of why the collision survived:

- it never appeared in `git status`, so an accidental overwrite showed up as **nothing at all**;
- it lived in a directory a CI job writes to, alongside generated HTML;
- and a generator aimed at that same directory looked, from the outside, entirely reasonable.

A hand-maintained document inside build output cannot be defended by naming. It has to be moved.

## Fix

**The hand-maintained document moves to `COMPATIBILITY.md`** at the repo root, beside `README.md`, `SECURITY.md` and `CHANGELOG.md` — tracked, visible in `git status`, and in a directory no build writes to. It gained two lines naming its generated counterpart.

**The generated table stays in `docs/` and is not committed.** It is derived from `COMPATIBILITY_MATRIX`, so a committed copy could only ever be a stale duplicate of what the build produces. Both `docs.yaml` and `docs-preview.yaml` now run the generator immediately after pdoc, which is what publishes it.

Four guards, the first being the one that matters: **`COMPATIBILITY.md` exists, is tracked, and is not under any gitignore rule** — it fails if anyone moves a hand-maintained document back into build output. Then: `GENERATED_DOC` is neither the hand-maintained nor the old shared path, *is* ignored, and differs in content; both workflows invoke the generator, since the build is now the only thing that can produce the table; and the script imports the path constant rather than repeating the literal.

Regenerating is no longer something anyone must remember, because nothing is committed to go stale. That is a stronger guarantee than the idempotence check I first reached for — which could not have worked anyway, since the file it wanted to compare cannot be committed.

## Rejected

**Fold the hand-maintained content into the generator** — the version bounds are measurements ("verified by pinning each package to its minimum in an isolated venv"), not facts derivable from `COMPATIBILITY_MATRIX`; a generator would have to invent them. **Delete the generator** — the table is useful and genuinely derived; the defect was its destination. **Force-add the generated table past the ignore rule**, as the other file had been — that is the practice that hid this, and repeating it knowingly for a second file in the same directory is worse. **Redirect the generator and leave the hand-maintained doc in `docs/`** — my first attempt, which CI rejected, and which would have left the next collision just as quiet.

`src/tests/utils`: 371 passed, 5 skipped. pre-commit green.