### PR TITLE
fix(audio): read an mp3 window from the timeline its samples are on

### DIFF
--- a/specs/20260819-122715-mp3-decode-timeline/design.md
+++ b/specs/20260819-122715-mp3-decode-timeline/design.md
@@ -1,0 +1,155 @@
+# A windowed read of an MP3 returned content it did not contain
+
+`Audio(filepath=..., offset_in_sec=..., duration_in_sec=...)` served, for MP3 only, samples from
+about 50 ms before the requested offset, while reporting the requested offset as the timestamp of
+what it returned. The misalignment certified itself as correct, so nothing downstream could notice.
+
+## Measurement
+
+A 6 s file, 22050 Hz mono: 3 s of uniform noise, then the same noise 60 dB down. Written to
+`.wav`, `.flac` and `.mp3` from one signal. The comparison that matters is against **another
+decoder reading the same MP3**, not against the lossless source — an amplitude step in an MP3
+carries codec ringing either side of it, and comparing to the source conflates that ringing with
+the shift under investigation.
+
+Requesting `[3.000, 3.200)` s, the window that begins exactly at the step:
+
+| reader | peak returned |
+| --- | --- |
+| `torchcodec` `get_samples_played_in_range` | 1.1639 |
+| `torchcodec` `get_all_samples()` sliced `[66150:70560]` | 0.1172 |
+| `torchaudio.load(frame_offset=66150, num_frames=4410)` | 0.1172 |
+| `soundfile.read(start=66150, frames=4410)` | 0.1172 |
+| `ffmpeg -i … -ss 3.0 -t 0.2` | 0.1172 |
+
+Ratio against the three decoders that agree: **9.93×** (`raw/invariants_run3.txt` lines 20-23 of the
+I/O audit). The returned `pts_seconds` was `3.000000` — the value asked for.
+
+Three further measurements fix the mechanism:
+
+- The shift is a constant **1105 samples earlier**, at every seek position swept across an MP3
+  frame (offsets +0, +1, +288, +576, +1151, +1152, +1153, +2304), and the returned block is
+  **bit-identical** to `get_all_samples()[…, start-1105 : …]`. Not a rounding or frame-boundary
+  effect: a whole-timeline offset.
+- Tiling consecutive ranges over the file yields **131195 samples against 132300** for the full
+  decode — 1105 short, the same number lost once at the end.
+- `get_all_samples()` on the MP3 reports `pts_seconds = 0.050113` = **1105 samples**, and
+  `metadata.begin_stream_seconds` reports the same value without decoding anything. For `.wav`,
+  `.flac`, `.m4a` and `.opus` both are exactly `0.000000`, and their range reads are bit-exact and
+  tile without loss.
+
+1105 = 576 + 529, the libmp3lame encoder delay.
+
+## Mechanism
+
+An MP3 stream begins at a non-zero presentation timestamp because the encoder prepends its delay.
+Decoders trim that delay, so the first *decoded sample* is source time 0 while the first
+*timestamp* is 0.050113 s. `get_samples_played_in_range` seeks on the timestamp timeline;
+`get_all_samples()` returns data on the trimmed-sample timeline and labels it with the untrimmed
+origin. Asking for 3.0 s therefore lands at sample 3.0 × sr on a timeline whose zero sits 1105
+samples later than the data's zero — 1105 samples early — and the returned `pts_seconds` is echoed
+back from the request rather than derived from what was decoded, so the error is invisible at the
+call site. The lost tail is the same disagreement at the other end: the last range stops 1105
+samples before the data ends.
+
+Upstream is `meta-pytorch/torchcodec`; present in 0.11.1 and still in 0.16.0. Chunked decoding is
+an active workstream there (#1614 merged, #1601 reopened in practice), but this specific timeline
+disagreement appears unreported. Nothing was filed.
+
+## Fix
+
+`Audio._lazy_load_data_from_filepath` asks the decoder whether the two origins coincide
+(`metadata.begin_stream_seconds == 0`) and only then uses the range API. Otherwise it decodes the
+stream and slices by sample index — `_window_of_all_samples`.
+
+The gate is the file's own reported timeline, not a codec allowlist. A stream that starts at a
+non-zero timestamp is exactly the condition under which the two origins can differ, and it is
+readable from metadata before any decoding. A decoder that does not report the field reads as
+"cannot confirm" and takes the slicing path.
+
+### Cost accepted
+
+A windowed read of a file with a non-zero start timestamp now decodes the whole stream. Measured on
+a 10-minute 22050 Hz mono MP3 (single run, loaded laptop, so upper bounds):
+
+| operation | time |
+| --- | --- |
+| range read of a 0.2 s window | 52 ms |
+| full decode, then slice | 146 ms |
+| `soundfile.read(start=…, frames=…)` | 11 ms |
+
+2.8× on time, and the full decode's buffer is transient — `convert_to_tensor` clones the slice, so
+only the window is retained. Peak memory is the real cost: 4 bytes per sample per channel for the
+duration of the call, ~2.8 GB for a 2-hour stereo 48 kHz MP3. Windowed reads of `.wav`, `.flac`,
+`.m4a` and `.opus` are untouched and still seek. The full-file read path is untouched for every
+format.
+
+## Rejected alternatives
+
+**Compensate: add `begin_stream_seconds` to the requested range.** Bit-exact at all seven swept
+seek positions, recovers the lost tail, and keeps the 52 ms seek. Rejected because it depends on an
+upstream convention that no call can verify, and inverts the defect exactly: the day torchcodec
+aligns the two timelines, every compensated window goes 1105 samples wrong in the other direction,
+silently. Slicing a decode we already trust cannot fail that way.
+
+**Seek with `soundfile` (11 ms) or `torchaudio` (bit-exact) for the affected formats.** Rejected
+for consistency: libsndfile's MP3 decode differs from torchcodec's by up to 2.4e-06, so a window
+would no longer be exactly the corresponding slice of `Audio(filepath=...).waveform`. That
+invariant is asserted with `torch.equal` in
+`test_consecutive_windows_concatenate_to_the_full_decode`, and it is worth more than 135 ms.
+libsndfile also cannot open `.m4a`.
+
+**Slice a full decode for every format.** Rejected: the range API is measured bit-exact and
+loss-free for `.wav`, `.flac`, `.m4a` and `.opus`, so this would pay the whole-file decode on every
+windowed read of every format to fix one.
+
+**Honour `pts_seconds` on the full-decode path.** Rejected, and it would introduce an error rather
+than remove one — see below.
+
+## `pts_seconds` on the full-decode path corresponds to nothing in the data
+
+`Audio` discards `pts_seconds`, which for an MP3 full decode is 0.050113 s. Whether honouring it
+would fix or create an alignment error is settled by encoding a burst at a known source time:
+silence for exactly 1.000 s (22050 samples), then noise, at 22050 Hz.
+
+| decode | first sample above 0.05 |
+| --- | --- |
+| lossless `.wav` | 22050 |
+| `.mp3`, `torchcodec` `get_all_samples()` | 21839 |
+| `.mp3`, `torchaudio.load()` | 21839 |
+| `.mp3`, `soundfile.read()` | 21839 |
+
+The MP3 full decode is 66150 samples for a 66150-sample source. Index 0 is source time 0: the onset
+lands 211 samples early in all three decoders alike, which is the encoder's analysis window
+spreading energy backwards across the onset, not a timeline offset. Honouring `pts_seconds` would
+place index 0 at 0.050113 s and shift every absolute time derived from the waveform — ASR
+timestamps, diarization turns, alignment spans — 1105 samples late. The full-decode path is
+therefore correct as it stands, and `pts_seconds` is correctly ignored there.
+
+## Blast radius
+
+`get_samples_played_in_range` has exactly one call site in the tree, the one fixed here. Nothing in
+`src/senselab` constructs an `Audio` with `offset_in_sec`; the only in-tree users are
+`src/tests/audio/data_structures/audio_test.py` and callers outside the repository. Every other
+windowed read in the tree goes through paths measured clean: `Audio.from_stream` uses sequential
+`soundfile` blocks (bit-exact against the full decode on every format tested),
+`Audio.window_generator` slices an already-decoded waveform, `Video` decodes its audio with
+`get_all_samples()`, and every other `sf.read` call in `src/senselab` reads a whole file.
+
+## Tests
+
+`src/tests/audio/data_structures/audio_test.py`, four assertions parametrised over `.wav`, `.flac`
+and `.mp3` — fixture written from one signal through `Audio.save_to_file`:
+
+- a window holds what `soundfile` reads over the same sample range;
+- a window lying wholly inside the quiet half peaks below 5% of the loud half (pre-fix: 64%);
+- an offset-only read returns exactly the tail (pre-fix: 67255 samples for a 66150-sample tail);
+- windows tiling the file concatenate back to the full decode, bit for bit (pre-fix: 131195 against
+  132300).
+
+Pre-fix, all four fail for `.mp3` and pass for `.wav` and `.flac`. The window begins 512 samples
+inside the quiet half, which is far enough for the codec ringing at the step to have decayed to
+0.0016 and near enough that a 1105-sample shift reaches back into content peaking at 1.81.
+
+Raw measurements: `~/Downloads/senselab-io-audit/raw/invariants_run{1,2,3}.txt`, scripts in that
+audit's `scripts/`.

--- a/src/senselab/audio/data_structures/audio.py
+++ b/src/senselab/audio/data_structures/audio.py
@@ -42,11 +42,22 @@ except ModuleNotFoundError:
     SOUNDFILE_AVAILABLE = False
 
 
-# What the non-libsndfile backends actually write. torchcodec's AudioEncoder exposes no encoding
-# control, and torchaudio 2.9 forwards save() to it while warning that ``encoding`` and
-# ``bits_per_sample`` are unsupported, so 16-bit fixed point is the conservative assumption the
-# range policy is applied against for those containers.
+# What the non-libsndfile backends write; neither exposes encoding control.
 _TORCH_BACKEND_SUBTYPE = "PCM_16"
+
+
+def _decoded_samples_start_the_stream_timeline(decoder: "AudioDecoder") -> bool:
+    """Reports whether a stream's decoded samples and its timestamps share an origin.
+
+    Args:
+        decoder: An open torchcodec AudioDecoder.
+
+    Returns:
+        True when the stream's first timestamp is zero, so a time range requested of the decoder
+        and the sequence of decoded samples are measured from the same point. False when the
+        stream begins at a non-zero timestamp, and False when the decoder does not report one.
+    """
+    return getattr(decoder.metadata, "begin_stream_seconds", None) == 0
 
 
 class Audio(BaseModel):
@@ -219,14 +230,19 @@ class Audio(BaseModel):
             decoder = AudioDecoder(str(filepath))
             self._sampling_rate = decoder.metadata.sample_rate
 
-            if stop_seconds is not None:
-                samples = decoder.get_samples_played_in_range(start_seconds=start_seconds, stop_seconds=stop_seconds)
-            elif start_seconds > 0:
-                samples = decoder.get_samples_played_in_range(start_seconds=start_seconds)
-            else:
-                samples = decoder.get_all_samples()
+            if stop_seconds is None and start_seconds == 0.0:
+                return decoder.get_all_samples().data  # shape: (num_channels, num_samples)
 
-            return samples.data  # shape: (num_channels, num_samples)
+            if _decoded_samples_start_the_stream_timeline(decoder):
+                if stop_seconds is not None:
+                    samples = decoder.get_samples_played_in_range(
+                        start_seconds=start_seconds, stop_seconds=stop_seconds
+                    )
+                else:
+                    samples = decoder.get_samples_played_in_range(start_seconds=start_seconds)
+                return samples.data  # shape: (num_channels, num_samples)
+
+            return self._window_of_all_samples(decoder, start_seconds, stop_seconds)
 
         if TORCHAUDIO_AVAILABLE:
             # Fallback: torchaudio for loading, soundfile for metadata
@@ -261,6 +277,36 @@ class Audio(BaseModel):
             "Neither torchcodec nor torchaudio is available for audio loading. "
             "Ensure FFmpeg is installed system-wide and torchcodec/torchaudio matches your torch version."
         )
+
+    def _window_of_all_samples(
+        self, decoder: "AudioDecoder", start_seconds: float, stop_seconds: Optional[float]
+    ) -> torch.Tensor:
+        """Decodes the whole stream and returns the requested window as a slice of it.
+
+        Args:
+            decoder: An open torchcodec AudioDecoder.
+            start_seconds: Start of the window, measured from the first decoded sample.
+            stop_seconds: End of the window, measured from the first decoded sample.
+                None reads to the end of the stream.
+
+        Returns:
+            A torch.Tensor of shape (num_channels, num_samples).
+
+        Raises:
+            ValueError: If the start lies beyond the end of the stream.
+        """
+        all_samples = decoder.get_all_samples().data
+        total_samples = all_samples.shape[-1]
+        first_sample = round(start_seconds * self.sampling_rate)
+        if first_sample >= total_samples:
+            raise ValueError(
+                f"Offset ({start_seconds} s) exceeds the audio file duration "
+                f"({total_samples / self.sampling_rate:.2f} s)."
+            )
+        last_sample = total_samples
+        if stop_seconds is not None:
+            last_sample = min(round(stop_seconds * self.sampling_rate), total_samples)
+        return all_samples[:, first_sample:last_sample]
 
     def filepath(self) -> Union[str, None]:
         """Returns the file path of the audio if available."""

--- a/src/tests/audio/data_structures/audio_test.py
+++ b/src/tests/audio/data_structures/audio_test.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from typing import List, Tuple
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
+import soundfile as sf
 import torch
 import torchaudio
 
@@ -371,4 +373,115 @@ def test_window_generator_step_greater_than_audio(audio_fixture: str, request: p
     assert len(windowed_audios) == expected_windows, (
         f"Should yield {expected_windows} \
         windows when step size is greater than audio length. Yielded {len(windowed_audios)}."
+    )
+
+
+# --- Windowed reads: the file's timeline and the returned content must agree. ---
+
+STEP_SAMPLING_RATE = 22050
+STEP_HALF_SAMPLES = 66150  # 3.0 s of loud content, then 3.0 s of quiet content
+STEP_QUIET_SCALE = 1e-3  # the quiet half sits 60 dB below the loud half
+STEP_WINDOW_SAMPLES = 4410  # 0.2 s
+STEP_WINDOW_LEAD_IN_SAMPLES = 512  # window starts this far inside the quiet half
+STEP_FORMATS = [".wav", ".flac", ".mp3"]
+
+
+def write_amplitude_step_file(path: Path) -> None:
+    """Writes a two-half file: uniform noise, then the same noise 60 dB down.
+
+    Args:
+        path: Destination path; the container is inferred from its suffix.
+    """
+    generator = torch.Generator().manual_seed(41)
+    loud = torch.rand(STEP_HALF_SAMPLES, generator=generator) * 1.8 - 0.9
+    quiet = (torch.rand(STEP_HALF_SAMPLES, generator=generator) * 1.8 - 0.9) * STEP_QUIET_SCALE
+    signal = torch.cat([loud, quiet]).unsqueeze(0)
+    Audio(waveform=signal, sampling_rate=STEP_SAMPLING_RATE).save_to_file(path)
+
+
+def read_reference_window(path: Path, start: int, frames: int) -> torch.Tensor:
+    """Reads a sample range of the same file with soundfile, as (num_channels, num_samples)."""
+    data, _ = sf.read(str(path), dtype="float32", start=start, frames=frames, always_2d=True)
+    return torch.from_numpy(np.ascontiguousarray(data.T))
+
+
+@pytest.mark.parametrize("suffix", STEP_FORMATS)
+def test_windowed_read_matches_an_independent_decoder(tmp_path: Path, suffix: str) -> None:
+    """A window read by Audio must hold the samples another decoder reads over the same range."""
+    path = tmp_path / f"amplitude_step{suffix}"
+    write_amplitude_step_file(path)
+
+    start = STEP_HALF_SAMPLES + STEP_WINDOW_LEAD_IN_SAMPLES
+    audio = Audio(
+        filepath=str(path),
+        offset_in_sec=start / STEP_SAMPLING_RATE,
+        duration_in_sec=STEP_WINDOW_SAMPLES / STEP_SAMPLING_RATE,
+    )
+    reference = read_reference_window(path, start, STEP_WINDOW_SAMPLES)
+
+    assert audio.waveform.shape == reference.shape, (
+        f"{suffix}: expected {tuple(reference.shape)} samples, got {tuple(audio.waveform.shape)}"
+    )
+    deviation = (audio.waveform - reference).abs().max().item()
+    assert deviation < 1e-3, f"{suffix}: window differs from soundfile over the same range by {deviation:.3e}"
+
+
+@pytest.mark.parametrize("suffix", STEP_FORMATS)
+def test_windowed_read_of_a_quiet_window_holds_no_loud_content(tmp_path: Path, suffix: str) -> None:
+    """A window lying wholly inside the quiet half must not come back carrying the loud half."""
+    path = tmp_path / f"amplitude_step{suffix}"
+    write_amplitude_step_file(path)
+
+    loud_peak = read_reference_window(path, 0, STEP_HALF_SAMPLES).abs().max().item()
+    audio = Audio(
+        filepath=str(path),
+        offset_in_sec=(STEP_HALF_SAMPLES + STEP_WINDOW_LEAD_IN_SAMPLES) / STEP_SAMPLING_RATE,
+        duration_in_sec=STEP_WINDOW_SAMPLES / STEP_SAMPLING_RATE,
+    )
+
+    window_peak = audio.waveform.abs().max().item()
+    assert window_peak < 0.05 * loud_peak, (
+        f"{suffix}: quiet window peaks at {window_peak:.6f}, "
+        f"{window_peak / loud_peak:.3f} of the loud half's {loud_peak:.6f}"
+    )
+
+
+@pytest.mark.parametrize("suffix", STEP_FORMATS)
+def test_offset_only_read_starts_at_the_requested_offset(tmp_path: Path, suffix: str) -> None:
+    """Reading from an offset to the end must return exactly the tail beginning at that offset."""
+    path = tmp_path / f"amplitude_step{suffix}"
+    write_amplitude_step_file(path)
+
+    audio = Audio(filepath=str(path), offset_in_sec=STEP_HALF_SAMPLES / STEP_SAMPLING_RATE)
+    reference = read_reference_window(path, STEP_HALF_SAMPLES, -1)
+
+    assert audio.waveform.shape[-1] == reference.shape[-1], (
+        f"{suffix}: expected {reference.shape[-1]} samples from the offset, got {audio.waveform.shape[-1]}"
+    )
+    deviation = (audio.waveform - reference).abs().max().item()
+    assert deviation < 1e-3, f"{suffix}: tail differs from soundfile over the same range by {deviation:.3e}"
+
+
+@pytest.mark.parametrize("suffix", STEP_FORMATS)
+def test_consecutive_windows_concatenate_to_the_full_decode(tmp_path: Path, suffix: str) -> None:
+    """Windowed reads tiling the file must concatenate back to the whole-file decode."""
+    path = tmp_path / f"amplitude_step{suffix}"
+    write_amplitude_step_file(path)
+
+    whole = Audio(filepath=str(path)).waveform
+    chunk_in_sec = 0.5
+    duration_in_sec = whole.shape[-1] / STEP_SAMPLING_RATE
+    pieces = []
+    start_in_sec = 0.0
+    while start_in_sec < duration_in_sec:
+        chunk = min(chunk_in_sec, duration_in_sec - start_in_sec)
+        pieces.append(Audio(filepath=str(path), offset_in_sec=start_in_sec, duration_in_sec=chunk).waveform)
+        start_in_sec += chunk
+    tiled = torch.cat(pieces, dim=-1)
+
+    assert tiled.shape == whole.shape, (
+        f"{suffix}: tiled windows give {tuple(tiled.shape)} samples against {tuple(whole.shape)} for the full decode"
+    )
+    assert torch.equal(tiled, whole), (
+        f"{suffix}: tiled windows differ from the full decode by {(tiled - whole).abs().max().item():.3e}"
     )


### PR DESCRIPTION
A windowed read of an MP3 returned samples from ~50 ms (1105 samples) before the requested offset, while reporting the requested offset as the timestamp of what it returned. `.wav`, `.flac`, `.m4a` and `.opus` were unaffected.

## The measurement

6 s file at 22050 Hz, 3 s of noise then the same noise 60 dB down, written to three containers from one signal. Requesting `[3.000, 3.200)` s — the window that begins exactly at the step:

| reader | peak returned |
| --- | --- |
| `torchcodec.get_samples_played_in_range` | 1.1639 |
| `torchcodec.get_all_samples()` sliced | 0.1172 |
| `torchaudio.load(frame_offset=…)` | 0.1172 |
| `soundfile.read(start=…)` | 0.1172 |
| `ffmpeg -i … -ss 3.0 -t 0.2` | 0.1172 |

**9.93×** against the three decoders that agree, with `pts_seconds` reported as `3.000000` — the value asked for, so the misalignment certified itself. The comparison is deliberately decoder-against-decoder on the same MP3; comparing to the lossless source would conflate codec ringing at the step with the shift.

The shift is a constant 1105 samples at every seek position swept across an MP3 frame, and the returned block is bit-identical to the full decode offset by −1105. Tiling ranges over the file gives 131195 samples against 132300. `metadata.begin_stream_seconds` is 0.050113 s = 1105 samples for the MP3 and exactly 0 for the four formats that read correctly.

## Mechanism

An MP3 stream starts at a non-zero timestamp (the 1105-sample libmp3lame encoder delay, 576+529). Decoders trim the delay, so the first decoded sample is source time 0 while the first timestamp is 0.050113 s. `get_samples_played_in_range` seeks on the timestamp timeline and `get_all_samples()` returns data on the trimmed timeline — the two origins are 1105 samples apart, and the returned `pts_seconds` is echoed from the request rather than derived from the decode.

Upstream is `meta-pytorch/torchcodec`; present in 0.11.1 and 0.16.0, apparently unreported. Nothing filed.

## Fix

`_lazy_load_data_from_filepath` uses the range API only when the decoder reports `begin_stream_seconds == 0`; otherwise it decodes the stream and slices by sample index. The gate is the file's own reported timeline rather than a codec allowlist, and it is readable from metadata before any decode.

**Cost accepted:** a windowed read of a file with a non-zero start timestamp now decodes the whole stream — 146 ms against 52 ms for a 10-minute 22050 Hz mono MP3 (loaded laptop, upper bound), and 4 bytes/sample/channel transient, ~2.8 GB for a 2-hour stereo 48 kHz MP3. `convert_to_tensor` clones the slice, so only the window is retained. `.wav`, `.flac`, `.m4a` and `.opus` windowed reads still seek; the full-file path is untouched for every format.

Compensating the requested range by `begin_stream_seconds` is bit-exact and cheaper, and was rejected: it depends on an upstream convention no call can verify, and the day torchcodec aligns the timelines every compensated window goes 1105 samples wrong the other way, silently. Reasoning, the rest of the alternatives and the raw numbers: `specs/20260819-122715-mp3-decode-timeline/design.md`.

## `pts_seconds` on the full-decode path

`Audio` discards it, and that is correct. Encoding a burst at exactly 1.000 s and finding the onset: 22050 in the lossless wav, **21839** in the MP3 from all three of torchcodec, torchaudio and soundfile alike — the 211-sample lead is the encoder's analysis window smearing energy backwards, identical across decoders, not a timeline offset. Index 0 is source time 0. Honouring `pts_seconds` would put index 0 at 0.050113 s and shift every absolute time derived from the waveform 1105 samples late. Path left alone.

## Tests

Four assertions over `.wav`, `.flac` and `.mp3` in `audio_test.py`: a window matches `soundfile` over the same sample range; a window inside the quiet half peaks below 5% of the loud half (pre-fix 64%); an offset-only read returns exactly the tail (pre-fix 67255 samples for a 66150-sample tail); tiled windows concatenate back to the full decode bit for bit (pre-fix 131195 against 132300). Pre-fix all four fail for `.mp3` and pass for `.wav`/`.flac`.

`get_samples_played_in_range` had exactly one call site. Nothing in `src/senselab` constructs an `Audio` with `offset_in_sec`, so the defect was reachable only from outside the repo; `from_stream`, `window_generator` and `Video`'s audio decode all go through paths measured clean.

`src/tests/audio/data_structures` 53 passed, `src/tests/utils` 325 passed, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)